### PR TITLE
Erweiterungen und Fehlerkorrektur FS20-Code

### DIFF
--- a/hardware/radio/fs20/fs20.c
+++ b/hardware/radio/fs20/fs20.c
@@ -155,8 +155,8 @@ ISR(ANALOG_COMP_vect)
 
     /* if fs20 locked or timeout > 0, continue */
     if (fs20_global.fs20.timeout == 0
-    		&& ((fs20_global.fs20.rec < FS20_DATAGRAM_LENGTH && !(fs20_global.fs20.datagram.data.dg.cmd & (1 << 5)))
-			|| (fs20_global.fs20.rec < FS20_DATAGRAM_LENGTH_EXT && (fs20_global.fs20.datagram.data.dg.cmd & (1 << 5)))))
+    		&& ( (fs20_global.fs20.rec < FS20_DATAGRAM_LENGTH)
+    				|| ((fs20_global.fs20.datagram.data.edg.cmd & _BV(5)) && (fs20_global.fs20.rec < FS20_DATAGRAM_LENGTH_EXT)) ) )
 	{
         static uint8_t time_old = 0;
 
@@ -168,11 +168,8 @@ ISR(ANALOG_COMP_vect)
             /* we received a zero */
             time_old = 0;
             fs20_global.fs20.err = 0;
-
-            //fs20_global.fs20.raw <<= 1;
-
             fs20_global.fs20.rec++;
-        } 
+        }
         else if (FS20_PULSE_ONE(time) &&
                  FS20_PULSE_ONE(time_old) &&
                  FS20_PULSE_DIFFERENCE(time, time_old)) 
@@ -181,27 +178,24 @@ ISR(ANALOG_COMP_vect)
             time_old = 0;
             fs20_global.fs20.err = 0;
 
-            uint8_t byte = (FS20_DATAGRAM_BITS - fs20_global.fs20.rec) / 8;
-            uint8_t bit = (FS20_DATAGRAM_BITS - fs20_global.fs20.rec) % 8;
+            if (fs20_global.fs20.rec <= FS20_DATAGRAM_BITS)
+            {
+            	uint8_t o = FS20_DATAGRAM_BITS - fs20_global.fs20.rec;
+            	uint8_t byte =  o >> 3; // Division durch 8
+                uint8_t bit = o % 8;
 
-            if ( byte < 9 && bit < 8 )
-            	fs20_global.fs20.datagram.data.bytes[byte] |= (1 << bit);
-
-            //fs20_global.fs20.raw <<= 1;
-            //fs20_global.fs20.raw |= 1;
+                fs20_global.fs20.datagram.data.bytes[byte] |= _BV(bit);
+            }
 
             fs20_global.fs20.rec++;
-        } 
+        }
         else 
         {
             if (fs20_global.fs20.err > 3) 
             {
-                fs20_global.fs20.err = 0;
-                fs20_global.fs20.rec = 0;
-                time_old = 0;
-
-                memset((void *)&fs20_global.fs20.datagram, 0, sizeof(struct fs20_datagram_t));
-                //fs20_global.fs20.raw = 0;
+            	time_old = 0;
+            	fs20_global.fs20.err = 0;
+            	fs20_global.fs20.rec = 0;
             } 
             else 
             {
@@ -213,8 +207,8 @@ ISR(ANALOG_COMP_vect)
 
 #ifdef FS20_RECEIVE_WS300_SUPPORT
     /* if ws300 is not locked, continue */
-    if (fs20_global.ws300.rec < FS20_WS300_DATAGRAM_LENGTH) {
-
+    if (fs20_global.ws300.rec < FS20_WS300_DATAGRAM_LENGTH)
+    {
         /* save counter for processing */
         static uint8_t time_old = 0;
 
@@ -269,17 +263,19 @@ ISR(TIMER2_OVF_vect)
     fs20_global.ovf_counter++;
 #endif
 
+    //uint8_t extbit = fs20_global.fs20.datagram.data.dg.cmd & (1 << 5);
+
     /* reset data structures, if not locked */
-    if ( (fs20_global.fs20.rec != FS20_DATAGRAM_LENGTH && fs20_global.fs20.rec != FS20_DATAGRAM_LENGTH_EXT) ||
-         fs20_global.fs20.timeout > 0 ) 
+    if ( ((fs20_global.fs20.rec != FS20_DATAGRAM_LENGTH) && (fs20_global.fs20.rec != FS20_DATAGRAM_LENGTH_EXT))
+    	|| (fs20_global.fs20.timeout > 0) )
     {
-        fs20_global.fs20.rec = 0;
-        //fs20_global.fs20.raw = 0;
         memset((void *)&fs20_global.fs20.datagram, 0, sizeof(struct fs20_datagram_t));
+        fs20_global.fs20.rec = 0;
     }
 
 #ifdef FS20_RECEIVE_WS300_SUPPORT
-    if (fs20_global.ws300.rec != FS20_WS300_DATAGRAM_LENGTH) {
+    if (fs20_global.ws300.rec != FS20_WS300_DATAGRAM_LENGTH)
+    {
         fs20_global.ws300.rec = 0;
         fs20_global.ws300.sync = 0;
         fs20_global.ws300.null = 0;
@@ -291,10 +287,12 @@ ISR(TIMER2_OVF_vect)
 void fs20_process(void)
 {
     /* check if something has been received */
-    if (((fs20_global.fs20.rec == FS20_DATAGRAM_LENGTH) && !(fs20_global.fs20.datagram.data.dg.cmd & (1 << 5)))
-			|| (fs20_global.fs20.rec == FS20_DATAGRAM_LENGTH_EXT))
+	uint8_t extbit = (fs20_global.fs20.datagram.data.dg.cmd & _BV(5));
+
+    if ((fs20_global.fs20.rec == FS20_DATAGRAM_LENGTH && !extbit)
+			|| (fs20_global.fs20.rec == FS20_DATAGRAM_LENGTH_EXT && extbit))
     {
-        fs20_global.fs20.datagram.ext = (fs20_global.fs20.datagram.data.dg.cmd & (1 << 5)) ? 1 : 0;
+        fs20_global.fs20.datagram.ext = extbit ? 1 : 0;
 
 #ifdef DEBUG_FS20_REC
 		if (fs20_global.fs20.rec == FS20_DATAGRAM_LENGTH)
@@ -430,7 +428,7 @@ void fs20_process(void)
                 fs20parity += dg->data.edg.cmd2;
                 fhtparity += dg->data.edg.cmd2;
 
-                p5 = parity_even_bit(dg->data.edg.cmd2)    ^ dg->data.edg.p5;
+                p5 = parity_even_bit(dg->data.edg.cmd2)   ^ dg->data.edg.p5;
                 p6 = parity_even_bit(dg->data.edg.parity) ^ dg->data.edg.p6;
 
                 dgparity = dg->data.edg.parity;
@@ -449,12 +447,13 @@ void fs20_process(void)
 #ifdef DEBUG_FS20_REC
                 debug_printf("valid datagram\n");
 #endif
+                dg->send = 1;
+                dg->fht = (fhtparity == dgparity);
+
                 /* shift queue backwards */
                 memmove(&fs20_global.fs20.queue[1],
                         &fs20_global.fs20.queue[0],
                         (FS20_QUEUE_LENGTH-1) * sizeof(struct fs20_datagram_t));
-
-                dg->send = 1;
 
                 /* copy datagram to queue */
                 memcpy(&fs20_global.fs20.queue[0],
@@ -481,9 +480,8 @@ void fs20_process(void)
 #endif
         }
 
-        fs20_global.fs20.rec = 0;
-        //fs20_global.fs20.raw = 0;
         memset((void *)&fs20_global.fs20.datagram, 0, sizeof(struct fs20_datagram_t));
+        fs20_global.fs20.rec = 0;
     }
 
 #ifdef FS20_RECEIVE_WS300_SUPPORT
@@ -639,8 +637,7 @@ void fs20_init(void)
 
 #ifdef FS20_RECEIVE_SUPPORT
     /* reset global data structures */
-    //fs20_global.fs20.raw = 0;
-    memset((void *)&fs20_global.fs20.datagram, 0, sizeof(fs20_global.fs20.datagram));
+    memset((void *)&fs20_global.fs20, 0, sizeof(fs20_global.fs20));
 
     /* configure port pin for use as input to the analoge comparator */
     DDR_CONFIG_IN(FS20_RECV);

--- a/hardware/radio/fs20/fs20.h
+++ b/hardware/radio/fs20/fs20.h
@@ -133,7 +133,7 @@
 
 
 /* queue length */
-#define FS20_QUEUE_LENGTH 5
+#define FS20_QUEUE_LENGTH 4
 
 /* structures */
 struct fs20_data_t {
@@ -173,10 +173,11 @@ struct fs20_datagram_t {
     {
         struct fs20_data_t dg;
         struct fs20_extdata_t edg;
-        uint8_t bytes[10]; // using 58/67 of 72 bits
+        uint8_t bytes[9]; // using 58/67 of 72 bits
     } data;
-    uint8_t ext; // 0 = dg, 1 = edg
-    uint8_t send; 
+    uint8_t ext; // 0 = one command byte, use data.dg, 1 = extended message, 2 command bytes, use data.edg
+    uint8_t send; // 1 = send this message, 0 = message was send
+    uint8_t fht; // 0 = is a FS20 message, 1 = is a FHT message, 2 = is a FHT message
 };
 
 struct ws300_datagram_t {
@@ -219,7 +220,6 @@ struct fs20_global_t {
 #ifdef FS20_RECEIVE_SUPPORT
     struct {
         struct fs20_datagram_t datagram;
-        //uint64_t raw;
         uint8_t rec;
         uint8_t err;
         struct fs20_datagram_t queue[FS20_QUEUE_LENGTH];

--- a/hardware/radio/fs20/fs20_ecmd.c
+++ b/hardware/radio/fs20/fs20_ecmd.c
@@ -105,22 +105,13 @@ int16_t parse_cmd_fs20_receive(char *cmd, char *output, uint16_t len)
     uint8_t outlen = 0;
 
 #ifdef DEBUG_ECMD_FS20
-    debug_printf("%u positions in queue\n", fs20_global.fs20.len);
+    debug_printf("queue: %u, len: %u\n", fs20_global.fs20.len, len);
 #endif
 
     while (l < fs20_global.fs20.len && (uint8_t)(outlen+11) < len) 
     {
         if ( fs20_global.fs20.queue[l].ext )
         {
-#ifdef DEBUG_ECMD_FS20
-            debug_printf("generating for pos %u: %02x%02x%02x%02x%02x", l,
-                         fs20_global.fs20.queue[l].data.edg.hc1,
-                         fs20_global.fs20.queue[l].data.edg.hc2,
-                         fs20_global.fs20.queue[l].data.edg.addr,
-                         fs20_global.fs20.queue[l].data.edg.cmd,
-                         fs20_global.fs20.queue[l].data.edg.cmd2);
-#endif
-            
             sprintf_P(s, PSTR("%02x%02x%02x%02x%02x\n"),
                       fs20_global.fs20.queue[l].data.edg.hc1,
                       fs20_global.fs20.queue[l].data.edg.hc2,
@@ -130,17 +121,18 @@ int16_t parse_cmd_fs20_receive(char *cmd, char *output, uint16_t len)
 
             s += 11;
             outlen += 11;
+
+#ifdef DEBUG_ECMD_FS20
+            debug_printf("outlen: %d, pos %u: %02x%02x%02x%02x%02x\n", outlen, l,
+                         fs20_global.fs20.queue[l].data.edg.hc1,
+                         fs20_global.fs20.queue[l].data.edg.hc2,
+                         fs20_global.fs20.queue[l].data.edg.addr,
+                         fs20_global.fs20.queue[l].data.edg.cmd,
+                         fs20_global.fs20.queue[l].data.edg.cmd2);
+#endif
         }
         else
         {
-#ifdef DEBUG_ECMD_FS20
-            debug_printf("generating for pos %u: %02x%02x%02x%02x", l,
-                         fs20_global.fs20.queue[l].data.dg.hc1,
-                         fs20_global.fs20.queue[l].data.dg.hc2,
-                         fs20_global.fs20.queue[l].data.dg.addr,
-                         fs20_global.fs20.queue[l].data.dg.cmd);
-#endif
-            
             sprintf_P(s, PSTR("%02x%02x%02x%02x\n"),
                       fs20_global.fs20.queue[l].data.dg.hc1,
                       fs20_global.fs20.queue[l].data.dg.hc2,
@@ -149,15 +141,23 @@ int16_t parse_cmd_fs20_receive(char *cmd, char *output, uint16_t len)
 
             s += 9;
             outlen += 9;
+
+            #ifdef DEBUG_ECMD_FS20
+            debug_printf("outlen: %d, pos %u: %02x%02x%02x%02x\n", outlen, l,
+                         fs20_global.fs20.queue[l].data.dg.hc1,
+                         fs20_global.fs20.queue[l].data.dg.hc2,
+                         fs20_global.fs20.queue[l].data.dg.addr,
+                         fs20_global.fs20.queue[l].data.dg.cmd);
+#endif
         }
     
         l++;
+    }
 
 #ifdef DEBUG_ECMD_FS20
         *s = '\0';
         debug_printf("output is \"%s\"\n", output);
 #endif
-    }
 
     /* clear queue */
     fs20_global.fs20.len = 0;

--- a/hardware/radio/fs20/fs20_sender_state.h
+++ b/hardware/radio/fs20/fs20_sender_state.h
@@ -22,7 +22,7 @@
  */
 
 #ifndef FS20_SENDER_STATE_H
-#define WATHASYNC_STATE_H
+#define FS20_SENDER_STATE_H
 
 // State of coonection, new until acked or aborted, after that old
 struct fs20_sender_connection_state_t {


### PR DESCRIPTION
Hallo,

ich habe den FS20-Code so erweitert das 

1) FS20-Datagramme mit 2. Commando-Byte empfangen und dekodiert werden
2) FHT-Datagramme der FHT-Komponenten (FHT-Bxx (Heizungssteuerungs-Regler mit Ventilantrieben) empfangen und kodiert werden können. (Andere Checksumme als FS20-Datagramme.)

Im alten Code war noch ein Fehler, der unter Umständen zum Absturz führte.

Außerdem kann man sich über eine Erweiterung die dekodierten FS20/FHT-Datagramme an einen Server schicken lassen, muß also nicht über ECMD-Kommandos pollen. 

Das ganze läuft seit ca. einem Monat bei mir stabil.

Grüße,
Moritz
