### PR TITLE
Dhcpclientid

### DIFF
--- a/protocols/dhcp/dhcp.c
+++ b/protocols/dhcp/dhcp.c
@@ -89,6 +89,7 @@ struct dhcp_msg {
 #define DHCP_OPTION_MSG_TYPE     53
 #define DHCP_OPTION_SERVER_ID    54
 #define DHCP_OPTION_REQ_LIST     55
+#define DHCP_OPTION_CLIENT_ID    61
 #define DHCP_OPTION_END         255
 
 static const uint8_t xid[4] = {0xad, 0xde, 0x12, 0x23};
@@ -142,6 +143,19 @@ add_hostname(uint8_t *optptr)
   *optptr++ = DHCP_OPTION_HOSTNAME;
   *optptr++ = len;
   memcpy(optptr, CONF_HOSTNAME, len);
+  return optptr + len;
+}
+/*---------------------------------------------------------------------------*/
+static uint8_t *
+add_client_id(uint8_t *optptr)
+{
+  int len = 1+sizeof(struct uip_eth_addr); /* hardware type + MAC-Adress */
+  *optptr++ = DHCP_OPTION_CLIENT_ID;
+  *optptr++ = len;
+  /* hardware type: ether */
+  optptr[0] = 1;
+  /* mac address */
+  memcpy(&optptr[1], uip_ethaddr.addr, sizeof(struct uip_eth_addr));
   return optptr + len;
 }
 /*---------------------------------------------------------------------------*/
@@ -203,6 +217,7 @@ send_request(void)
   end = add_server_id(end);
   end = add_req_ipaddr(end);
   end = add_hostname(end);
+  end = add_client_id(end);
   end = add_end(end);
   
   uip_send(uip_appdata, end - (uint8_t *)uip_appdata);
@@ -312,7 +327,7 @@ void dhcp_net_init(void) {
 #endif 
 
   uip_ipaddr_t ip;
-  uip_ipaddr(&ip, 255,255,255,255);
+  uip_ipaddr_copy(&ip, all_ones_addr);
   
   uip_udp_conn_t *dhcp_conn = uip_udp_new(&ip, HTONS(DHCPC_SERVER_PORT), dhcp_net_main);
   


### PR DESCRIPTION
Adding the client id to the request packet finally gives full fritzbox functionality (i.e. the host name you specified in the config of ethersex is later available in fritzbox dns).

Please pull.

Mike
