### PR TITLE
ECMD: Stella Buffer Overflow fix

### DIFF
--- a/protocols/ecmd/via_tcp/ecmd_state.h
+++ b/protocols/ecmd/via_tcp/ecmd_state.h
@@ -23,7 +23,7 @@
 #define ECMD_STATE_H
 
 #define ECMD_INPUTBUF_LENGTH  50
-#define ECMD_OUTPUTBUF_LENGTH 50
+#define ECMD_OUTPUTBUF_LENGTH 258
 
 struct ecmd_connection_state_t {
     char inbuf[ECMD_INPUTBUF_LENGTH];


### PR DESCRIPTION
This one fixes a buffer overflow when more than 12 stella channels are configured and the return message of "channel" which then dumps all channels is therefore greater than 50 chars (Returned characters of n channels: 3+4n-1, see https://github.com/ethersex/ethersex/blob/master/services/stella/stella_ecmd.c#L136 for the ecmd function).

The buffer length of 258 enables the stella module to have up to 64 channel in the future (I'm currently working on that).
