### PR TITLE
Reseting the try counter to 0 on ntp_init

### DIFF
--- a/services/ntp/ntp.c
+++ b/services/ntp/ntp.c
@@ -75,6 +75,7 @@ ntp_init()
     resolv_query(NTP_SERVER, ntp_dns_query_cb);
   else
     ntp_conf(ipaddr);
+  ntp_tries = 0; // reset try counter
 
 #else /* ! DNS_SUPPORT */
   uip_ipaddr_t ip;


### PR DESCRIPTION
Der Zähler ntp_tries wird nur auf 0 gesetzt, wenn eine ntp_query erfolgreich war. Überschreitet der Zähler einmal den Wert 5 so kann keine ntp_query mehr erfolgreich sein, da immer zu ntp_init gesprungen wird.

Folglich muss in ntp_init der Wert wieder auf 0 gesetzt werden, damit erneute ntp_queries überhaupt abgesetzt werden können.
