### PR TITLE
ECMD: Stella Buffer Overflow fix v2

### DIFF
--- a/services/stella/stella_ecmd.c
+++ b/services/stella/stella_ecmd.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2009 by David Gräff <david.graeff@web.de>
- * Copyright (c) 2011 by David Gräff <maximilian.guentner@gmail.com>
+ * Copyright (c) 2011 by Maximilian Güntner <maximilian.guentner@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License


### PR DESCRIPTION
This one fixes a buffer overflow when more than 12 stella channels are configured and the return message of "channel" which then dumps all channels is therefore greater than 50 chars (Returned characters of n channels: 2+4n).
