### PR TITLE
Added content-length=0 to watchasync_request_end

### DIFF
--- a/services/watchasync/watchasync_strings.c
+++ b/services/watchasync/watchasync_strings.c
@@ -39,7 +39,8 @@ static const char PROGMEM watchasync_summarize_path[] =
 // and the http footer including the http protocol version and the server name
 static const char PROGMEM watchasync_request_end[] =
     CONF_WATCHASYNC_END_PATH " HTTP/1.1\r\n"
-    "Host: " CONF_WATCHASYNC_SERVER "\r\n\r\n";
+    "Host: " CONF_WATCHASYNC_SERVER "\r\n"
+    "Content-Length: 0\r\n\r\n";
 
 #ifndef CONF_WATCHASYNC_PORT
 #define CONF_WATCHASYNC_PORT 80


### PR DESCRIPTION
because lighttpd responds with 411 (length required)
if content-length is missing in a HTTP POST request

lighttpd error message: (request.c.1116) POST-request, but content-length missing -> 411

It seems other http servers are less pedantic and
accept HTTP POST requests without content-length
