### PR TITLE
stella now uses dmx-storage, stella removed from artnet

### DIFF
--- a/protocols/artnet/artnet.c
+++ b/protocols/artnet/artnet.c
@@ -38,9 +38,6 @@
 #include "protocols/uip/uip.h"
 #include "protocols/uip/uip_router.h"
 #include "protocols/ecmd/ecmd-base.h"
-#ifdef STELLA_SUPPORT
-#include "services/stella/stella.h"
-#endif
 
 #ifdef DMX_STORAGE_SUPPORT
 #include "services/dmx-storage/dmx_storage.h"
@@ -731,17 +728,14 @@ void artnet_get(void) {
 
   if (dmx->universe == ((artnet_subNet << 4) | artnet_outputUniverse1)) {
    if (artnet_dmxDirection == 0) {
-    uint16_t len = (dmx->lengthHi << 8) + dmx->length;
-    ARTNET_DEBUG ("Updating %d channels ...\n", len);
-		#ifdef STELLA_SUPPORT
-			stella_dmx(&dmx->dataStart, len);
-		#endif
-    		#ifdef DMX_STORAGE_SUPPORT
-			set_dmx_channels(&dmx->dataStart,CONF_ARTNET_OUTUNIVERSE,len);
-    		#endif
-		if (artnet_sendPollReplyOnChange == TRUE) {
-      artnet_pollReplyCounter++;
-      artnet_sendPollReply();
+	uint16_t len = (dmx->lengthHi << 8) + dmx->length;
+	ARTNET_DEBUG ("Updating %d channels ...\n", len);
+	#ifdef DMX_STORAGE_SUPPORT
+		set_dmx_channels(&dmx->dataStart,CONF_ARTNET_OUTUNIVERSE,len);
+    	#endif
+	if (artnet_sendPollReplyOnChange == TRUE) {
+	artnet_pollReplyCounter++;
+	artnet_sendPollReply();
     }
    }
   }

--- a/services/stella/config.in
+++ b/services/stella/config.in
@@ -1,4 +1,8 @@
 dep_bool_menu "StellaLight: Multichannel pwm" STELLA_SUPPORT $ARCH_AVR
+	if [ "$DMX_STORAGE_SUPPORT" = "y" ]; then
+		int "Stella DMX Universe" STELLA_UNIVERSE 1
+		int "Offset in Universe" STELLA_UNIVERSE_OFFSET 0
+	fi
 	dep_bool "Higher frequency" STELLA_HIGHFREQ
 	comment  '----- Initial -----'
 	if [ "$MOODLIGHT_SUPPORT" = "y" ]; then

--- a/services/stella/stella.h
+++ b/services/stella/stella.h
@@ -104,7 +104,6 @@ extern uint8_t stella_fade_func;
 
 extern uint8_t stella_brightness[STELLA_CHANNELS];
 extern uint8_t stella_fade[STELLA_CHANNELS];
-
 /* stella.c */
 void stella_init(void);
 void stella_process(void);
@@ -119,7 +118,6 @@ void stella_loadFromEEROMFading(void);
 void stella_storeToEEROM(void);
 
 uint8_t stella_output_channels(void* target);
-void stella_dmx(uint8_t* dmx_data, uint16_t len);
 
 #endif  /* STELLA_SUPPORT */
 


### PR DESCRIPTION
Stella gets the dmx (artnet) information now from dmx-storage (now an optional dependency).

The DMX layout is still the same:

mccccccccc

m := mode
c  := channel

Tested using NetIO, with stella configured for 4 Channels.
