### PR TITLE
Makefile stuff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,10 +144,9 @@ endif
 # logging to file make.log
 # calls make all and redirects stdout and stderr to make.log
 v:
-	@echo "===== logging make activity to file make.log ====="
-	@echo "Build started on " `date` | tee make.log
-	@${MAKE} all 2>&1 | tee -a make.log
-
+	(echo "===== logging make activity to file make.log =====";\
+         echo "Build started on `date`";\
+         ${MAKE} all 2>&1) | tee make.log
 
 ##############################################################################
 # print information about binary size and flash usage


### PR DESCRIPTION
Hopefully it works for other shells than bash now.
Don't know what exactly was wrong as i know the bash shell only.

Added new targets "v", "size-info" and "help" to main Makefile.

v redirects output of make into make.log file
size-info displays size info of flash usage
help displays help about available targets
