### PR TITLE
Use gsed on FreeBSD in usart-config.sh

### DIFF
--- a/scripts/usart-config.sh
+++ b/scripts/usart-config.sh
@@ -1,6 +1,7 @@
+[ "FreeBSD" = `uname` ] && SED=gsed || SED=sed
 
 get_usart_count() {
-  USARTS=$(( $(echo "#include <avr/io.h>" | avr-gcc -mmcu=$MCU -C -E -dD - | sed -n 's/.* UDR\([0-9]\+\).*/\1/p' | sort -n -r | sed -n 1p) + 1 ))
+  USARTS=$(( $(echo "#include <avr/io.h>" | avr-gcc -mmcu=$MCU -C -E -dD - | ${SED} -n 's/.* UDR\([0-9]\+\).*/\1/p' | sort -n -r | ${SED} -n 1p) + 1 ))
 }
 
 usart_choice() {


### PR DESCRIPTION
die regex in get_usart_count() funktionert mit BSD sed nicht. Das ist ein Workaround um die regex nicht zu ändern - aber gsed muss auf FreeBSD eh installiert sein um ethersex zu bauen ...
