### PR TITLE
display lockbits in 'fuse' ecmd

### DIFF
--- a/hardware/avr/fuse.c
+++ b/hardware/avr/fuse.c
@@ -38,7 +38,7 @@ int16_t parse_cmd_fuse(char *cmd, char *output, uint16_t len)
     _SPMCR = 1<<BLBSET | 1<<SPMEN;
     uint8_t lock = pgm_read_byte(1);
 
-    return ECMD_FINAL(snprintf_P(output, len, PSTR("Fuses: low=%02X high=%02X ex=%02X"), lo, hi, ex,lock));
+    return ECMD_FINAL(snprintf_P(output, len, PSTR("Fuses: low=%02X high=%02X ex=%02X lock=%02X"), lo, hi, ex, lock));
 #else
     return ECMD_FINAL(snprintf_P(output, len, PSTR("Fuses: unsupported")));
 #endif


### PR DESCRIPTION
lock wird zwar ausgelesen aber im ecmd nicht angezeigt.
