### PR TITLE
fixed 2k problems in clock modul

### DIFF
--- a/services/clock/clock.c
+++ b/services/clock/clock.c
@@ -306,7 +306,7 @@ clock_utc2timestamp (struct clock_datetime_t * d, uint8_t cest)
    *
    */
   /* year, check if we have enough days left to fill a year */
-  for (uint16_t year = EPOCH_YEAR; year < d->year + 1900; year++)
+  for (uint16_t year = EPOCH_YEAR; year < d->year; year++)
     {
       timestamp += (is_leap_year (year)) ? 31622400UL : 31536000UL;
     }
@@ -364,7 +364,7 @@ clock_datetime (struct clock_datetime_t *d, uint32_t timestamp)
       days -= 365;
       year++;
     }
-  d->year = year - 1900;
+  d->year = year;
   d->month = 0;
 
   /* month */

--- a/services/clock/clock.h
+++ b/services/clock/clock.h
@@ -39,7 +39,7 @@ struct clock_datetime_t {
             uint8_t dow;
         };
     };
-    uint8_t year;
+    uint16_t year;
 };
 
 /* current_time is the amount of seconds since 1.1.1900, 00:00:00 UTC */


### PR DESCRIPTION
resolved 2k problems: converting from utc2timestamp generated a wront timestamp. e.g. year 11 was translated to 1911. variable year changed from 2 digit format to 4 digit. please review and check possible effects to other modules.
