### PR TITLE
yport: read UDR upon buffer overflow, to avoid IRQ loop

### DIFF
--- a/protocols/yport/yport.c
+++ b/protocols/yport/yport.c
@@ -113,7 +113,8 @@ ISR(usart(USART,_RX_vect))
 
         yport_rx_bufferfull++;
 #endif
-        break;
+        uint8_t v = usart(UDR);
+        (void) v;
       }
     }
   }


### PR DESCRIPTION
When a buffer overflow occurs, make sure that UDR is read and the result thrown away, similiar to when a framing error happens. If this is not done, there will be a tight interrupt loop until the yport network buffer is emptied.
