### PR TITLE
Fixed a typecasting bug.

### DIFF
--- a/protocols/uip/uip.c
+++ b/protocols/uip/uip.c
@@ -853,8 +853,8 @@ uip_process(u8_t flag)
      the packet has been padded and we set uip_len to the correct
      value.. */
 
-  if((u16_t)(BUF->len[0] << 8) + BUF->len[1] <= uip_len) {
-    uip_len = (BUF->len[0] << 8) + BUF->len[1];
+  if(((u16_t)(BUF->len[0]) << 8) + BUF->len[1] <= uip_len) {
+    uip_len = ((u16_t)(BUF->len[0]) << 8) + BUF->len[1];
 #if UIP_CONF_IPV6
     uip_len += 40; /* The length reported in the IPv6 header is the
 		      length of the payload that follows the


### PR DESCRIPTION
The high bytes of the old expressions always expanded to zero.
