### PR TITLE
compile fix for avr-gcc 4.6.*

### DIFF
--- a/services/watchasync/watchasync_strings.c
+++ b/services/watchasync/watchasync_strings.c
@@ -143,7 +143,7 @@ static const char PROGMEM watchasync_ID_PD6[] = CONF_WATCHASYNC_PD6_ID;
 static const char PROGMEM watchasync_ID_PD7[] = CONF_WATCHASYNC_PD7_ID;
 #endif
 
-PGM_P watchasync_ID[] PROGMEM =
+const PGM_P const watchasync_ID[] PROGMEM =
 {
 #ifdef CONF_WATCHASYNC_PA0
   watchasync_ID_PA0


### PR DESCRIPTION
avr-gcc 4.6.\* complaint:
avr-gcc -Wall -W -Wno-unused-parameter -Wno-sign-compare -Wno-char-subscripts -g -Os -std=gnu99 -fdata-sections -ffunction-sections -funsigned-char -funsigned-bitfields -fpack-struct -fshort-enums -mcall-prologues -fshort-enums -fno-strict-aliasing -Iprotocols/usb/usbdrv -Iprotocols/usb -DAVR_BUILD -DF_CPU=20000000UL -mmcu=atmega644 -I.  -c -o services/watchasync/watchasync.o services/watchasync/watchasync.c
In file included from services/watchasync/watchasync.c:55:0:
./services/watchasync/watchasync_strings.c:146:19: error: variable 'watchasync_ID' must be const in order to be put into read-only section by means of '**attribute**((progmem))'
make: **\* [services/watchasync/watchasync.o] Error 1
