### PR TITLE
- in i2c_master_stop(), the check condition for the TWSTO bit was revers...

### DIFF
--- a/hardware/i2c/master/i2c_master.c
+++ b/hardware/i2c/master/i2c_master.c
@@ -63,7 +63,7 @@ uint8_t
 i2c_master_do(uint8_t mode)
 {
     TWCR = mode;                    // �bertragung starten
-    while(!( TWCR & (1<<TWINT)));   // warten bis Byte �bertragen ist
+    loop_until_bit_is_set(TWCR,TWINT);
     return TW_STATUS;           // Returncode = Statusbits
 }
 
@@ -72,7 +72,7 @@ void
 i2c_master_stop(void)
 {
     TWCR=((1<<TWEN)|(1<<TWINT)|(1<<TWSTO));     // Stopbedingung senden
-    while(bit_is_set(TWCR, TWSTO));		// Warten bis STOP executed
+    loop_until_bit_is_clear(TWCR, TWSTO);
     i2c_master_disable();
 }
 


### PR DESCRIPTION
...ed.

According to the Atmega datasheet(*), the bit is _cleared_ when the STOP condition
  has been executed, however, the check waited for the TWSTO bit to be set.
  As the bit was generally set when entering the loop, the loop exited immediately
  and the i2c bus was disabled, often before the STOP condition was actually sent.

  The mistake probably stems from the TWINT check, which works
  exactly the other way round (TWINT is set on completion)

  (*) Atmega 32 datasheet, page 178
