### PR TITLE
onewire - narrow down irq-lock to atomic time critical functions (bit r/w, bus reset)

### DIFF
--- a/hardware/onewire/ds2450.c
+++ b/hardware/onewire/ds2450.c
@@ -17,6 +17,7 @@
  * Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
+
 #include <avr/io.h>
 #include <stdlib.h>
 #include <util/crc16.h>
@@ -30,652 +31,731 @@
 
 
 /*
-   Missing get- and set-functions for:
-   - alarm enable low (AEL)
-   - alarm enable high (AEH)
-   - alarm flag low (AFL)
-   - alarm flag high (AFH)
-   - alarm treshold voltages (high and low)
-
-   Missing functions for
-   - conditional search
+ * Missing get- and set-functions for:
+ * - alarm enable low (AEL)
+ * - alarm enable high (AEH)
+ * - alarm flag low (AFL)
+ * - alarm flag high (AFH)
+ * - alarm treshold voltages (high and low)
+ *
+ * Missing functions for
+ * - conditional search
 */
 
 
 /* match ROM vs. skip ROM */
-int8_t noinline ow_match_skip_rom(ow_rom_code_t *rom)
+int8_t noinline
+ow_match_skip_rom(ow_rom_code_t * rom)
 {
-	int8_t ret;
+  int8_t ret;
 
-	if(rom == NULL)
-	{
-		DS2450_CORE_DEBUG("ow_match_skip_rom: rom == NULL, using skip command.\n");
-		ret = ow_skip_rom();
-	}
-	else
-	{
-		if(!ow_ds2450_sensor(rom))
-		{
-			DS2450_CORE_DEBUG("ow_match_skip_rom: family code mismatch!\n");
-			ret = -3;
-		}
-		else
-		{
-			DS2450_CORE_DEBUG("ow_match_skip_rom: rom != NULL, using match command.\n");
-			ret = ow_match_rom(rom);
-		}
-	}
+  if (rom == NULL)
+  {
+    DS2450_CORE_DEBUG
+      ("ow_match_skip_rom: rom == NULL, using skip command.\n");
+    ret = ow_skip_rom();
+  }
+  else
+  {
+    if (!ow_ds2450_sensor(rom))
+    {
+      DS2450_CORE_DEBUG("ow_match_skip_rom: family code mismatch!\n");
+      ret = -3;
+    }
+    else
+    {
+      DS2450_CORE_DEBUG
+        ("ow_match_skip_rom: rom != NULL, using match command.\n");
+      ret = ow_match_rom(rom);
+    }
+  }
 
-	DS2450_CORE_DEBUG("ow_match_skip_rom: returning: %i.\n", ret);
+  DS2450_CORE_DEBUG("ow_match_skip_rom: returning: %i.\n", ret);
 
-	return ret;
+  return ret;
 }
 
-/* check CRC16 with seed */
-/*
-	starting value for seed: 0
 
-	input for just checking CRC16:
-	- all data bytes (in order they were send/received)
-	- two CRC16 bytes (in order they were received)
-	-> seed should result in 0xB001 ifeverything is fine!
-	   (check with ow_crc16_check)
-
-	input for calculation CRC16:
-	- all data bytes (in order they were send/received)
-	-> CRC16 is stored as complement in seed!
-	   (use ow_crc16_calc to convert)
-*/
-void noinline ow_crc16_seed(uint8_t *b, uint8_t len, uint16_t *seed)
+/* check CRC16 with seed
+ *
+ * starting value for seed: 0
+ *
+ * input for just checking CRC16:
+ * - all data bytes (in order they were send/received)
+ * - two CRC16 bytes (in order they were received)
+ * -> seed should result in 0xB001 ifeverything is fine!
+ *     (check with ow_crc16_check)
+ *
+ * input for calculation CRC16:
+ * - all data bytes (in order they were send/received)
+ * -> CRC16 is stored as complement in seed!
+ *    (use ow_crc16_calc to convert)
+ */
+void noinline
+ow_crc16_seed(uint8_t * b, uint8_t len, uint16_t * seed)
 {
-	uint8_t i,j;
+  uint8_t i, j;
 
-	for (i = 0; i < len; ++i)
-	{
-		DS2450_CORE_DEBUG("ow_crc16_seed: byte: %02x, CRC16 starting seed: %04x\n", b[i], *seed);
-		*seed ^= b[i];
-		for (j = 0; j < 8; ++j)
-		{
-			if(*seed & 1)
-				*seed = (*seed >> 1) ^ 0xA001;
-			else
-				*seed = (*seed >> 1);
-		}
-		DS2450_CORE_DEBUG("DS2450:\tCRC16 ending seed: %04x.\n", *seed);
-	}
+  for (i = 0; i < len; ++i)
+  {
+    DS2450_CORE_DEBUG
+      ("ow_crc16_seed: byte: %02x, CRC16 starting seed: %04x\n", b[i], *seed);
+    *seed ^= b[i];
+    for (j = 0; j < 8; ++j)
+    {
+      if (*seed & 1)
+        *seed = (*seed >> 1) ^ 0xA001;
+      else
+        *seed = (*seed >> 1);
+    }
+    DS2450_CORE_DEBUG("DS2450:\tCRC16 ending seed: %04x.\n", *seed);
+  }
 }
 
-/* check CRC16 seed after eating all data bytes an both CRC16 bytes */
-/* return 0 on success (CRC16 good), -1 on failure (CRC16 bad) */
-int8_t noinline ow_crc16_check(uint16_t *seed)
+
+/* check CRC16 seed after eating all data bytes an both CRC16 bytes
+ * return 0 on success (CRC16 good), -1 on failure (CRC16 bad) */
+int8_t noinline
+ow_crc16_check(uint16_t * seed)
 {
-	if(*seed == 0xB001)
-	{
-		/* good */
-		DS2450_CORE_DEBUG("ow_crc16_check: CRC16 good!\n");
-		return 0;
-	}
-	else
-	{
-		/* bad */
-		DS2450_CORE_DEBUG("ow_crc16_check: CRC16 bad!\n");
-		return -1;
-	}
+  if (*seed == 0xB001)
+  {
+    /* good */
+    DS2450_CORE_DEBUG("ow_crc16_check: CRC16 good!\n");
+    return 0;
+  }
+  else
+  {
+    /* bad */
+    DS2450_CORE_DEBUG("ow_crc16_check: CRC16 bad!\n");
+    return -1;
+  }
 }
+
 
 /* calculates CRC16 after eating all data bytes */
-uint16_t noinline ow_crc16_calc(uint16_t *seed)
+uint16_t noinline
+ow_crc16_calc(uint16_t * seed)
 {
-	DS2450_CORE_DEBUG("ow_crc16_calc: CRC16 seed: %04x, CRC16 seed complement: %04x.\n", *seed, ~(*seed));
-	return ~(*seed);
+  DS2450_CORE_DEBUG
+    ("ow_crc16_calc: CRC16 seed: %04x, CRC16 seed complement: %04x.\n", *seed,
+     ~(*seed));
+  return ~(*seed);
 }
 
+
 /* input for ow_crc16_seed but bytewise */
-void noinline ow_crc16_seed_bytewise(uint8_t b, uint16_t *seed)
+void noinline
+ow_crc16_seed_bytewise(uint8_t b, uint16_t * seed)
 {
-	ow_crc16_seed(&b, 1, seed);
+  ow_crc16_seed(&b, 1, seed);
 }
 
 
 /* check sensor family againt DS2450 */
-uint8_t noinline ow_ds2450_sensor(ow_rom_code_t *rom)
+uint8_t noinline
+ow_ds2450_sensor(ow_rom_code_t * rom)
 {
-	if(rom->family == OW_DS2450_FAMILY)
-	{
-		DS2450_CORE_DEBUG("ow_ds2450_sensor: family code matched.\n");
-		return 1;
-	}
+  if (rom->family == OW_DS2450_FAMILY)
+  {
+    DS2450_CORE_DEBUG("ow_ds2450_sensor: family code matched.\n");
+    return 1;
+  }
 
-	DS2450_CORE_DEBUG("ow_ds2450_sensor: family code (%02x) mismatch.\n", rom->family);
+  DS2450_CORE_DEBUG("ow_ds2450_sensor: family code (%02x) mismatch.\n",
+                    rom->family);
 
-	return 0;
+  return 0;
 }
 
 
 /* get AD conversion resultion mask bits */
-int8_t ow_ds2450_res_get(ow_rom_code_t *rom, uint8_t channel)
+int8_t
+ow_ds2450_res_get(ow_rom_code_t * rom, uint8_t channel)
 {
-	int8_t ret;
-	uint8_t b;
+  int8_t ret;
+  uint8_t b;
 
-	ret = ow_ds2450_mempage_read(rom, OW_DS2450_RC0_A + channel*2, 1, &b);
+  ret = ow_ds2450_mempage_read(rom, OW_DS2450_RC0_A + channel * 2, 1, &b);
 
-	if(ret != 1)
-		return -2;
+  if (ret != 1)
+    return -2;
 
-	/* check returned memory page data */
+  /* check returned memory page data */
 
-	return b & OW_DS2450_RC_MASK;
+  return b & OW_DS2450_RC_MASK;
 }
+
 
 /* set AD conversion resultion mask bits */
-int8_t ow_ds2450_res_set(ow_rom_code_t *rom, uint8_t channel, uint8_t res)
+int8_t
+ow_ds2450_res_set(ow_rom_code_t * rom, uint8_t channel, uint8_t res)
 {
-	int8_t ret;
-	uint8_t b;
+  int8_t ret;
+  uint8_t b;
 
-	/* we need to read the corresponding status byte since we want only modify the last four bits of this byte, the rest should be unchanged */
-	ret = ow_ds2450_mempage_read(rom, OW_DS2450_RC0_A + channel*2, 1, &b);
+  /* we need to read the corresponding status byte since we want only modify
+   * the last four bits of this byte, the rest should be unchanged */
+  ret = ow_ds2450_mempage_read(rom, OW_DS2450_RC0_A + channel * 2, 1, &b);
 
-	if(ret != 1)
-		return -2;
+  if (ret != 1)
+    return -2;
 
-	/* overwrite with given result bits */
-	res &= OW_DS2450_RC_MASK;
-	b &= ~OW_DS2450_RC_MASK;
-	b |= res;
+  /* overwrite with given result bits */
+  res &= OW_DS2450_RC_MASK;
+  b &= ~OW_DS2450_RC_MASK;
+  b |= res;
 
-	ret = ow_ds2450_mempage_write(rom, OW_DS2450_RC0_A + channel*2, 1, &b);
+  ret = ow_ds2450_mempage_write(rom, OW_DS2450_RC0_A + channel * 2, 1, &b);
 
-	if(ret != 1)
-		return -2;
+  if (ret != 1)
+    return -2;
 
-	return 0;
+  return 0;
 }
+
 
 /* get output control bit */
-int8_t ow_ds2450_oc_get(ow_rom_code_t *rom, uint8_t channel)
+int8_t
+ow_ds2450_oc_get(ow_rom_code_t * rom, uint8_t channel)
 {
-	int8_t ret;
-	uint8_t b;
+  int8_t ret;
+  uint8_t b;
 
-	ret = ow_ds2450_mempage_read(rom, OW_DS2450_OC_A + channel*2, 1, &b);
+  ret = ow_ds2450_mempage_read(rom, OW_DS2450_OC_A + channel * 2, 1, &b);
 
-	if(ret != 1)
-		return -2;
+  if (ret != 1)
+    return -2;
 
-	/* check returned memory page data */
-	if(b & OW_DS2450_OC_MASK)
-		return 1;
+  /* check returned memory page data */
+  if (b & OW_DS2450_OC_MASK)
+    return 1;
 
-	return 0;
+  return 0;
 }
+
 
 /* set output control bit */
 /* (oc == 0 => make output transistor conducting) */
 /* (oc == 1 => make output transistor non-conducting) */
-int8_t ow_ds2450_oc_set(ow_rom_code_t *rom, uint8_t channel, uint8_t oc)
+int8_t
+ow_ds2450_oc_set(ow_rom_code_t * rom, uint8_t channel, uint8_t oc)
 {
-	int8_t ret;
-	uint8_t b;
+  int8_t ret;
+  uint8_t b;
 
-	/* we need to read the corresponding status byte since we want only modify the last bit of this byte, the rest should be unchanged */
-	ret = ow_ds2450_mempage_read(rom, OW_DS2450_OC_A + channel*2, 1, &b);
+  /* we need to read the corresponding status byte since we want only modify
+   * the last bit of this byte, the rest should be unchanged */
+  ret = ow_ds2450_mempage_read(rom, OW_DS2450_OC_A + channel * 2, 1, &b);
 
-	if(ret != 1)
-		return -2;
+  if (ret != 1)
+    return -2;
 
-	if(oc)
-		oc = 0xff;
-	else
-		oc = 0x00;
+  if (oc)
+    oc = 0xff;
+  else
+    oc = 0x00;
 
-	/* overwrite with given output control bit */
-	oc &= OW_DS2450_OC_MASK;
-	b &= ~OW_DS2450_OC_MASK;
-	b |= oc;
+  /* overwrite with given output control bit */
+  oc &= OW_DS2450_OC_MASK;
+  b &= ~OW_DS2450_OC_MASK;
+  b |= oc;
 
-	ret = ow_ds2450_mempage_write(rom, OW_DS2450_OC_A + channel*2, 1, &b);
+  ret = ow_ds2450_mempage_write(rom, OW_DS2450_OC_A + channel * 2, 1, &b);
 
-	if(ret != 1)
-		return -2;
+  if (ret != 1)
+    return -2;
 
-	return 0;
+  return 0;
 }
+
 
 /* get output enable bit */
-int8_t ow_ds2450_oe_get(ow_rom_code_t *rom, uint8_t channel)
+int8_t
+ow_ds2450_oe_get(ow_rom_code_t * rom, uint8_t channel)
 {
-	int8_t ret;
-	uint8_t b;
+  int8_t ret;
+  uint8_t b;
 
-	ret = ow_ds2450_mempage_read(rom, OW_DS2450_OE_A + channel*2, 1, &b);
+  ret = ow_ds2450_mempage_read(rom, OW_DS2450_OE_A + channel * 2, 1, &b);
 
-	if(ret != 1)
-		return -2;
+  if (ret != 1)
+    return -2;
 
-	/* check returned memory page data */
-	if(b & OW_DS2450_OE_MASK)
-		return 1;
+  /* check returned memory page data */
+  if (b & OW_DS2450_OE_MASK)
+    return 1;
 
-	return 0;
+  return 0;
 }
+
 
 /* set output enable bit */
 /* (oe == 0 => use channel for AD conversion) */
 /* (oe == 1 => use channel as output channel) */
-int8_t ow_ds2450_oe_set(ow_rom_code_t *rom, uint8_t channel, uint8_t oe)
+int8_t
+ow_ds2450_oe_set(ow_rom_code_t * rom, uint8_t channel, uint8_t oe)
 {
-	int8_t ret;
-	uint8_t b;
+  int8_t ret;
+  uint8_t b;
 
-	/* we need to read the corresponding status byte since we want only modify the last bit of this byte, the rest should be unchanged */
-	ret = ow_ds2450_mempage_read(rom, OW_DS2450_OE_A + channel*2, 1, &b);
+  /* we need to read the corresponding status byte since we want only modify
+   * the last bit of this byte, the rest should be unchanged */
+  ret = ow_ds2450_mempage_read(rom, OW_DS2450_OE_A + channel * 2, 1, &b);
 
-	if(ret != 1)
-		return -2;
+  if (ret != 1)
+    return -2;
 
-	if(oe)
-		oe = 0xff;
-	else
-		oe = 0x00;
+  if (oe)
+    oe = 0xff;
+  else
+    oe = 0x00;
 
-	/* overwrite with given output control bit */
-	oe &= OW_DS2450_OE_MASK;
-	b &= ~OW_DS2450_OE_MASK;
-	b |= oe;
+  /* overwrite with given output control bit */
+  oe &= OW_DS2450_OE_MASK;
+  b &= ~OW_DS2450_OE_MASK;
+  b |= oe;
 
-	ret = ow_ds2450_mempage_write(rom, OW_DS2450_OE_A + channel*2, 1, &b);
+  ret = ow_ds2450_mempage_write(rom, OW_DS2450_OE_A + channel * 2, 1, &b);
 
-	if(ret != 1)
-		return -2;
+  if (ret != 1)
+    return -2;
 
-	return 0;
+  return 0;
 }
+
 
 /* get AD conversion input voltage range (2.55/5.10V) bit */
-int8_t ow_ds2450_range_get(ow_rom_code_t *rom, uint8_t channel)
+int8_t
+ow_ds2450_range_get(ow_rom_code_t * rom, uint8_t channel)
 {
-	int8_t ret;
-	uint8_t b;
+  int8_t ret;
+  uint8_t b;
 
-	ret = ow_ds2450_mempage_read(rom, OW_DS2450_IR_A + channel*2, 1, &b);
+  ret = ow_ds2450_mempage_read(rom, OW_DS2450_IR_A + channel * 2, 1, &b);
 
-	if(ret != 1)
-		return -2;
+  if (ret != 1)
+    return -2;
 
-	/* check returned memory page data */
-	if(b & OW_DS2450_IR_MASK)
-		return 1;
+  /* check returned memory page data */
+  if (b & OW_DS2450_IR_MASK)
+    return 1;
 
-	return 0;
+  return 0;
 }
+
 
 /* set AD conversion input voltage range (2.55/5.10V) bit */
 /* (range == 0 => 2.55V) */
 /* (range == 1 => 5.10V) */
-int8_t ow_ds2450_range_set(ow_rom_code_t *rom, uint8_t channel, uint8_t range)
+int8_t
+ow_ds2450_range_set(ow_rom_code_t * rom, uint8_t channel, uint8_t range)
 {
-	int8_t ret;
-	uint8_t b;
+  int8_t ret;
+  uint8_t b;
 
-	/* we need to read the corresponding status byte since we want only modify the last bit of this byte, the rest should be unchanged */
-	ret = ow_ds2450_mempage_read(rom, OW_DS2450_IR_A + channel*2, 1, &b);
+  /* we need to read the corresponding status byte since we want only modify
+   * the last bit of this byte, the rest should be unchanged */
+  ret = ow_ds2450_mempage_read(rom, OW_DS2450_IR_A + channel * 2, 1, &b);
 
-	if(ret != 1)
-		return -2;
+  if (ret != 1)
+    return -2;
 
-	/* overwrite with given range bit */
-	range &= OW_DS2450_IR_MASK;
-	b &= ~OW_DS2450_IR_MASK;
-	b |= range;
+  /* overwrite with given range bit */
+  range &= OW_DS2450_IR_MASK;
+  b &= ~OW_DS2450_IR_MASK;
+  b |= range;
 
-	ret = ow_ds2450_mempage_write(rom, OW_DS2450_IR_A + channel*2, 1, &b);
+  ret = ow_ds2450_mempage_write(rom, OW_DS2450_IR_A + channel * 2, 1, &b);
 
-	if(ret != 1)
-		return -2;
+  if (ret != 1)
+    return -2;
 
-	return 0;
+  return 0;
 }
+
 
 /* get power on reset bit */
-int8_t ow_ds2450_por_get(ow_rom_code_t *rom, uint8_t channel)
+int8_t
+ow_ds2450_por_get(ow_rom_code_t * rom, uint8_t channel)
 {
-	int8_t ret;
-	uint8_t b;
+  int8_t ret;
+  uint8_t b;
 
-	ret = ow_ds2450_mempage_read(rom, OW_DS2450_POR_A + channel*2, 1, &b);
+  ret = ow_ds2450_mempage_read(rom, OW_DS2450_POR_A + channel * 2, 1, &b);
 
-	if(ret != 1)
-		return -2;
+  if (ret != 1)
+    return -2;
 
-	/* check returned memory page data */
-	if(b & OW_DS2450_POR_MASK)
-		return 1;
+  /* check returned memory page data */
+  if (b & OW_DS2450_POR_MASK)
+    return 1;
 
-	return 0;
+  return 0;
 }
+
 
 /* set power on reset bit */
 /* (por == 0 => do not respond to conditional search command) */
 /* (por == 1 => respond to conditional search command) */
-int8_t ow_ds2450_por_set(ow_rom_code_t *rom, uint8_t channel, uint8_t por)
+int8_t
+ow_ds2450_por_set(ow_rom_code_t * rom, uint8_t channel, uint8_t por)
 {
-	int8_t ret;
-	uint8_t b;
+  int8_t ret;
+  uint8_t b;
 
-	/* we need to read the corresponding status byte since we want only modify the last bit of this byte, the rest should be unchanged */
-	ret = ow_ds2450_mempage_read(rom, OW_DS2450_POR_A + channel*2, 1, &b);
+  /* we need to read the corresponding status byte since we want only modify
+   * the last bit of this byte, the rest should be unchanged */
+  ret = ow_ds2450_mempage_read(rom, OW_DS2450_POR_A + channel * 2, 1, &b);
 
-	if(ret != 1)
-		return -2;
+  if (ret != 1)
+    return -2;
 
-	/* overwrite with given output control bit */
-	por &= OW_DS2450_POR_MASK;
-	b &= ~OW_DS2450_POR_MASK;
-	b |= por;
+  /* overwrite with given output control bit */
+  por &= OW_DS2450_POR_MASK;
+  b &= ~OW_DS2450_POR_MASK;
+  b |= por;
 
-	ret = ow_ds2450_mempage_write(rom, OW_DS2450_POR_A + channel*2, 1, &b);
+  ret = ow_ds2450_mempage_write(rom, OW_DS2450_POR_A + channel * 2, 1, &b);
 
-	if(ret != 1)
-		return -2;
+  if (ret != 1)
+    return -2;
 
-	return 0;
+  return 0;
 }
+
 
 /* get power mode */
-int8_t ow_ds2450_power_get(ow_rom_code_t *rom)
+int8_t
+ow_ds2450_power_get(ow_rom_code_t * rom)
 {
-	int8_t ret;
-	uint8_t b;
+  int8_t ret;
+  uint8_t b;
 
-	ret = ow_ds2450_mempage_read(rom, OW_DS2450_VCC_POWERED, 1, &b);
+  ret = ow_ds2450_mempage_read(rom, OW_DS2450_VCC_POWERED, 1, &b);
 
-	if(ret != 1)
-		return -2;
+  if (ret != 1)
+    return -2;
 
-	/* check returned memory page data */
-	if(b == OW_DS2450_VCC_POWERED_ON)
-	{
-		DS2450_CORE_DEBUG("ow_ds2450_power_get: VCC power: ON\n");
-		return 1;
-	}
-	else if(b == OW_DS2450_VCC_POWERED_OFF)
-	{
-		DS2450_CORE_DEBUG("ow_ds2450_power_get: VCC power: OFF\n");
-		return 0;
-	}
+  /* check returned memory page data */
+  if (b == OW_DS2450_VCC_POWERED_ON)
+  {
+    DS2450_CORE_DEBUG("ow_ds2450_power_get: VCC power: ON\n");
+    return 1;
+  }
+  else if (b == OW_DS2450_VCC_POWERED_OFF)
+  {
+    DS2450_CORE_DEBUG("ow_ds2450_power_get: VCC power: OFF\n");
+    return 0;
+  }
 
-	DS2450_CORE_DEBUG("ow_ds2450_power_get: VCC power: unknown value: %02x!\n", b);
-	return -2;
+  DS2450_CORE_DEBUG("ow_ds2450_power_get: VCC power: unknown value: %02x!\n",
+                    b);
+  return -2;
 }
 
+
 /* set power mode */
-int8_t ow_ds2450_power_set(ow_rom_code_t *rom, uint8_t vcc_powered)
+int8_t
+ow_ds2450_power_set(ow_rom_code_t * rom, uint8_t vcc_powered)
 {
-	int8_t ret;
+  int8_t ret;
 
-	if(vcc_powered)
-		vcc_powered = OW_DS2450_VCC_POWERED_ON;
-	else
-		vcc_powered = OW_DS2450_VCC_POWERED_OFF;
+  if (vcc_powered)
+    vcc_powered = OW_DS2450_VCC_POWERED_ON;
+  else
+    vcc_powered = OW_DS2450_VCC_POWERED_OFF;
 
-	ret = ow_ds2450_mempage_write(rom, OW_DS2450_VCC_POWERED, 1, &vcc_powered);
+  ret = ow_ds2450_mempage_write(rom, OW_DS2450_VCC_POWERED, 1, &vcc_powered);
 
-	if(ret != 1)
-		return -2;
+  if (ret != 1)
+    return -2;
 
-	return 0;
+  return 0;
 }
 
 
 /* do AD conversion */
-int8_t ow_ds2450_convert(ow_rom_code_t *rom, uint8_t input_select, uint8_t readout)
+int8_t
+ow_ds2450_convert(ow_rom_code_t * rom, uint8_t input_select, uint8_t readout)
 {
-	uint8_t mask = 1 << (ONEWIRE_STARTPIN); // FIXME: currently only on 1st bus
-	int8_t ret;
-	uint16_t seed = 0;
+  // FIXME: currently only on 1st bus
+  uint8_t mask = 1 << (ONEWIRE_STARTPIN);
+  int8_t ret;
+  uint16_t seed = 0;
 
-	/* match ROM vs. skip ROM */
-	ret = ow_match_skip_rom(rom);
-	if(ret < 0)
-	{
-		return ret;
-	}
+  /* match ROM vs. skip ROM */
+  ret = ow_match_skip_rom(rom);
+  if (ret < 0)
+  {
+    return ret;
+  }
 
-	ow_write_byte(mask, OW_DS2450_CONVERT);
-	ow_crc16_seed_bytewise(OW_DS2450_CONVERT, &seed);
-	ow_write_byte(mask, input_select);
-	ow_crc16_seed_bytewise(input_select, &seed);
-	ow_write_byte(mask, readout);
-	ow_crc16_seed_bytewise(readout, &seed);
+  ow_write_byte(mask, OW_DS2450_CONVERT);
+  ow_crc16_seed_bytewise(OW_DS2450_CONVERT, &seed);
+  ow_write_byte(mask, input_select);
+  ow_crc16_seed_bytewise(input_select, &seed);
+  ow_write_byte(mask, readout);
+  ow_crc16_seed_bytewise(readout, &seed);
 
-	/* read CRC16 */
-	ow_crc16_seed_bytewise(ow_read_byte(mask), &seed);
-	ow_crc16_seed_bytewise(ow_read_byte(mask), &seed);
+  /* read CRC16 */
+  ow_crc16_seed_bytewise(ow_read_byte(mask), &seed);
+  ow_crc16_seed_bytewise(ow_read_byte(mask), &seed);
 
-	/* check CRC16 */
-	if(ow_crc16_check(&seed) < 0)
-	{
-		DS2450_CORE_DEBUG("ow_ds2450_convert: CRC16 invalid!\n");
-		return -2;
-	}
+  /* check CRC16 */
+  if (ow_crc16_check(&seed) < 0)
+  {
+    DS2450_CORE_DEBUG("ow_ds2450_convert: CRC16 invalid!\n");
+    return -2;
+  }
 
-	return 0;
+  return 0;
 }
 
-/* get AD conversion result for one or more channels */
-/*
-  channel_start is first channel to be read
-  channel_stop is last channel to be read
-  (evident: channel_start <= channel_stop)
-  res is loaded with ADC results (2 bytes per channel)
-  returns the number of channels processed
-*/
-int8_t ow_ds2450_get(ow_rom_code_t *rom, uint8_t channel_start, uint8_t channel_stop, uint16_t *res)
+
+/* get AD conversion result for one or more channels
+ *
+ * channel_start is first channel to be read
+ * channel_stop is last channel to be read
+ * (evident: channel_start <= channel_stop)
+ * res is loaded with ADC results (2 bytes per channel)
+ * returns the number of channels processed
+ */
+int8_t
+ow_ds2450_get(ow_rom_code_t * rom, uint8_t channel_start,
+              uint8_t channel_stop, uint16_t * res)
 {
-	int8_t ret;
-	int8_t num_channels = channel_stop - channel_start;
-	uint8_t i;
-	uint8_t *b;
+  int8_t ret;
+  int8_t num_channels = channel_stop - channel_start;
+  uint8_t i;
+  uint8_t *b;
 
-	/* increment num_channels before comparing, so that channel_start = 0 and channel_stop = 0 (which should lead to just one channel - A - gets read) will lead to num_channels = 1 */
-	if(++num_channels <= 0 || num_channels > 4)
-		return -4;
+  /* increment num_channels before comparing, so that channel_start = 0
+   * and channel_stop = 0 (which should lead to just one channel -
+   * A - gets read) will lead to num_channels = 1 */
+  if (++num_channels <= 0 || num_channels > 4)
+    return -4;
 
-	b = malloc(sizeof(uint8_t) * num_channels * 2);
+  b = malloc(sizeof(uint8_t) * num_channels * 2);
 
 #ifndef TEENSY_SUPPORT
-	/* check if malloc did fine */
-	if(!b)
-	{
-		DS2450_CORE_DEBUG("ow_ds2450_get: malloc did not return memory pointer!\n");
-		return -4;
-	}
+  /* check if malloc did fine */
+  if (!b)
+  {
+    DS2450_CORE_DEBUG
+      ("ow_ds2450_get: malloc did not return memory pointer!\n");
+    return -4;
+  }
 #endif
 
-	ret = ow_ds2450_mempage_read(rom, OW_DS2450_ADC_A_LSB + channel_start*2, num_channels*2, b);
+  ret =
+    ow_ds2450_mempage_read(rom, OW_DS2450_ADC_A_LSB + channel_start * 2,
+                           num_channels * 2, b);
 
-	if(ret != num_channels*2)
-		return -2;
+  if (ret != num_channels * 2)
+    return -2;
 
-	for(i = 0; i < num_channels; ++i)
-	{
-		/* transform two 8 bit values (LSB and MSB) to one 16 bit value */
-		res[i] = (b[(2 * i) + 1]<<8) + b[(2 * i) + 0];
+  for (i = 0; i < num_channels; ++i)
+  {
+    /* transform two 8 bit values (LSB and MSB) to one 16 bit value */
+    res[i] = (b[(2 * i) + 1] << 8) + b[(2 * i) + 0];
 
-		DS2450_CORE_DEBUG("ow_ds2450_get: channel %c: LSB: %02x, MSB: %02x, res: %04x.\n", (unsigned char) i+65, b[(2 * i) + 0], b[(2 * i) + 1], res[i]);
-	}
+    DS2450_CORE_DEBUG
+      ("ow_ds2450_get: channel %c: LSB: %02x, MSB: %02x, res: %04x.\n",
+       (unsigned char) i + 65, b[(2 * i) + 0], b[(2 * i) + 1], res[i]);
+  }
 
-	return num_channels;
+  return num_channels;
 }
 
 
-/* read a memory page beginning from given address */
-/*
-  mempage is starting address, memory get's read until end of memory page is reached (between 1 and 8 byte)
-  len counts maximal bytes read
-  mem pointer has to be big enough for the number of bytes that should be read (1..8 byte)
-  returns the number of bytes successfully read, -1 on failure
-*/
-int8_t ow_ds2450_mempage_read(ow_rom_code_t *rom, int8_t mempage, uint8_t len, uint8_t *mem)
+/* read a memory page beginning from given address
+ *
+ * mempage is starting address, memory get's read until end of memory page is
+ * reached (between 1 and 8 byte)
+ * len counts maximal bytes read
+ * mem pointer has to be big enough for the number of bytes that should be
+ * read (1..8 byte)
+ * returns the number of bytes successfully read, -1 on failure
+ */
+int8_t
+ow_ds2450_mempage_read(ow_rom_code_t * rom, int8_t mempage, uint8_t len,
+                       uint8_t * mem)
 {
-	uint8_t mask = 1 << (ONEWIRE_STARTPIN); // FIXME: currently only on 1st bus
-	int8_t ret;
-	uint16_t seed = 0;
+  // FIXME: currently only on 1st bus
+  uint8_t mask = 1 << (ONEWIRE_STARTPIN);
+  int8_t ret;
+  uint16_t seed = 0;
 
-	if(mempage > OW_DS2450_LAST_MEMPAGE_ADDR)
-		return -4;
+  if (mempage > OW_DS2450_LAST_MEMPAGE_ADDR)
+    return -4;
 
-	/* number of bytes from requested memory page that remain */
-	uint8_t bytes_remaining = 8 - (mempage % 8);
+  /* number of bytes from requested memory page that remain */
+  uint8_t bytes_remaining = 8 - (mempage % 8);
 
-	if(len == 0 || len > bytes_remaining)
-		return -4;
+  if (len == 0 || len > bytes_remaining)
+    return -4;
 
-	/* match ROM vs. skip ROM */
-	ret = ow_match_skip_rom(rom);
-	if(ret < 0)
-	{
-		return ret;
-	}
+  /* match ROM vs. skip ROM */
+  ret = ow_match_skip_rom(rom);
+  if (ret < 0)
+  {
+    return ret;
+  }
 
-	DS2450_CORE_DEBUG("ow_ds2450_mempage_read: memory page starting addr: %02x, bytes remaining: %i, len: %i.\n", mempage, bytes_remaining, len);
+  DS2450_CORE_DEBUG
+    ("ow_ds2450_mempage_read: memory page starting addr: %02x, bytes " +
+     "remaining: %i, len: %i.\n", mempage, bytes_remaining, len);
 
-	ow_write_byte(mask, OW_DS2450_READ_MEMORY);
-	ow_crc16_seed_bytewise(OW_DS2450_READ_MEMORY, &seed);
-	ow_write_byte(mask, mempage);
-	ow_crc16_seed_bytewise(mempage, &seed);
-	ow_write_byte(mask, OW_DS2450_SECOND_MEM_ADDR);
-	ow_crc16_seed_bytewise(OW_DS2450_SECOND_MEM_ADDR, &seed);
+  ow_write_byte(mask, OW_DS2450_READ_MEMORY);
+  ow_crc16_seed_bytewise(OW_DS2450_READ_MEMORY, &seed);
+  ow_write_byte(mask, mempage);
+  ow_crc16_seed_bytewise(mempage, &seed);
+  ow_write_byte(mask, OW_DS2450_SECOND_MEM_ADDR);
+  ow_crc16_seed_bytewise(OW_DS2450_SECOND_MEM_ADDR, &seed);
 
-	/* read data from memory page */
-	ret = 0;
-	for(uint8_t i = 0; i < bytes_remaining; ++i)
-	{
-		if(i < len)
-		{
-			/* still reading data that should be collected */
-			mem[i] = ow_read_byte(mask);
+  /* read data from memory page */
+  ret = 0;
+  for (uint8_t i = 0; i < bytes_remaining; ++i)
+  {
+    if (i < len)
+    {
+      /* still reading data that should be collected */
+      mem[i] = ow_read_byte(mask);
 
-			DS2450_CORE_DEBUG("ow_ds2450_mempage_read: addr: %02x, val: %02x.\n", mempage + i , mem[i]);
+      DS2450_CORE_DEBUG("ow_ds2450_mempage_read: addr: %02x, val: %02x.\n",
+                        mempage + i, mem[i]);
 
-			/* feeding value to CRC16 calculation */
-			ow_crc16_seed_bytewise(mem[i], &seed);
+      /* feeding value to CRC16 calculation */
+      ow_crc16_seed_bytewise(mem[i], &seed);
 
-			++ret;
-		}
-		else
-		{
-			/* all requested data was read, but we still need to read more data to calculate CRC16 correctly... */
-			/* just feeding value to CRC16 calculation */
+      ++ret;
+    }
+    else
+    {
+      /* all requested data was read, but still need to read more data to
+       * calculate CRC16 correctly. just feeding value to CRC16 calculation */
 #ifdef DEBUG_OW_DS2450_CORE
-			uint8_t b = ow_read_byte(mask);
-			ow_crc16_seed_bytewise(b, &seed);
+      uint8_t b = ow_read_byte(mask);
+      ow_crc16_seed_bytewise(b, &seed);
 #else
-			ow_crc16_seed_bytewise(ow_read_byte(mask), &seed);
+      ow_crc16_seed_bytewise(ow_read_byte(mask), &seed);
 #endif
 
-			DS2450_CORE_DEBUG("ow_ds2450_mempage_read: addr: %02x, val: %02x (dropped).\n", mempage + i , b);
-		}
-	}
+      DS2450_CORE_DEBUG
+        ("ow_ds2450_mempage_read: addr: %02x, val: %02x (dropped).\n",
+         mempage + i, b);
+    }
+  }
 
-	/* CRC16 */
-	ow_crc16_seed_bytewise(ow_read_byte(mask), &seed);
-	ow_crc16_seed_bytewise(ow_read_byte(mask), &seed);
+  /* CRC16 */
+  ow_crc16_seed_bytewise(ow_read_byte(mask), &seed);
+  ow_crc16_seed_bytewise(ow_read_byte(mask), &seed);
 
-	/* check CRC16 */
-	if(ow_crc16_check(&seed) < 0)
-	{
-		DS2450_CORE_DEBUG("ow_ds2450_mempage_read: CRC16 invalid!\n");
-		return -2;
-	}
+  /* check CRC16 */
+  if (ow_crc16_check(&seed) < 0)
+  {
+    DS2450_CORE_DEBUG("ow_ds2450_mempage_read: CRC16 invalid!\n");
+    return -2;
+  }
 
-	return ret;
+  return ret;
 }
 
-/* write a memory page beginning from given address */
-/*
-  mempage is starting address, memory get's written until end of memory page is reached (between 1 and 8 byte)
-  len bytes are written (len may not be greater then the number of bytes remaining of the requested memory page)
-  mem pointer contains data to be written (1..8 byte)
-  returns the number of bytes successfully written, -1 on failure
-*/
-int8_t ow_ds2450_mempage_write(ow_rom_code_t *rom, int8_t mempage, uint8_t len, uint8_t *mem)
+
+/* write a memory page beginning from given address
+ *
+ * mempage is starting address, memory gets written until end of memory page
+ * is reached (between 1 and 8 byte)
+ * len bytes are written (len may not be greater then the number of bytes
+ * remaining of the requested memory page)
+ * mem pointer contains data to be written (1..8 byte)
+ * returns the number of bytes successfully written, -1 on failure
+ */
+int8_t
+ow_ds2450_mempage_write(ow_rom_code_t * rom, int8_t mempage, uint8_t len,
+                        uint8_t * mem)
 {
-	uint8_t mask = 1 << (ONEWIRE_STARTPIN); // FIXME: currently only on 1st bus
-	int8_t ret;
-	uint16_t seed = 0;
+  // FIXME: currently only on 1st bus
+  uint8_t mask = 1 << (ONEWIRE_STARTPIN);
+  int8_t ret;
+  uint16_t seed = 0;
 
-	if(mempage > OW_DS2450_LAST_MEMPAGE_ADDR)
-		return -4;
+  if (mempage > OW_DS2450_LAST_MEMPAGE_ADDR)
+    return -4;
 
-	/* number of bytes from requested memory page that remain */
-	uint8_t bytes_remaining = 8 - (mempage % 8);
+  /* number of bytes from requested memory page that remain */
+  uint8_t bytes_remaining = 8 - (mempage % 8);
 
-	if(len == 0 || len > bytes_remaining)
-		return -4;
+  if (len == 0 || len > bytes_remaining)
+    return -4;
 
-	/* match ROM vs. skip ROM */
-	ret = ow_match_skip_rom(rom);
-	if(ret < 0)
-	{
-		return ret;
-	}
+  /* match ROM vs. skip ROM */
+  ret = ow_match_skip_rom(rom);
+  if (ret < 0)
+  {
+    return ret;
+  }
 
-	DS2450_CORE_DEBUG("ow_ds2450_mempage_write: memory page starting addr: %02x, bytes remaining: %i, len: %i.\n", mempage, bytes_remaining, len);
+  DS2450_CORE_DEBUG
+    ("ow_ds2450_mempage_write: memory page starting addr: %02x, bytes " +
+     "remaining: %i, len: %i.\n", mempage, bytes_remaining, len);
 
-	ow_write_byte(mask, OW_DS2450_WRITE_MEMORY);
-	ow_crc16_seed_bytewise(OW_DS2450_WRITE_MEMORY, &seed);
-	ow_write_byte(mask, mempage);
-	ow_crc16_seed_bytewise(mempage, &seed);
-	ow_write_byte(mask, OW_DS2450_SECOND_MEM_ADDR);
-	ow_crc16_seed_bytewise(OW_DS2450_SECOND_MEM_ADDR, &seed);
+  ow_write_byte(mask, OW_DS2450_WRITE_MEMORY);
+  ow_crc16_seed_bytewise(OW_DS2450_WRITE_MEMORY, &seed);
+  ow_write_byte(mask, mempage);
+  ow_crc16_seed_bytewise(mempage, &seed);
+  ow_write_byte(mask, OW_DS2450_SECOND_MEM_ADDR);
+  ow_crc16_seed_bytewise(OW_DS2450_SECOND_MEM_ADDR, &seed);
 
-	/* write data to memory page */
-	ret = 0;
-	for(uint8_t i = 0; i < len; ++i)
-	{
-		DS2450_CORE_DEBUG("ow_ds2450_mempage_write: addr: %02x, val: %02x.\n", mempage + i , mem[i]);
+  /* write data to memory page */
+  ret = 0;
+  for (uint8_t i = 0; i < len; ++i)
+  {
+    DS2450_CORE_DEBUG("ow_ds2450_mempage_write: addr: %02x, val: %02x.\n",
+                      mempage + i, mem[i]);
 
-		ow_write_byte(mask, mem[i]);
+    ow_write_byte(mask, mem[i]);
 
-		/* reset seed and feed memory page address to CRC16 calculation only if first run is passed */
-		if(i != 0)
-		{
-			seed = 0;
-			ow_crc16_seed_bytewise(mempage + i, &seed);
-			ow_crc16_seed_bytewise(OW_DS2450_SECOND_MEM_ADDR, &seed);
-		}
+    /* reset seed and feed memory page address to CRC16 calculation only if
+     * first run is passed */
+    if (i != 0)
+    {
+      seed = 0;
+      ow_crc16_seed_bytewise(mempage + i, &seed);
+      ow_crc16_seed_bytewise(OW_DS2450_SECOND_MEM_ADDR, &seed);
+    }
 
-		/* feeding value to CRC16 calculation */
-		ow_crc16_seed_bytewise(mem[i], &seed);
+    /* feeding value to CRC16 calculation */
+    ow_crc16_seed_bytewise(mem[i], &seed);
 
-		/* CRC16 */
-		ow_crc16_seed_bytewise(ow_read_byte(mask), &seed);
-		ow_crc16_seed_bytewise(ow_read_byte(mask), &seed);
+    /* CRC16 */
+    ow_crc16_seed_bytewise(ow_read_byte(mask), &seed);
+    ow_crc16_seed_bytewise(ow_read_byte(mask), &seed);
 
-		/* check CRC16 */
-		if(ow_crc16_check(&seed) < 0)
-		{
-			DS2450_CORE_DEBUG("ow_ds2450_mempage_write: CRC16 invalid!\n");
-			return -2;
-		}
+    /* check CRC16 */
+    if (ow_crc16_check(&seed) < 0)
+    {
+      DS2450_CORE_DEBUG("ow_ds2450_mempage_write: CRC16 invalid!\n");
+      return -2;
+    }
 
-		/* read-back for simple verification */
+    /* read-back for simple verification */
 #ifdef DEBUG_OW_DS2450_CORE
-		uint8_t b = ow_read_byte(mask);
-		if(b != mem[i])
+    uint8_t b = ow_read_byte(mask);
+    if (b != mem[i])
 #else
-		if(ow_read_byte(mask) != mem[i])
+    if (ow_read_byte(mask) != mem[i])
 #endif
-		{
-			DS2450_CORE_DEBUG("ow_ds2450_mempage_write: read-back verification failed: wrote: %02x, read-back: %02x!\n", mem[i], b);
-			return -2;
-		}
+    {
+      DS2450_CORE_DEBUG
+        ("ow_ds2450_mempage_write: read-back verification failed: wrote: " +
+         "%02x, read-back: %02x!\n", mem[i], b);
+      return -2;
+    }
 
-		++ret;
-	}
+    ++ret;
+  }
 
-	return ret;
+  return ret;
 }

--- a/hardware/onewire/ds2450.h
+++ b/hardware/onewire/ds2450.h
@@ -2,20 +2,22 @@
  * Support for ADC DS2450
  * real hardware access - header file
  * Copyright (C) 2009 Meinhard Schneider <meini@meini.org>
- * 
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 2 of the License, or (at your option) any later
- * version.
- * 
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License along with
- * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
- * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
+
 
 #ifndef _DS2450_H
 #define _DS2450_H
@@ -28,25 +30,28 @@
 
 /* Debugging */
 #ifdef DEBUG_OW_DS2450_CORE
-	#include "core/debug.h"
-	#define DS2450_CORE_DEBUG(a...) debug_printf("DS2450: " a)
+#include "core/debug.h"
+#define DS2450_CORE_DEBUG(a...) debug_printf("DS2450: " a)
 #else
-	#define DS2450_CORE_DEBUG(a...)
+#define DS2450_CORE_DEBUG(a...)
 #endif
 
+
 #ifdef DEBUG_OW_DS2450_ECMD
-	#include "core/debug.h"
-	#define DS2450_ECMD_DEBUG(a...) debug_printf("DS2450: " a)
+#include "core/debug.h"
+#define DS2450_ECMD_DEBUG(a...) debug_printf("DS2450: " a)
 #else
-	#define DS2450_ECMD_DEBUG(a...)
+#define DS2450_ECMD_DEBUG(a...)
 #endif
 
 
 /* 1wire family definition for DS2450 */
 #define OW_DS2450_FAMILY 0x20
 
+
 /* memory map pages */
 #define OW_DS2450_SECOND_MEM_ADDR 0x00
+
 
 /* channel offset for A, B, C and D */
 #define OW_DS2450_A_OFFSET 0
@@ -54,13 +59,15 @@
 #define OW_DS2450_C_OFFSET 4
 #define OW_DS2450_D_OFFSET 6
 
-/* page 0 (conversion read-out) */
-/* (addresses for channel B, C and D can be computed from channel offsets) */
+
+/* page 0 (conversion read-out)
+ * (addresses for channel B, C and D can be computed from channel offsets) */
 #define OW_DS2450_ADC_A_LSB 0x00
 #define OW_DS2450_ADC_A_MSB 0x01
 
-/* page 1 (control/status data) */
-/* (addresses for channel B, C and D can be computed from channel offsets) */
+
+/* page 1 (control/status data)
+ * (addresses for channel B, C and D can be computed from channel offsets) */
 #define OW_DS2450_RC_A 0x08
 #define OW_DS2450_RC0_A 0x08
 #define OW_DS2450_RC1_A 0x08
@@ -75,6 +82,7 @@
 #define OW_DS2450_AFL_A 0x09
 #define OW_DS2450_AFH_A 0x09
 #define OW_DS2450_POR_A 0x09
+
 
 /* page 1 masks (common to all channels) */
 #define OW_DS2450_RC_MASK 0x0f
@@ -92,18 +100,22 @@
 #define OW_DS2450_AFH_MASK 0x20
 #define OW_DS2450_POR_MASK 0x80
 
-/* page 2 (alarm settings) */
-/* (addresses for channel B, C and D can be computed from channel offsets) */
+
+/* page 2 (alarm settings)
+ * (addresses for channel B, C and D can be computed from channel offsets) */
 #define OW_DS2450_ALARM_LOW_A 0x00
 #define OW_DS2450_ALARM_HIGH_A 0x01
+
 
 /* page 3 (factory calibration and VCC control) */
 #define OW_DS2450_VCC_POWERED 0x1c
 #define OW_DS2450_VCC_POWERED_ON 0x40
 #define OW_DS2450_VCC_POWERED_OFF 0x00
 
+
 /* last valid memory page addresses */
 #define OW_DS2450_LAST_MEMPAGE_ADDR 0x1f
+
 
 /* function commands */
 #define OW_DS2450_READ_MEMORY 0xaa
@@ -112,69 +124,95 @@
 
 
 /* match ROM vs. skip ROM */
-int8_t ow_match_skip_rom(ow_rom_code_t *rom);
+int8_t ow_match_skip_rom(ow_rom_code_t * rom);
+
 
 /* check CRC16 with seed */
-void ow_crc16_seed(uint8_t *b, uint8_t len, uint16_t *seed);
+void ow_crc16_seed(uint8_t * b, uint8_t len, uint16_t * seed);
 
-/* check CRC16 seed after eating all data bytes an both CRC16 bytes */
-/* return 0 on success (CRC16 good), -1 on failure (CRC16 bad) */
-int8_t ow_crc16_check(uint16_t *seed);
+
+/* check CRC16 seed after eating all data bytes an both CRC16 bytes
+ * return 0 on success (CRC16 good), -1 on failure (CRC16 bad) */
+int8_t ow_crc16_check(uint16_t * seed);
+
 
 /* calculates CRC16 after eating all data bytes */
-uint16_t ow_crc16_calc(uint16_t *seed);
+uint16_t ow_crc16_calc(uint16_t * seed);
+
 
 /* input for ow_crc16_seed but bytewise */
-void ow_crc16_seed_bytewise(uint8_t b, uint16_t *seed);
+void ow_crc16_seed_bytewise(uint8_t b, uint16_t * seed);
+
 
 /* check sensor family againt DS2450 */
-uint8_t ow_ds2450_sensor(ow_rom_code_t *rom);
+uint8_t ow_ds2450_sensor(ow_rom_code_t * rom);
+
 
 /* get AD conversion resultion mask bits */
-int8_t ow_ds2450_res_get(ow_rom_code_t *rom, uint8_t channel);
+int8_t ow_ds2450_res_get(ow_rom_code_t * rom, uint8_t channel);
+
 
 /* set AD conversion resultion mask bits */
-int8_t ow_ds2450_res_set(ow_rom_code_t *rom, uint8_t channel, uint8_t res);
+int8_t ow_ds2450_res_set(ow_rom_code_t * rom, uint8_t channel, uint8_t res);
+
 
 /* get output control bit */
-int8_t ow_ds2450_oc_get(ow_rom_code_t *rom, uint8_t channel);
+int8_t ow_ds2450_oc_get(ow_rom_code_t * rom, uint8_t channel);
+
 
 /* set output control bit */
-int8_t ow_ds2450_oc_set(ow_rom_code_t *rom, uint8_t channel, uint8_t oc);
+int8_t ow_ds2450_oc_set(ow_rom_code_t * rom, uint8_t channel, uint8_t oc);
+
 
 /* get output enable bit */
-int8_t ow_ds2450_oe_get(ow_rom_code_t *rom, uint8_t channel);
+int8_t ow_ds2450_oe_get(ow_rom_code_t * rom, uint8_t channel);
+
 
 /* set output enable bit */
-int8_t ow_ds2450_oe_set(ow_rom_code_t *rom, uint8_t channel, uint8_t oe);
+int8_t ow_ds2450_oe_set(ow_rom_code_t * rom, uint8_t channel, uint8_t oe);
+
 
 /* get AD conversion input voltage range (2.55/5.10V) bit */
-int8_t ow_ds2450_range_get(ow_rom_code_t *rom, uint8_t channel);
+int8_t ow_ds2450_range_get(ow_rom_code_t * rom, uint8_t channel);
+
 
 /* set AD conversion input voltage range (2.55/5.10V) bit */
-int8_t ow_ds2450_range_set(ow_rom_code_t *rom, uint8_t channel, uint8_t range);
+int8_t ow_ds2450_range_set(ow_rom_code_t * rom, uint8_t channel,
+                           uint8_t range);
+
 
 /* get power on reset bit */
-int8_t ow_ds2450_por_get(ow_rom_code_t *rom, uint8_t channel);
+int8_t ow_ds2450_por_get(ow_rom_code_t * rom, uint8_t channel);
+
 
 /* set power on reset bit */
-int8_t ow_ds2450_por_set(ow_rom_code_t *rom, uint8_t channel, uint8_t por);
+int8_t ow_ds2450_por_set(ow_rom_code_t * rom, uint8_t channel, uint8_t por);
+
 
 /* get power mode */
-int8_t ow_ds2450_power_get(ow_rom_code_t *rom);
+int8_t ow_ds2450_power_get(ow_rom_code_t * rom);
+
 
 /* set power mode */
-int8_t ow_ds2450_power_set(ow_rom_code_t *rom, uint8_t vcc_powered);
+int8_t ow_ds2450_power_set(ow_rom_code_t * rom, uint8_t vcc_powered);
+
 
 /* do AD conversion */
-int8_t ow_ds2450_convert(ow_rom_code_t *rom, uint8_t input_select, uint8_t readout);
+int8_t ow_ds2450_convert(ow_rom_code_t * rom, uint8_t input_select,
+                         uint8_t readout);
+
 
 /* get AD conversion result for one or more channels */
-int8_t ow_ds2450_get(ow_rom_code_t *rom, uint8_t channel_start, uint8_t channel_stop, uint16_t *res);
+int8_t ow_ds2450_get(ow_rom_code_t * rom, uint8_t channel_start,
+                     uint8_t channel_stop, uint16_t * res);
+
 
 /* read a memory page beginning from given address */
-int8_t ow_ds2450_mempage_read(ow_rom_code_t *rom, int8_t mempage, uint8_t len, uint8_t *mem);
+int8_t ow_ds2450_mempage_read(ow_rom_code_t * rom, int8_t mempage,
+                              uint8_t len, uint8_t * mem);
+
 
 /* write a memory page beginning from given address */
-int8_t ow_ds2450_mempage_write(ow_rom_code_t *rom, int8_t mempage, uint8_t len, uint8_t *mem);
+int8_t ow_ds2450_mempage_write(ow_rom_code_t * rom, int8_t mempage,
+                               uint8_t len, uint8_t * mem);
 #endif

--- a/hardware/onewire/ds2450_ecmd.c
+++ b/hardware/onewire/ds2450_ecmd.c
@@ -2,20 +2,22 @@
  * Support for ADC DS2450
  * ECMD interface
  * Copyright (C) 2009 Meinhard Schneider <meini@meini.org>
- * 
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 2 of the License, or (at your option) any later
- * version.
- * 
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License along with
- * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
- * Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
+
 
 #include <avr/interrupt.h>
 #include <avr/pgmspace.h>
@@ -32,708 +34,835 @@
 
 
 /* from ecmd.c: */
-int8_t parse_ow_rom(char *cmd, ow_rom_code_t *rom);
+int8_t parse_ow_rom(char *cmd, ow_rom_code_t * rom);
 
 
 /* parse the command line and check for a rom code */
-int8_t noinline ow_ecmd_parse_rom_arg(char **cmd, ow_rom_code_t **ptr_rom)
+int8_t noinline
+ow_ecmd_parse_rom_arg(char **cmd, ow_rom_code_t ** ptr_rom)
 {
-	int8_t ret;
+  int8_t ret;
 
-	while(**cmd == ' ')
-		(*cmd)++;
+  while (**cmd == ' ')
+    (*cmd)++;
 
-	if(strlen(*cmd) >= 16)
-	{
-		/* called with rom code */
-		DS2450_ECMD_DEBUG("ow_ecmd_parse_rom_arg: called with rom code.\n");
-		*ptr_rom = malloc(sizeof(ow_rom_code_t));
+  if (strlen(*cmd) >= 16)
+  {
+    /* called with rom code */
+    DS2450_ECMD_DEBUG("ow_ecmd_parse_rom_arg: called with rom code.\n");
+    *ptr_rom = malloc(sizeof(ow_rom_code_t));
 
 #ifndef TEENSY_SUPPORT
-		/* check if malloc did fine */
-		if(!*ptr_rom)
-		{
-			DS2450_ECMD_DEBUG("ow_ecmd_parse_rom_arg: malloc did not return memory pointer!\n");
-			return ECMD_ERR_READ_ERROR;
-		}
+    /* check if malloc did fine */
+    if (!*ptr_rom)
+    {
+      DS2450_ECMD_DEBUG
+        ("ow_ecmd_parse_rom_arg: malloc did not return memory pointer!\n");
+      return ECMD_ERR_READ_ERROR;
+    }
 #endif
 
-		ret = parse_ow_rom(*cmd, *ptr_rom);
+    ret = parse_ow_rom(*cmd, *ptr_rom);
 
-		/* check for parse error */
-		if(ret < 0)
-		{
-			DS2450_ECMD_DEBUG("ow_ecmd_parse_rom_arg: parser error (parse_ow_rom ret: %i)!\n", ret);
-			return ECMD_ERR_PARSE_ERROR;
-		}
+    /* check for parse error */
+    if (ret < 0)
+    {
+      DS2450_ECMD_DEBUG
+        ("ow_ecmd_parse_rom_arg: parser error (parse_ow_rom ret: %i)!\n",
+         ret);
+      return ECMD_ERR_PARSE_ERROR;
+    }
 
-		/* move pointer behind rom code */
-		*cmd += 16;
+    /* move pointer behind rom code */
+    *cmd += 16;
 
 #ifdef DEBUG_OW_DS2450_ECMD
-		uint8_t *addr = (*ptr_rom)->bytewise;
-		DS2450_ECMD_DEBUG("ow_ecmd_parse_rom_arg: parsed rom code: %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x.\n",
-			addr[0], addr[1], addr[2], addr[3],
-			addr[4], addr[5], addr[6], addr[7]);
+    uint8_t *addr = (*ptr_rom)->bytewise;
+    DS2450_ECMD_DEBUG
+      ("ow_ecmd_parse_rom_arg: parsed rom code: " +
+       "%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x.\n", addr[0], addr[1],
+       addr[2], addr[3], addr[4], addr[5], addr[6], addr[7]);
 #endif
-	}
-	else
-	{
-		/* no rom code, use skip command */
-		DS2450_ECMD_DEBUG("ow_ecmd_parse_rom_arg: called without rom code.\n");
-		*ptr_rom = NULL;
-	}
+  }
+  else
+  {
+    /* no rom code, use skip command */
+    DS2450_ECMD_DEBUG("ow_ecmd_parse_rom_arg: called without rom code.\n");
+    *ptr_rom = NULL;
+  }
 
-	while(**cmd == ' ')
-		(*cmd)++;
+  while (**cmd == ' ')
+    (*cmd)++;
 
-	return 0;
+  return 0;
 }
+
 
 /* convert channel character to decimal */
-int8_t noinline ow_ds2450_channel_char(char c)
+int8_t noinline
+ow_ds2450_channel_char(char c)
 {
-	DS2450_ECMD_DEBUG("ow_ds2450_channel_char: called with character: %c.\n", c);
-	if(c >= 65 && c <= 68)
-	{
-		/* channel ASCII value A to D (uppercase) */
-		return c - 'A';
-	}
-	else if(c >= 97 && c <= 100)
-	{
-		/* channel ASCII value a to d (lowercase) */
-		return c - 'a';
-	}
+  DS2450_ECMD_DEBUG("ow_ds2450_channel_char: called with character: %c.\n",
+                    c);
+  if (c >= 65 && c <= 68)
+  {
+    /* channel ASCII value A to D (uppercase) */
+    return c - 'A';
+  }
+  else if (c >= 97 && c <= 100)
+  {
+    /* channel ASCII value a to d (lowercase) */
+    return c - 'a';
+  }
 
-	DS2450_ECMD_DEBUG("ow_ds2450_channel_char: channel character invalid!\n", c);
+  DS2450_ECMD_DEBUG("ow_ds2450_channel_char: channel character invalid!\n",
+                    c);
 
-	return -1;
+  return -1;
 }
 
 
-int16_t parse_cmd_onewire_ds2450_power(char *cmd, char *output, uint16_t len)
+int16_t
+parse_cmd_onewire_ds2450_power(char *cmd, char *output, uint16_t len)
 {
-	int8_t ret;
-	uint8_t ecmd_return_len = 0;
-	uint8_t power;
-	ow_rom_code_t *ptr_rom;
+  int8_t ret;
+  uint8_t ecmd_return_len = 0;
+  uint8_t power;
+  ow_rom_code_t *ptr_rom;
 
-	ret = ow_ecmd_parse_rom_arg(&cmd, &ptr_rom);
-	if(ret != 0)
-		return ret;
+  ret = ow_ecmd_parse_rom_arg(&cmd, &ptr_rom);
+  if (ret != 0)
+    return ret;
 
-	/* next byte may be the power value, if so: set power value, if not: read and print power value */
-	if(*cmd == '\0') {
-		ret = ow_ds2450_power_get(ptr_rom);
+  /* next byte may be the power value, if so: set power value, if not: read
+   * and print power value */
+  if (*cmd == '\0')
+  {
+    ret = ow_ds2450_power_get(ptr_rom);
 
-		DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_power: ow_ds2450_power_get ret: %i.\n", ret);
+    DS2450_ECMD_DEBUG
+      ("parse_cmd_onewire_ds2450_power: ow_ds2450_power_get ret: %i.\n", ret);
 
-		if(ret < 0)
-			return ECMD_ERR_READ_ERROR;
+    if (ret < 0)
+      return ECMD_ERR_READ_ERROR;
 
-		ecmd_return_len = snprintf_P(output, len, PSTR("POWER: %i"), ret);
-	}
-	else
-	{
+    ecmd_return_len = snprintf_P(output, len, PSTR("POWER: %i"), ret);
+  }
+  else
+  {
 #ifdef DEBUG_OW_DS2450_ECMD
-		uint8_t sret = sscanf_P(cmd, PSTR("%1hx"), &power);
-		DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_power: sscanf_P ret: %i, power: %u.\n", sret, power);
-		if(sret != 1)
+    uint8_t sret = sscanf_P(cmd, PSTR("%1hx"), &power);
+    DS2450_ECMD_DEBUG
+      ("parse_cmd_onewire_ds2450_power: sscanf_P ret: %i, power: %u.\n",
+       sret, power);
+    if (sret != 1)
 #else
-		if(sscanf_P(cmd, PSTR("%1hx"), &power) != 1)
+    if (sscanf_P(cmd, PSTR("%1hx"), &power) != 1)
 #endif
-			return ECMD_ERR_PARSE_ERROR;
+      return ECMD_ERR_PARSE_ERROR;
 
-		if(!(power == 0 || power == 1))
-			return ECMD_ERR_PARSE_ERROR;
+    if (!(power == 0 || power == 1))
+      return ECMD_ERR_PARSE_ERROR;
 
 #ifndef TEENSY_SUPPORT
-		/* argument should have been 1-digit, so move cmd pointer one position forward */
-		++cmd;
+    /* argument should have been 1-digit, so move cmd pointer one position
+     * forward */
+    ++cmd;
 
-		/* no more characters should be waiting in cmd */
-		if(strlen(cmd) > 0)
-		{
-			DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_power: cmd still contains data after parsing all argumentes!\n");
-			return ECMD_ERR_PARSE_ERROR;
-		}
+    /* no more characters should be waiting in cmd */
+    if (strlen(cmd) > 0)
+    {
+      DS2450_ECMD_DEBUG
+        ("parse_cmd_onewire_ds2450_power: cmd still contains data after " +
+         "parsing all argumentes!\n");
+      return ECMD_ERR_PARSE_ERROR;
+    }
 #endif
 
-		ret = ow_ds2450_power_set(ptr_rom, power);
+    ret = ow_ds2450_power_set(ptr_rom, power);
 
-		DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_power: ow_ds2450_power_set ret: %i\n", ret);
+    DS2450_ECMD_DEBUG
+      ("parse_cmd_onewire_ds2450_power: ow_ds2450_power_set ret: %i\n", ret);
 
-		if(ret != 0)
-			return ECMD_ERR_READ_ERROR;
-	}
+    if (ret != 0)
+      return ECMD_ERR_READ_ERROR;
+  }
 
-	if(ecmd_return_len)
-		return ECMD_FINAL(ecmd_return_len);
-	else
-		return ECMD_FINAL_OK;
+  if (ecmd_return_len)
+    return ECMD_FINAL(ecmd_return_len);
+  else
+    return ECMD_FINAL_OK;
 }
 
-int16_t parse_cmd_onewire_ds2450_res(char *cmd, char *output, uint16_t len)
+
+int16_t
+parse_cmd_onewire_ds2450_res(char *cmd, char *output, uint16_t len)
 {
-	int8_t ret;
-	int8_t channel_requested;
-	uint8_t ecmd_return_len = 0;
-	uint8_t res;
-	ow_rom_code_t *ptr_rom;
+  int8_t ret;
+  int8_t channel_requested;
+  uint8_t ecmd_return_len = 0;
+  uint8_t res;
+  ow_rom_code_t *ptr_rom;
 
-	ret = ow_ecmd_parse_rom_arg(&cmd, &ptr_rom);
-	if(ret != 0)
-		return ret;
+  ret = ow_ecmd_parse_rom_arg(&cmd, &ptr_rom);
+  if (ret != 0)
+    return ret;
 
-	if(*cmd == '\0')
-	{
-		/* no more data to read from cmd */
-		DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_res: not enogh arguments, expecting at least a channel name!\n");
-		return ECMD_ERR_PARSE_ERROR;
-	}
-	else
-	{
-		/* next byte should be a channel character */
-		channel_requested = ow_ds2450_channel_char(*cmd);
-		if(channel_requested < 0)
-			return ECMD_ERR_PARSE_ERROR;
+  if (*cmd == '\0')
+  {
+    /* no more data to read from cmd */
+    DS2450_ECMD_DEBUG
+      ("parse_cmd_onewire_ds2450_res: not enogh arguments, expecting at " +
+       "least a channel name!\n");
+    return ECMD_ERR_PARSE_ERROR;
+  }
+  else
+  {
+    /* next byte should be a channel character */
+    channel_requested = ow_ds2450_channel_char(*cmd);
+    if (channel_requested < 0)
+      return ECMD_ERR_PARSE_ERROR;
 
-		/* channel char must have been 1-digit, so move cmd pointer one position forward */
-		++cmd;
+    /* channel char must have been 1-digit, so move cmd pointer one position
+     * forward */
+    ++cmd;
 
-		while(*cmd == ' ')
-			++cmd;
+    while (*cmd == ' ')
+      ++cmd;
 
-		/* next byte may be the res value, if so: set res value, if not: read and print res value */
-		if(*cmd == '\0') {
+    /* next byte may be the res value, if so: set res value, if not: read and
+     * print res value */
+    if (*cmd == '\0')
+    {
 
-			ret = ow_ds2450_res_get(ptr_rom, channel_requested);
+      ret = ow_ds2450_res_get(ptr_rom, channel_requested);
 
-			DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_res: ow_ds2450_res_get ret: %i.\n", ret);
+      DS2450_ECMD_DEBUG
+        ("parse_cmd_onewire_ds2450_res: ow_ds2450_res_get ret: %i.\n", ret);
 
-			if(ret < 0)
-				return ECMD_ERR_READ_ERROR;
+      if (ret < 0)
+        return ECMD_ERR_READ_ERROR;
 
-			ecmd_return_len = snprintf_P(output, len, PSTR("ch %c RES: %02x"), (unsigned char) channel_requested+65, ret);
-		}
-		else
-		{
+      ecmd_return_len =
+        snprintf_P(output, len, PSTR("ch %c RES: %02x"),
+                   (unsigned char) channel_requested + 65, ret);
+    }
+    else
+    {
 #ifdef DEBUG_OW_DS2450_ECMD
-			uint8_t sret = sscanf_P(cmd, PSTR("%2hhx"), &res);
-			DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_res: sscanf_P ret: %i, res: %02x.\n", sret, res);
-			if(sret != 1)
+      uint8_t sret = sscanf_P(cmd, PSTR("%2hhx"), &res);
+      DS2450_ECMD_DEBUG
+        ("parse_cmd_onewire_ds2450_res: sscanf_P ret: %i, res: %02x.\n", sret,
+         res);
+      if (sret != 1)
 #else
-			if(sscanf_P(cmd, PSTR("%2hhx"), &res) != 1)
+      if (sscanf_P(cmd, PSTR("%2hhx"), &res) != 1)
 #endif
-				return ECMD_ERR_PARSE_ERROR;
+        return ECMD_ERR_PARSE_ERROR;
 
-			/* valid values are 0x1 (1 bit resultion) up to 0xf (15 bit resultion) */
-			/* for 16 bit resultion the four least significant bits must set to zero (0x0), we will also accept 0x10 as decimal representation of 16 */
-			if(res == 0x10)
-				res = 0x00;
-			else if(res > OW_DS2450_RC_MASK)
-				return ECMD_ERR_PARSE_ERROR;
+      /* valid values are 0x1 (1 bit resultion) up to 0xf (15 bit resultion)
+       * for 16 bit resultion the four least significant bits must set to
+       * zero (0x0), we will also accept 0x10 as decimal representation of
+       * 16 */
+      if (res == 0x10)
+        res = 0x00;
+      else if (res > OW_DS2450_RC_MASK)
+        return ECMD_ERR_PARSE_ERROR;
 
 #ifndef TEENSY_SUPPORT
-			/* argument should have been 2-digit, so move cmd pointer two positions forward */
-			cmd += 2;
+      /* argument should have been 2-digit, so move cmd pointer two positions
+       * forward */
+      cmd += 2;
 
-			/* no more characters should be waiting in cmd */
-			if(strlen(cmd) > 0)
-			{
-				DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_res: cmd still contains data after parsing all argumentes!\n");
-				return ECMD_ERR_PARSE_ERROR;
-			}
+      /* no more characters should be waiting in cmd */
+      if (strlen(cmd) > 0)
+      {
+        DS2450_ECMD_DEBUG
+          ("parse_cmd_onewire_ds2450_res: cmd still contains data after " +
+           "parsing all argumentes!\n");
+        return ECMD_ERR_PARSE_ERROR;
+      }
 #endif
-			ret = ow_ds2450_res_set(ptr_rom, channel_requested, res);
+      ret = ow_ds2450_res_set(ptr_rom, channel_requested, res);
 
-			DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_res: ow_ds2450_res_set ret: %i\n", ret);
+      DS2450_ECMD_DEBUG
+        ("parse_cmd_onewire_ds2450_res: ow_ds2450_res_set ret: %i\n", ret);
 
-			if(ret != 0)
-				return ECMD_ERR_READ_ERROR;
-		}
-	}
+      if (ret != 0)
+        return ECMD_ERR_READ_ERROR;
+    }
+  }
 
-	if(ecmd_return_len)
-		return ECMD_FINAL(ecmd_return_len);
-	else
-		return ECMD_FINAL_OK;
+  if (ecmd_return_len)
+    return ECMD_FINAL(ecmd_return_len);
+  else
+    return ECMD_FINAL_OK;
 }
 
-int16_t parse_cmd_onewire_ds2450_oc(char *cmd, char *output, uint16_t len)
+
+int16_t
+parse_cmd_onewire_ds2450_oc(char *cmd, char *output, uint16_t len)
 {
-	int8_t ret;
-	int8_t channel_requested;
-	uint8_t ecmd_return_len = 0;
-	uint8_t oc;
-	ow_rom_code_t *ptr_rom;
+  int8_t ret;
+  int8_t channel_requested;
+  uint8_t ecmd_return_len = 0;
+  uint8_t oc;
+  ow_rom_code_t *ptr_rom;
 
-	ret = ow_ecmd_parse_rom_arg(&cmd, &ptr_rom);
-	if(ret != 0)
-		return ret;
+  ret = ow_ecmd_parse_rom_arg(&cmd, &ptr_rom);
+  if (ret != 0)
+    return ret;
 
-	if(*cmd == '\0')
-	{
-		/* no more data to read from cmd */
-		DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_oc: not enogh arguments, expecting at least a channel name!\n");
-		return ECMD_ERR_PARSE_ERROR;
-	}
-	else
-	{
-		/* next byte should be a channel character */
-		channel_requested = ow_ds2450_channel_char(*cmd);
-		if(channel_requested < 0)
-			return ECMD_ERR_PARSE_ERROR;
+  if (*cmd == '\0')
+  {
+    /* no more data to read from cmd */
+    DS2450_ECMD_DEBUG
+      ("parse_cmd_onewire_ds2450_oc: not enogh arguments, expecting at " +
+       "least a channel name!\n");
+    return ECMD_ERR_PARSE_ERROR;
+  }
+  else
+  {
+    /* next byte should be a channel character */
+    channel_requested = ow_ds2450_channel_char(*cmd);
+    if (channel_requested < 0)
+      return ECMD_ERR_PARSE_ERROR;
 
-		/* channel char must have been 1-digit, so move cmd pointer one position forward */
-		++cmd;
+    /* channel char must have been 1-digit, so move cmd pointer one position
+     * forward */
+    ++cmd;
 
-		while(*cmd == ' ')
-			++cmd;
+    while (*cmd == ' ')
+      ++cmd;
 
-		/* next byte may be the OC value, if so: set OC value, if not: read and print OC value */
-		if(*cmd == '\0') {
+    /* next byte may be the OC value, if so: set OC value, if not: read and
+     * print OC value */
+    if (*cmd == '\0')
+    {
 
-			ret = ow_ds2450_oc_get(ptr_rom, channel_requested);
+      ret = ow_ds2450_oc_get(ptr_rom, channel_requested);
 
-			DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_oc: ow_ds2450_oc_get ret: %i.\n", ret);
+      DS2450_ECMD_DEBUG
+        ("parse_cmd_onewire_ds2450_oc: ow_ds2450_oc_get ret: %i.\n", ret);
 
-			if(ret < 0)
-				return ECMD_ERR_READ_ERROR;
+      if (ret < 0)
+        return ECMD_ERR_READ_ERROR;
 
-			ecmd_return_len = snprintf_P(output, len, PSTR("ch %c OC: %i"), (unsigned char) channel_requested+65, ret);
-		}
-		else
-		{
+      ecmd_return_len =
+        snprintf_P(output, len, PSTR("ch %c OC: %i"),
+                   (unsigned char) channel_requested + 65, ret);
+    }
+    else
+    {
 #ifdef DEBUG_OW_DS2450_ECMD
-			uint8_t sret = sscanf_P(cmd, PSTR("%1hx"), &oc);
-			DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_oc: sscanf_P ret: %i, OC: %u.\n", sret, oc);
-			if(sret != 1)
+      uint8_t sret = sscanf_P(cmd, PSTR("%1hx"), &oc);
+      DS2450_ECMD_DEBUG
+        ("parse_cmd_onewire_ds2450_oc: sscanf_P ret: %i, OC: %u.\n", sret,
+         oc);
+      if (sret != 1)
 #else
-			if(sscanf_P(cmd, PSTR("%1hx"), &oc) != 1)
+      if (sscanf_P(cmd, PSTR("%1hx"), &oc) != 1)
 #endif
-				return ECMD_ERR_PARSE_ERROR;
+        return ECMD_ERR_PARSE_ERROR;
 
-			if(!(oc == 0 || oc == 1))
-				return ECMD_ERR_PARSE_ERROR;
+      if (!(oc == 0 || oc == 1))
+        return ECMD_ERR_PARSE_ERROR;
 
 #ifndef TEENSY_SUPPORT
-			/* argument should have been 1-digit, so move cmd pointer one position forward */
-			++cmd;
+      /* argument should have been 1-digit, so move cmd pointer one position
+       * forward */
+      ++cmd;
 
-			/* no more characters should be waiting in cmd */
-			if(strlen(cmd) > 0)
-			{
-				DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_oc: cmd still contains data after parsing all argumentes!\n");
-				return ECMD_ERR_PARSE_ERROR;
-			}
+      /* no more characters should be waiting in cmd */
+      if (strlen(cmd) > 0)
+      {
+        DS2450_ECMD_DEBUG
+          ("parse_cmd_onewire_ds2450_oc: cmd still contains data after " +
+           "parsing all argumentes!\n");
+        return ECMD_ERR_PARSE_ERROR;
+      }
 #endif
 
-			ret = ow_ds2450_oc_set(ptr_rom, channel_requested, oc);
+      ret = ow_ds2450_oc_set(ptr_rom, channel_requested, oc);
 
-			DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_oc: ow_ds2450_oc_set ret: %i\n", ret);
+      DS2450_ECMD_DEBUG
+        ("parse_cmd_onewire_ds2450_oc: ow_ds2450_oc_set ret: %i\n", ret);
 
-			if(ret != 0)
-				return ECMD_ERR_READ_ERROR;
-		}
-	}
+      if (ret != 0)
+        return ECMD_ERR_READ_ERROR;
+    }
+  }
 
-	if(ecmd_return_len)
-		return ECMD_FINAL(ecmd_return_len);
-	else
-		return ECMD_FINAL_OK;
+  if (ecmd_return_len)
+    return ECMD_FINAL(ecmd_return_len);
+  else
+    return ECMD_FINAL_OK;
 }
 
-int16_t parse_cmd_onewire_ds2450_oe(char *cmd, char *output, uint16_t len)
+
+int16_t
+parse_cmd_onewire_ds2450_oe(char *cmd, char *output, uint16_t len)
 {
-	int8_t ret;
-	int8_t channel_requested;
-	uint8_t ecmd_return_len = 0;
-	uint8_t oe;
-	ow_rom_code_t *ptr_rom;
+  int8_t ret;
+  int8_t channel_requested;
+  uint8_t ecmd_return_len = 0;
+  uint8_t oe;
+  ow_rom_code_t *ptr_rom;
 
-	ret = ow_ecmd_parse_rom_arg(&cmd, &ptr_rom);
-	if(ret != 0)
-		return ret;
+  ret = ow_ecmd_parse_rom_arg(&cmd, &ptr_rom);
+  if (ret != 0)
+    return ret;
 
-	if(*cmd == '\0')
-	{
-		/* no more data to read from cmd */
-		DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_oe: not enogh arguments, expecting at least a channel name!\n");
-		return ECMD_ERR_PARSE_ERROR;
-	}
-	else
-	{
-		/* next byte should be a channel character */
-		channel_requested = ow_ds2450_channel_char(*cmd);
-		if(channel_requested < 0)
-			return ECMD_ERR_PARSE_ERROR;
+  if (*cmd == '\0')
+  {
+    /* no more data to read from cmd */
+    DS2450_ECMD_DEBUG
+      ("parse_cmd_onewire_ds2450_oe: not enogh arguments, expecting at " +
+       "least a channel name!\n");
+    return ECMD_ERR_PARSE_ERROR;
+  }
+  else
+  {
+    /* next byte should be a channel character */
+    channel_requested = ow_ds2450_channel_char(*cmd);
+    if (channel_requested < 0)
+      return ECMD_ERR_PARSE_ERROR;
 
-		/* channel char must have been 1-digit, so move cmd pointer one position forward */
-		++cmd;
+    /* channel char must have been 1-digit, so move cmd pointer one position
+     * forward */
+    ++cmd;
 
-		while(*cmd == ' ')
-			++cmd;
+    while (*cmd == ' ')
+      ++cmd;
 
-		/* next byte may be the oe value, if so: set oe value, if not: read and print oe value */
-		if (*cmd == '\0') {
-			ret = ow_ds2450_oe_get(ptr_rom, channel_requested);
+    /* next byte may be the oe value, if so: set oe value, if not: read and
+     * print oe value */
+    if (*cmd == '\0')
+    {
+      ret = ow_ds2450_oe_get(ptr_rom, channel_requested);
 
-			DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_oe: ow_ds2450_oe_get ret: %i.\n", ret);
+      DS2450_ECMD_DEBUG
+        ("parse_cmd_onewire_ds2450_oe: ow_ds2450_oe_get ret: %i.\n", ret);
 
-			if(ret < 0)
-				return ECMD_ERR_READ_ERROR;
+      if (ret < 0)
+        return ECMD_ERR_READ_ERROR;
 
-			ecmd_return_len = snprintf_P(output, len, PSTR("ch %c OE: %i"), (unsigned char) channel_requested+65, ret);
-		}
-		else
-		{
+      ecmd_return_len =
+        snprintf_P(output, len, PSTR("ch %c OE: %i"),
+                   (unsigned char) channel_requested + 65, ret);
+    }
+    else
+    {
 #ifdef DEBUG_OW_DS2450_ECMD
-			uint8_t sret = sscanf_P(cmd, PSTR("%1hx"), &oe);
-			DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_oe: sscanf_P ret: %i, oe: %u.\n", sret, oe);
-			if(sret != 1)
+      uint8_t sret = sscanf_P(cmd, PSTR("%1hx"), &oe);
+      DS2450_ECMD_DEBUG
+        ("parse_cmd_onewire_ds2450_oe: sscanf_P ret: %i, oe: %u.\n", sret,
+         oe);
+      if (sret != 1)
 #else
-			if(sscanf_P(cmd, PSTR("%1hx"), &oe) != 1)
+      if (sscanf_P(cmd, PSTR("%1hx"), &oe) != 1)
 #endif
-				return ECMD_ERR_PARSE_ERROR;
+        return ECMD_ERR_PARSE_ERROR;
 
-			if(!(oe == 0 || oe == 1))
-				return ECMD_ERR_PARSE_ERROR;
+      if (!(oe == 0 || oe == 1))
+        return ECMD_ERR_PARSE_ERROR;
 
 #ifndef TEENSY_SUPPORT
-			/* argument should have been 1-digit, so move cmd pointer one position forward */
-			++cmd;
+      /* argument should have been 1-digit, so move cmd pointer one position
+       * forward */
+      ++cmd;
 
-			/* no more characters should be waiting in cmd */
-			if(strlen(cmd) > 0)
-			{
-				DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_oe: cmd still contains data after parsing all argumentes!\n");
-				return ECMD_ERR_PARSE_ERROR;
-			}
+      /* no more characters should be waiting in cmd */
+      if (strlen(cmd) > 0)
+      {
+        DS2450_ECMD_DEBUG
+          ("parse_cmd_onewire_ds2450_oe: cmd still contains data after " +
+           "parsing all argumentes!\n");
+        return ECMD_ERR_PARSE_ERROR;
+      }
 #endif
-			ret = ow_ds2450_oe_set(ptr_rom, channel_requested, oe);
+      ret = ow_ds2450_oe_set(ptr_rom, channel_requested, oe);
 
-			DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_oe: ow_ds2450_oe_set ret: %i\n", ret);
+      DS2450_ECMD_DEBUG
+        ("parse_cmd_onewire_ds2450_oe: ow_ds2450_oe_set ret: %i\n", ret);
 
-			if(ret != 0)
-				return ECMD_ERR_READ_ERROR;
-		}
-	}
+      if (ret != 0)
+        return ECMD_ERR_READ_ERROR;
+    }
+  }
 
-	if(ecmd_return_len)
-		return ECMD_FINAL(ecmd_return_len);
-	else
-		return ECMD_FINAL_OK;
+  if (ecmd_return_len)
+    return ECMD_FINAL(ecmd_return_len);
+  else
+    return ECMD_FINAL_OK;
 }
 
-int16_t parse_cmd_onewire_ds2450_range(char *cmd, char *output, uint16_t len)
+int16_t
+parse_cmd_onewire_ds2450_range(char *cmd, char *output, uint16_t len)
 {
-	int8_t ret;
-	int8_t channel_requested;
-	uint8_t ecmd_return_len = 0;
-	uint8_t range;
-	ow_rom_code_t *ptr_rom;
+  int8_t ret;
+  int8_t channel_requested;
+  uint8_t ecmd_return_len = 0;
+  uint8_t range;
+  ow_rom_code_t *ptr_rom;
 
-	ret = ow_ecmd_parse_rom_arg(&cmd, &ptr_rom);
-	if(ret != 0)
-		return ret;
+  ret = ow_ecmd_parse_rom_arg(&cmd, &ptr_rom);
+  if (ret != 0)
+    return ret;
 
-	if(*cmd == '\0')
-	{
-		/* no more data to read from cmd */
-		DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_range: not enogh arguments, expecting at least a channel name!\n");
-		return ECMD_ERR_PARSE_ERROR;
-	}
-	else
-	{
-		/* next byte should be a channel character */
-		channel_requested = ow_ds2450_channel_char(*cmd);
-		if(channel_requested < 0)
-			return ECMD_ERR_PARSE_ERROR;
+  if (*cmd == '\0')
+  {
+    /* no more data to read from cmd */
+    DS2450_ECMD_DEBUG
+      ("parse_cmd_onewire_ds2450_range: not enogh arguments, expecting at " +
+       "least a channel name!\n");
+    return ECMD_ERR_PARSE_ERROR;
+  }
+  else
+  {
+    /* next byte should be a channel character */
+    channel_requested = ow_ds2450_channel_char(*cmd);
+    if (channel_requested < 0)
+      return ECMD_ERR_PARSE_ERROR;
 
-		/* channel char must have been 1-digit, so move cmd pointer one position forward */
-		++cmd;
+    /* channel char must have been 1-digit, so move cmd pointer one position
+     * forward */
+    ++cmd;
 
-		while(*cmd == ' ')
-			++cmd;
+    while (*cmd == ' ')
+      ++cmd;
 
-		/* next byte may be the range value, if so: set range value, if not: read and print range value */
-		if (*cmd == '\0') {
-			ret = ow_ds2450_range_get(ptr_rom, channel_requested);
+    /* next byte may be the range value, if so: set range value, if not: read
+     * and print range value */
+    if (*cmd == '\0')
+    {
+      ret = ow_ds2450_range_get(ptr_rom, channel_requested);
 
-			DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_range: ow_ds2450_range_get ret: %i.\n", ret);
+      DS2450_ECMD_DEBUG
+        ("parse_cmd_onewire_ds2450_range: ow_ds2450_range_get ret: %i.\n",
+         ret);
 
-			if(ret < 0)
-				return ECMD_ERR_READ_ERROR;
+      if (ret < 0)
+        return ECMD_ERR_READ_ERROR;
 
-			ecmd_return_len = snprintf_P(output, len, PSTR("ch %c RANGE: %i"), (unsigned char) channel_requested+65, ret);
-		}
-		else
-		{
+      ecmd_return_len =
+        snprintf_P(output, len, PSTR("ch %c RANGE: %i"),
+                   (unsigned char) channel_requested + 65, ret);
+    }
+    else
+    {
 #ifdef DEBUG_OW_DS2450_ECMD
-			uint8_t sret = sscanf_P(cmd, PSTR("%1hx"), &range);
-			DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_range: sscanf_P ret: %i, range: %u.\n", sret, range);
-			if(sret != 1)
+      uint8_t sret = sscanf_P(cmd, PSTR("%1hx"), &range);
+      DS2450_ECMD_DEBUG
+        ("parse_cmd_onewire_ds2450_range: sscanf_P ret: %i, range: %u.\n",
+         sret, range);
+      if (sret != 1)
 #else
-			if(sscanf_P(cmd, PSTR("%1hx"), &range) != 1)
+      if (sscanf_P(cmd, PSTR("%1hx"), &range) != 1)
 #endif
-				return ECMD_ERR_PARSE_ERROR;
+        return ECMD_ERR_PARSE_ERROR;
 
-			if(!(range == 0 || range == 1))
-				return ECMD_ERR_PARSE_ERROR;
+      if (!(range == 0 || range == 1))
+        return ECMD_ERR_PARSE_ERROR;
 
 #ifndef TEENSY_SUPPORT
-			/* argument should have been 1-digit, so move cmd pointer one position forward */
-			++cmd;
+      /* argument should have been 1-digit, so move cmd pointer one position
+       * forward */
+      ++cmd;
 
-			/* no more characters should be waiting in cmd */
-			if(strlen(cmd) > 0)
-			{
-				DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_range: cmd still contains data after parsing all argumentes!\n");
-				return ECMD_ERR_PARSE_ERROR;
-			}
+      /* no more characters should be waiting in cmd */
+      if (strlen(cmd) > 0)
+      {
+        DS2450_ECMD_DEBUG
+          ("parse_cmd_onewire_ds2450_range: cmd still contains data after " +
+           "parsing all argumentes!\n");
+        return ECMD_ERR_PARSE_ERROR;
+      }
 #endif
-			ret = ow_ds2450_range_set(ptr_rom, channel_requested, range);
+      ret = ow_ds2450_range_set(ptr_rom, channel_requested, range);
 
-			DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_range: ow_ds2450_range_set ret: %i\n", ret);
+      DS2450_ECMD_DEBUG
+        ("parse_cmd_onewire_ds2450_range: ow_ds2450_range_set ret: %i\n",
+         ret);
 
-			if(ret != 0)
-				return ECMD_ERR_READ_ERROR;
-		}
-	}
+      if (ret != 0)
+        return ECMD_ERR_READ_ERROR;
+    }
+  }
 
-	if(ecmd_return_len)
-		return ECMD_FINAL(ecmd_return_len);
-	else
-		return ECMD_FINAL_OK;
+  if (ecmd_return_len)
+    return ECMD_FINAL(ecmd_return_len);
+  else
+    return ECMD_FINAL_OK;
 }
 
-int16_t parse_cmd_onewire_ds2450_por(char *cmd, char *output, uint16_t len)
+
+int16_t
+parse_cmd_onewire_ds2450_por(char *cmd, char *output, uint16_t len)
 {
-	int8_t ret;
-	int8_t channel_requested;
-	uint8_t ecmd_return_len = 0;
-	uint8_t por;
-	ow_rom_code_t *ptr_rom;
+  int8_t ret;
+  int8_t channel_requested;
+  uint8_t ecmd_return_len = 0;
+  uint8_t por;
+  ow_rom_code_t *ptr_rom;
 
-	ret = ow_ecmd_parse_rom_arg(&cmd, &ptr_rom);
-	if(ret != 0)
-		return ret;
+  ret = ow_ecmd_parse_rom_arg(&cmd, &ptr_rom);
+  if (ret != 0)
+    return ret;
 
-	if(*cmd == '\0')
-	{
-		/* no more data to read from cmd */
-		DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_por: not enogh arguments, expecting at least a channel name!\n");
-		return ECMD_ERR_PARSE_ERROR;
-	}
-	else
-	{
-		/* next byte should be a channel character */
-		channel_requested = ow_ds2450_channel_char(*cmd);
-		if(channel_requested < 0)
-			return ECMD_ERR_PARSE_ERROR;
+  if (*cmd == '\0')
+  {
+    /* no more data to read from cmd */
+    DS2450_ECMD_DEBUG
+      ("parse_cmd_onewire_ds2450_por: not enogh arguments, expecting at " +
+       "least a channel name!\n");
+    return ECMD_ERR_PARSE_ERROR;
+  }
+  else
+  {
+    /* next byte should be a channel character */
+    channel_requested = ow_ds2450_channel_char(*cmd);
+    if (channel_requested < 0)
+      return ECMD_ERR_PARSE_ERROR;
 
-		/* channel char must have been 1-digit, so move cmd pointer one position forward */
-		++cmd;
+    /* channel char must have been 1-digit, so move cmd pointer one position
+     * forward */
+    ++cmd;
 
-		while(*cmd == ' ')
-			++cmd;
+    while (*cmd == ' ')
+      ++cmd;
 
-		/* next byte may be the por value, if so: set por value, if not: read and print por value */
-		if (*cmd == '\0') {
+    /* next byte may be the por value, if so: set por value, if not: read and
+     * print por value */
+    if (*cmd == '\0')
+    {
 
-			ret = ow_ds2450_por_get(ptr_rom, channel_requested);
+      ret = ow_ds2450_por_get(ptr_rom, channel_requested);
 
-			DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_por: ow_ds2450_por_get ret: %i.\n", ret);
+      DS2450_ECMD_DEBUG
+        ("parse_cmd_onewire_ds2450_por: ow_ds2450_por_get ret: %i.\n", ret);
 
-			if(ret < 0)
-				return ECMD_ERR_READ_ERROR;
+      if (ret < 0)
+        return ECMD_ERR_READ_ERROR;
 
-			ecmd_return_len = snprintf_P(output, len, PSTR("ch %c POR: %i"), (unsigned char) channel_requested+65, ret);
-		}
-		else
-		{
+      ecmd_return_len =
+        snprintf_P(output, len, PSTR("ch %c POR: %i"),
+                   (unsigned char) channel_requested + 65, ret);
+    }
+    else
+    {
 #ifdef DEBUG_OW_DS2450_ECMD
-			uint8_t sret = sscanf_P(cmd, PSTR("%1hx"), &por);
-			DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_por: sscanf_P ret: %i, por: %u.\n", sret, por);
-			if(sret != 1)
+      uint8_t sret = sscanf_P(cmd, PSTR("%1hx"), &por);
+      DS2450_ECMD_DEBUG
+        ("parse_cmd_onewire_ds2450_por: sscanf_P ret: %i, por: %u.\n", sret,
+         por);
+      if (sret != 1)
 #else
-			if(sscanf_P(cmd, PSTR("%1hx"), &por) != 1)
+      if (sscanf_P(cmd, PSTR("%1hx"), &por) != 1)
 #endif
-				return ECMD_ERR_PARSE_ERROR;
+        return ECMD_ERR_PARSE_ERROR;
 
-			if(!(por == 0 || por == 1))
-				return ECMD_ERR_PARSE_ERROR;
+      if (!(por == 0 || por == 1))
+        return ECMD_ERR_PARSE_ERROR;
 
 #ifndef TEENSY_SUPPORT
-			/* argument should have been 1-digit, so move cmd pointer one position forward */
-			++cmd;
+      /* argument should have been 1-digit, so move cmd pointer one position
+       * forward */
+      ++cmd;
 
-			/* no more characters should be waiting in cmd */
-			if(strlen(cmd) > 0)
-			{
-				DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_por: cmd still contains data after parsing all argumentes!\n");
-				return ECMD_ERR_PARSE_ERROR;
-			}
+      /* no more characters should be waiting in cmd */
+      if (strlen(cmd) > 0)
+      {
+        DS2450_ECMD_DEBUG
+          ("parse_cmd_onewire_ds2450_por: cmd still contains data after " +
+           "parsing all argumentes!\n");
+        return ECMD_ERR_PARSE_ERROR;
+      }
 #endif
-			ret = ow_ds2450_por_set(ptr_rom, channel_requested, por);
+      ret = ow_ds2450_por_set(ptr_rom, channel_requested, por);
 
-			DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_por: ow_ds2450_por_set ret: %i\n", ret);
+      DS2450_ECMD_DEBUG
+        ("parse_cmd_onewire_ds2450_por: ow_ds2450_por_set ret: %i\n", ret);
 
-			if(ret != 0)
-				return ECMD_ERR_READ_ERROR;
-		}
-	}
+      if (ret != 0)
+        return ECMD_ERR_READ_ERROR;
+    }
+  }
 
-	if(ecmd_return_len)
-		return ECMD_FINAL(ecmd_return_len);
-	else
-		return ECMD_FINAL_OK;
+  if (ecmd_return_len)
+    return ECMD_FINAL(ecmd_return_len);
+  else
+    return ECMD_FINAL_OK;
 }
 
 
-int16_t parse_cmd_onewire_ds2450_convert(char *cmd, char *output, uint16_t len)
+int16_t
+parse_cmd_onewire_ds2450_convert(char *cmd, char *output, uint16_t len)
 {
-	int8_t ret;
-	uint8_t input_select, readout;
-	ow_rom_code_t *ptr_rom;
+  int8_t ret;
+  uint8_t input_select, readout;
+  ow_rom_code_t *ptr_rom;
 
-	ret = ow_ecmd_parse_rom_arg(&cmd, &ptr_rom);
-	if(ret != 0)
-		return ret;
+  ret = ow_ecmd_parse_rom_arg(&cmd, &ptr_rom);
+  if (ret != 0)
+    return ret;
 
-	/* maybe two byte following: input select mask and read-out control */
-	/* default values: 0000 1111 for input_select (convert all channels) */
-	input_select = 0x0f;
+  /* maybe two byte following: input select mask and read-out control
+   * default values: 0000 1111 for input_select (convert all channels) */
+  input_select = 0x0f;
 
-	/* default values: 0000 0000 for readout (no preset, leave as is) */
-	readout = 0x00;
+  /* default values: 0000 0000 for readout (no preset, leave as is) */
+  readout = 0x00;
 
-	if(*cmd == '\0')
-	{
-		/* no more data to read from cmd */
-		DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_convert: no input select mask and read-out control given, using default values.\n");
-	}
-	else
-	{
-		uint8_t ret = sscanf_P(cmd, PSTR("%2hhx %2hhx"), &input_select, &readout);
-		DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_convert: sscanf_P ret: %i, input select mask: %02x, read-out control: %02x.\n", ret, input_select, readout);
-		if(ret != 2)
-			return ECMD_ERR_PARSE_ERROR;
+  if (*cmd == '\0')
+  {
+    /* no more data to read from cmd */
+    DS2450_ECMD_DEBUG
+      ("parse_cmd_onewire_ds2450_convert: no input select mask and " +
+       "read-out control given, using default values.\n");
+  }
+  else
+  {
+    uint8_t ret = sscanf_P(cmd, PSTR("%2hhx %2hhx"), &input_select, &readout);
+    DS2450_ECMD_DEBUG
+      ("parse_cmd_onewire_ds2450_convert: sscanf_P ret: %i, input select " +
+       "mask: %02x, read-out control: %02x.\n", ret, input_select, readout);
+    if (ret != 2)
+      return ECMD_ERR_PARSE_ERROR;
 
-		if(input_select == 0x00 || input_select > 0x0f)
-			return ECMD_ERR_PARSE_ERROR;
+    if (input_select == 0x00 || input_select > 0x0f)
+      return ECMD_ERR_PARSE_ERROR;
 
-		/* check for invalid read out combinations */
-		uint8_t readout_check = readout;
-		for(uint8_t i = 0; i < 4; ++i)
-		{
-			if((readout_check & 0x03) > 2)
-				return ECMD_ERR_PARSE_ERROR;
-			readout_check >>= 2;
-		}
+    /* check for invalid read out combinations */
+    uint8_t readout_check = readout;
+    for (uint8_t i = 0; i < 4; ++i)
+    {
+      if ((readout_check & 0x03) > 2)
+        return ECMD_ERR_PARSE_ERROR;
+      readout_check >>= 2;
+    }
 
 #ifndef TEENSY_SUPPORT
-		/* argument should have been 2*2-digit plus space, so move cmd pointer 5 positions forward */
-		cmd += 5;
+    /* argument should have been 2*2-digit plus space, so move cmd pointer
+     * 5 positions forward */
+    cmd += 5;
 
-		/* no more characters should be waiting in cmd */
-		if(strlen(cmd) > 0)
-		{
-			DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_convert: cmd still contains data after parsing all argumentes!\n");
-			return ECMD_ERR_PARSE_ERROR;
-		}
+    /* no more characters should be waiting in cmd */
+    if (strlen(cmd) > 0)
+    {
+      DS2450_ECMD_DEBUG
+        ("parse_cmd_onewire_ds2450_convert: cmd still contains data after " +
+         "parsing all argumentes!\n");
+      return ECMD_ERR_PARSE_ERROR;
+    }
 #endif
-	}
-	ret = ow_ds2450_convert(ptr_rom, input_select, readout);
+  }
+  ret = ow_ds2450_convert(ptr_rom, input_select, readout);
 
-	DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_convert: ow_ds2450_convert ret: %i\n", ret);
+  DS2450_ECMD_DEBUG
+    ("parse_cmd_onewire_ds2450_convert: ow_ds2450_convert ret: %i\n", ret);
 
-	if(ret != 0)
-		return ECMD_ERR_READ_ERROR;
+  if (ret != 0)
+    return ECMD_ERR_READ_ERROR;
 
-	return ECMD_FINAL_OK;
+  return ECMD_FINAL_OK;
 }
 
-int16_t parse_cmd_onewire_ds2450_get(char *cmd, char *output, uint16_t len, uint8_t raw)
+
+int16_t
+parse_cmd_onewire_ds2450_get(char *cmd, char *output, uint16_t len,
+                             uint8_t raw)
 {
-	int8_t ret;
-	int8_t channel_requested;
-	uint8_t ecmd_return_len;
-	ow_rom_code_t *ptr_rom;
+  int8_t ret;
+  int8_t channel_requested;
+  uint8_t ecmd_return_len;
+  ow_rom_code_t *ptr_rom;
 
-	ret = ow_ecmd_parse_rom_arg(&cmd, &ptr_rom);
-	if(ret != 0)
-		return ret;
+  ret = ow_ecmd_parse_rom_arg(&cmd, &ptr_rom);
+  if (ret != 0)
+    return ret;
 
-	if(*cmd == '\0')
-	{
-		/* no more data to read from cmd */
-		DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_get: no channel given.\n");
-		channel_requested = -1;
-	}
-	else
-	{
-		/* next byte should be a channel character */
-		channel_requested = ow_ds2450_channel_char(*cmd);
-		if(channel_requested < 0)
-			return ECMD_ERR_PARSE_ERROR;
+  if (*cmd == '\0')
+  {
+    /* no more data to read from cmd */
+    DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_get: no channel given.\n");
+    channel_requested = -1;
+  }
+  else
+  {
+    /* next byte should be a channel character */
+    channel_requested = ow_ds2450_channel_char(*cmd);
+    if (channel_requested < 0)
+      return ECMD_ERR_PARSE_ERROR;
 #ifndef TEENSY_SUPPORT
-		/* argument should have been 1-digit, so move cmd pointer one position forward */
-		++cmd;
+    /* argument should have been 1-digit, so move cmd pointer one position
+     * forward */
+    ++cmd;
 
-		/* no more characters should be waiting in cmd */
-		if(strlen(cmd) > 0)
-		{
-			DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_get: cmd still contains data after parsing all argumentes!\n");
-			return ECMD_ERR_PARSE_ERROR;
-		}
+    /* no more characters should be waiting in cmd */
+    if (strlen(cmd) > 0)
+    {
+      DS2450_ECMD_DEBUG
+        ("parse_cmd_onewire_ds2450_get: cmd still contains data after " +
+         "parsing all argumentes!\n");
+      return ECMD_ERR_PARSE_ERROR;
+    }
 #endif
-	}
+  }
 
-	if (channel_requested >= 0) {
-		/* request just one channel */
-		uint16_t val;
+  if (channel_requested >= 0)
+  {
+    /* request just one channel */
+    uint16_t val;
 
-		ret = ow_ds2450_get(ptr_rom, channel_requested, channel_requested, &val);
+    ret = ow_ds2450_get(ptr_rom, channel_requested, channel_requested, &val);
 
-		DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_get: ow_ds2450_get ret: %i.\n", ret);
+    DS2450_ECMD_DEBUG
+      ("parse_cmd_onewire_ds2450_get: ow_ds2450_get ret: %i.\n", ret);
 
-		if(ret <= 0)
-			return ECMD_ERR_READ_ERROR;
+    if (ret <= 0)
+      return ECMD_ERR_READ_ERROR;
 
-		DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_get: ow_ds2450_get channel: %c, val: %i.\n", (unsigned char) channel_requested+65, val);
+    DS2450_ECMD_DEBUG
+      ("parse_cmd_onewire_ds2450_get: ow_ds2450_get channel: %c, val: %i.\n",
+       (unsigned char) channel_requested + 65, val);
 
-		ecmd_return_len = snprintf_P(output, len, PSTR("ch %c: %05u"), (unsigned char) channel_requested+65, val);
-	}
-	else
-	{
-		/* request all channels */
-		uint16_t val[4];
+    ecmd_return_len =
+      snprintf_P(output, len, PSTR("ch %c: %05u"),
+                 (unsigned char) channel_requested + 65, val);
+  }
+  else
+  {
+    /* request all channels */
+    uint16_t val[4];
 
-		ret = ow_ds2450_get(ptr_rom, 0, 3, val);
+    ret = ow_ds2450_get(ptr_rom, 0, 3, val);
 
-		DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_get: ow_ds2450_get ret: %i.\n", ret);
+    DS2450_ECMD_DEBUG
+      ("parse_cmd_onewire_ds2450_get: ow_ds2450_get ret: %i.\n", ret);
 
-		if(ret <= 0)
-			return ECMD_ERR_READ_ERROR;
+    if (ret <= 0)
+      return ECMD_ERR_READ_ERROR;
 
-		ecmd_return_len = 0;
-		for(uint8_t i = 0; i < 4; ++i)
-		{
-			DS2450_ECMD_DEBUG("parse_cmd_onewire_ds2450_get: ow_ds2450 channel: %c, val: %u.\n", (unsigned char) i+65, val[i]);
-			ret = snprintf_P(output, len, PSTR("ch %c: %05u\n"), (unsigned char) i+65, val[i]);
-			output += ret;
-			len -= ret;
-			ecmd_return_len += ret;
-		}
-		/* remove last newline character */
-		--output;
-		*output = '\0';
-		--ecmd_return_len;
-	}
+    ecmd_return_len = 0;
+    for (uint8_t i = 0; i < 4; ++i)
+    {
+      DS2450_ECMD_DEBUG
+        ("parse_cmd_onewire_ds2450_get: ow_ds2450 channel: %c, val: %u.\n",
+         (unsigned char) i + 65, val[i]);
+      ret = snprintf_P(output, len, PSTR("ch %c: %05u\n"),
+                       (unsigned char) i + 65, val[i]);
+      output += ret;
+      len -= ret;
+      ecmd_return_len += ret;
+    }
+    /* remove last newline character */
+    --output;
+    *output = '\0';
+    --ecmd_return_len;
+  }
 
-	return ECMD_FINAL(ecmd_return_len);
+  return ECMD_FINAL(ecmd_return_len);
 }
 
 

--- a/hardware/onewire/ecmd.c
+++ b/hardware/onewire/ecmd.c
@@ -1,5 +1,4 @@
 /*
- *
  * Copyright (c) by Alexander Neumann <alexander@bumpern.de>
  * Copyright (c) 2007 by Stefan Siegl <stesie@brokenpipe.de>
  * Copyright (c) 2007 by Christian Dietrich <stettberger@dokucode.de>
@@ -21,6 +20,7 @@
  * http://www.gnu.org/copyleft/gpl.html
  */
 
+
 #include <string.h>
 #include <avr/pgmspace.h>
 #include <avr/eeprom.h>
@@ -36,427 +36,476 @@
 
 
 /* parse an onewire rom address at cmd, write result to ptr */
-int8_t parse_ow_rom(char *cmd, ow_rom_code_t *rom)
+int8_t
+parse_ow_rom(char *cmd, ow_rom_code_t * rom)
 {
-    uint8_t *addr = rom->bytewise;
-    uint8_t end;
+  uint8_t *addr = rom->bytewise;
+  uint8_t end;
 
 #ifdef DEBUG_ECMD_OW_ROM
-    debug_printf("called parse_ow_rom with string '%s'\n", cmd);
+  debug_printf("called parse_ow_rom with string '%s'\n", cmd);
 #endif
 
-    /* read 8 times 2 hex chars into a byte */
-    int ret = sscanf_P(cmd, PSTR("%2hhx%2hhx%2hhx%2hhx%2hhx%2hhx%2hhx%2hhx%c"),
-                       addr+0, addr+1, addr+2, addr+3,
-                       addr+4, addr+5, addr+6, addr+7,
-                       &end);
+  /* read 8 times 2 hex chars into a byte */
+  int ret = sscanf_P(cmd, PSTR("%2hhx%2hhx%2hhx%2hhx%2hhx%2hhx%2hhx%2hhx%c"),
+                     addr + 0, addr + 1, addr + 2, addr + 3,
+                     addr + 4, addr + 5, addr + 6, addr + 7, &end);
 
 #ifdef DEBUG_ECMD_OW_ROM
-    debug_printf("scanf returned %d\n", ret);
+  debug_printf("scanf returned %d\n", ret);
 #endif
 
-    if ((ret == 8) || ((ret == 9) && (end == ' '))) {
+  if ((ret == 8) || ((ret == 9) && (end == ' ')))
+  {
 #ifdef DEBUG_ECMD_OW_ROM
-        debug_printf("read rom %02x %02x %02x %02x %02x %02x %02x %02x\n",
-                     addr[0], addr[1], addr[2], addr[3],
-                     addr[4], addr[5], addr[6], addr[7]);
+    debug_printf("read rom %02x %02x %02x %02x %02x %02x %02x %02x\n",
+                 addr[0], addr[1], addr[2], addr[3],
+                 addr[4], addr[5], addr[6], addr[7]);
 #endif
-        return 0;
-    }
+    return 0;
+  }
 
-    return -1;
+  return -1;
 }
+
 
 #ifdef ONEWIRE_DETECT_SUPPORT
 #ifdef ONEWIRE_POLLING_SUPPORT
-int16_t parse_cmd_onewire_list(char *cmd, char *output, uint16_t len)
+int16_t
+parse_cmd_onewire_list(char *cmd, char *output, uint16_t len)
 {
-	#ifdef ONEWIRE_DS2502_SUPPORT
-	int8_t list_type;
-        while (*cmd == ' ')
-            cmd++;
-	switch (*cmd) {
-		case 't':
-			list_type = OW_LIST_TYPE_TEMP_SENSOR;
-			break;
-		case 'e':
-			list_type = OW_LIST_TYPE_EEPROM;
-			break;
-		case '\0':
-			list_type = OW_LIST_TYPE_ALL;
-			break;
-		default:
-			return ECMD_ERR_PARSE_ERROR;
-	}
-	cmd++; /* for static bytes */
-	#endif
-	/* trick: use bytes on cmd as "connection specific static variables" */
-	if (cmd[0] != 23)	/* indicator flag: real invocation:  0 */
-	{
-		cmd[0] = 23;	/* continuing call: 23 */
-		cmd[1] = 0;	/* counter for sensors in list*/
-	}
-	uint8_t i = cmd[1];
-	/* This is a special case: the while loop below printed a sensor which was last in the list,
-	   so we still need to send an 'OK' after the sensor id */
-	if(i>=OW_SENSORS_COUNT)
-	{
-		return ECMD_FINAL_OK;
-	}
-	int16_t ret = 0;
-	do
-	{
-		if(ow_sensors[i].ow_rom_code.raw != 0)
-		{
-			#ifdef ONEWIRE_DS2502_SUPPORT
-				if ( list_type == OW_LIST_TYPE_ALL ||
-				    (list_type == OW_LIST_TYPE_TEMP_SENSOR && ow_temp_sensor(&ow_sensors[i].ow_rom_code)) ||
-				    (list_type == OW_LIST_TYPE_EEPROM      && ow_eeprom(&ow_sensors[i].ow_rom_code))) {
-			#endif
-				ret = snprintf_P(output, len,
-				PSTR("%02x%02x%02x%02x%02x%02x%02x%02x"),
-				ow_sensors[i].ow_rom_code.bytewise[0],
-				ow_sensors[i].ow_rom_code.bytewise[1],
-				ow_sensors[i].ow_rom_code.bytewise[2],
-				ow_sensors[i].ow_rom_code.bytewise[3],
-				ow_sensors[i].ow_rom_code.bytewise[4],
-				ow_sensors[i].ow_rom_code.bytewise[5],
-				ow_sensors[i].ow_rom_code.bytewise[6],
-				ow_sensors[i].ow_rom_code.bytewise[7]
-				);
-			#ifdef ONEWIRE_DS2502_SUPPORT
-			}
-			#endif
-		}
-		i++;
-	} while(ret == 0 && i<OW_SENSORS_COUNT);
-	/* The while loop exited either because a sensor has been found or because there is no sensor left, let's check for that */
-	if(ret == 0)
-	{
-		/* => i has reached OW_SENSORS_COUNT */
-		return ECMD_FINAL_OK;
-	}
-	/* else, ret is != 0 which means a sensor has been found and this functions has to be called again
-	   to prevent a buffer overflow */
-	/* Save i to cmd[1] */
+#ifdef ONEWIRE_DS2502_SUPPORT
+  int8_t list_type;
+  while (*cmd == ' ')
+    cmd++;
+  switch (*cmd)
+  {
+    case 't':
+      list_type = OW_LIST_TYPE_TEMP_SENSOR;
+      break;
+    case 'e':
+      list_type = OW_LIST_TYPE_EEPROM;
+      break;
+    case '\0':
+      list_type = OW_LIST_TYPE_ALL;
+      break;
+    default:
+      return ECMD_ERR_PARSE_ERROR;
+  }
+  cmd++;                        /* for static bytes */
+#endif
+  /* trick: use bytes on cmd as "connection specific static variables" */
+  if (cmd[0] != 23)             /* indicator flag: real invocation:  0 */
+  {
+    cmd[0] = 23;                /* continuing call: 23 */
+    cmd[1] = 0;                 /* counter for sensors in list */
+  }
+  uint8_t i = cmd[1];
+  /* This is a special case: the while loop below printed a sensor which was
+   * last in the list, so we still need to send an 'OK' after the sensor id */
+  if (i >= OW_SENSORS_COUNT)
+  {
+    return ECMD_FINAL_OK;
+  }
+  int16_t ret = 0;
+  do
+  {
+    if (ow_sensors[i].ow_rom_code.raw != 0)
+    {
+#ifdef ONEWIRE_DS2502_SUPPORT
+      if (list_type == OW_LIST_TYPE_ALL ||
+          (list_type == OW_LIST_TYPE_TEMP_SENSOR &&
+           ow_temp_sensor(&ow_sensors[i].ow_rom_code)) ||
+          (list_type == OW_LIST_TYPE_EEPROM &&
+           ow_eeprom(&ow_sensors[i].ow_rom_code)))
+      {
+#endif
+        ret = snprintf_P(output, len,
+                         PSTR("%02x%02x%02x%02x%02x%02x%02x%02x"),
+                         ow_sensors[i].ow_rom_code.bytewise[0],
+                         ow_sensors[i].ow_rom_code.bytewise[1],
+                         ow_sensors[i].ow_rom_code.bytewise[2],
+                         ow_sensors[i].ow_rom_code.bytewise[3],
+                         ow_sensors[i].ow_rom_code.bytewise[4],
+                         ow_sensors[i].ow_rom_code.bytewise[5],
+                         ow_sensors[i].ow_rom_code.bytewise[6],
+                         ow_sensors[i].ow_rom_code.bytewise[7]);
+#ifdef ONEWIRE_DS2502_SUPPORT
+      }
+#endif
+    }
+    i++;
+  }
+  while (ret == 0 && i < OW_SENSORS_COUNT);
+  /* The while loop exited either because a sensor has been found or because
+   * there is no sensor left, let's check for that */
+  if (ret == 0)
+  {
+    /* => i has reached OW_SENSORS_COUNT */
+    return ECMD_FINAL_OK;
+  }
+  /* else, ret is != 0 which means a sensor has been found and this functions
+   * has to be called again to prevent a buffer overflow. save i to cmd[1] */
+  cmd[1] = i;
 
-	cmd[1] = i;
-
-	return	ECMD_AGAIN(ret);
+  return ECMD_AGAIN(ret);
 }
 #else
-int16_t parse_cmd_onewire_list(char *cmd, char *output, uint16_t len)
+
+
+int16_t
+parse_cmd_onewire_list(char *cmd, char *output, uint16_t len)
 {
 
-    uint8_t firstonbus = 0;
-    int16_t ret;
+  uint8_t firstonbus = 0;
+  int16_t ret;
 
-    if (ow_global.lock == 0) {
-        firstonbus = 1;
+  if (ow_global.lock == 0)
+  {
+    firstonbus = 1;
 #if ONEWIRE_BUSCOUNT > 1
-        ow_global.bus = 0;
+    ow_global.bus = 0;
 #endif
 #ifdef DEBUG_ECMD_OW_LIST
-        debug_printf("called onewire list for the first time\n");
+    debug_printf("called onewire list for the first time\n");
 #endif
 
 #ifdef ONEWIRE_DS2502_SUPPORT
-	/* parse optional parameters */
-        while (*cmd == ' ')
-            cmd++;
-	switch (*cmd) {
-		case 't':
-			ow_global.list_type = OW_LIST_TYPE_TEMP_SENSOR;
-			break;
-		case 'e':
-			ow_global.list_type = OW_LIST_TYPE_EEPROM;
-			break;
-		case '\0':
-			ow_global.list_type = OW_LIST_TYPE_ALL;
-			break;
-		default:
-			return ECMD_ERR_PARSE_ERROR;
-	}
-#endif
-    } else {
-#ifdef DEBUG_ECMD_OW_LIST
-        debug_printf("called onewire list again\n");
-#endif
-        firstonbus = 0;
+    /* parse optional parameters */
+    while (*cmd == ' ')
+      cmd++;
+    switch (*cmd)
+    {
+      case 't':
+        ow_global.list_type = OW_LIST_TYPE_TEMP_SENSOR;
+        break;
+      case 'e':
+        ow_global.list_type = OW_LIST_TYPE_EEPROM;
+        break;
+      case '\0':
+        ow_global.list_type = OW_LIST_TYPE_ALL;
+        break;
+      default:
+        return ECMD_ERR_PARSE_ERROR;
     }
+#endif
+  }
+  else
+  {
+#ifdef DEBUG_ECMD_OW_LIST
+    debug_printf("called onewire list again\n");
+#endif
+    firstonbus = 0;
+  }
 
 #if defined ONEWIRE_DS2502_SUPPORT || ONEWIRE_BUSCOUNT > 1
-list_next: ;
+list_next:;
 #endif
 
 #if ONEWIRE_BUSCOUNT > 1
-    ret = ow_search_rom((uint8_t)(1 << (ow_global.bus + ONEWIRE_STARTPIN)), firstonbus);
+  ret =
+    ow_search_rom((uint8_t) (1 << (ow_global.bus + ONEWIRE_STARTPIN)),
+                  firstonbus);
 #else
-    ret = ow_search_rom(ONEWIRE_BUSMASK, firstonbus);
+  ret = ow_search_rom(ONEWIRE_BUSMASK, firstonbus);
 #endif
 
-    /* make sure only one conversion happens at a time */
-    ow_global.lock = 1;
+  /* make sure only one conversion happens at a time */
+  ow_global.lock = 1;
 
-    if (ret == 1) {
+  if (ret == 1)
+  {
 #ifdef ONEWIRE_DS2502_SUPPORT
-        if ( ow_global.list_type == OW_LIST_TYPE_ALL ||
-            (ow_global.list_type == OW_LIST_TYPE_TEMP_SENSOR && ow_temp_sensor(&ow_global.current_rom)) ||
-            (ow_global.list_type == OW_LIST_TYPE_EEPROM      && ow_eeprom(&ow_global.current_rom))) {
-           /* only print device rom address if it matches the selected list type */
+    if (ow_global.list_type == OW_LIST_TYPE_ALL ||
+        (ow_global.list_type == OW_LIST_TYPE_TEMP_SENSOR &&
+         ow_temp_sensor(&ow_global.current_rom)) ||
+        (ow_global.list_type == OW_LIST_TYPE_EEPROM &&
+         ow_eeprom(&ow_global.current_rom)))
+    {
+      /* only print device rom address if it matches the selected list type */
 #endif
 
 #ifdef DEBUG_ECMD_OW_LIST
-           debug_printf("discovered device "
+      debug_printf("discovered device "
 #if ONEWIRE_BUSCOUNT > 1
-                    "%02x %02x %02x %02x %02x %02x %02x %02x on bus %d\n",
+                   "%02x %02x %02x %02x %02x %02x %02x %02x on bus %d\n",
 #else
-                    "%02x %02x %02x %02x %02x %02x %02x %02x\n",
+                   "%02x %02x %02x %02x %02x %02x %02x %02x\n",
 #endif
-                    ow_global.current_rom.bytewise[0],
-                    ow_global.current_rom.bytewise[1],
-                    ow_global.current_rom.bytewise[2],
-                    ow_global.current_rom.bytewise[3],
-                    ow_global.current_rom.bytewise[4],
-                    ow_global.current_rom.bytewise[5],
-                    ow_global.current_rom.bytewise[6],
-                    ow_global.current_rom.bytewise[7]
+                   ow_global.current_rom.bytewise[0],
+                   ow_global.current_rom.bytewise[1],
+                   ow_global.current_rom.bytewise[2],
+                   ow_global.current_rom.bytewise[3],
+                   ow_global.current_rom.bytewise[4],
+                   ow_global.current_rom.bytewise[5],
+                   ow_global.current_rom.bytewise[6],
+                   ow_global.current_rom.bytewise[7]
 #if ONEWIRE_BUSCOUNT > 1
-                    ,ow_global.bus);
+                   , ow_global.bus);
 #else
-		    );
+        );
 #endif
 #endif
-           ret = snprintf_P(output, len,
-                    PSTR("%02x%02x%02x%02x%02x%02x%02x%02x"),
-                    ow_global.current_rom.bytewise[0],
-                    ow_global.current_rom.bytewise[1],
-                    ow_global.current_rom.bytewise[2],
-                    ow_global.current_rom.bytewise[3],
-                    ow_global.current_rom.bytewise[4],
-                    ow_global.current_rom.bytewise[5],
-                    ow_global.current_rom.bytewise[6],
-                    ow_global.current_rom.bytewise[7]);
+      ret = snprintf_P(output, len,
+                       PSTR("%02x%02x%02x%02x%02x%02x%02x%02x"),
+                       ow_global.current_rom.bytewise[0],
+                       ow_global.current_rom.bytewise[1],
+                       ow_global.current_rom.bytewise[2],
+                       ow_global.current_rom.bytewise[3],
+                       ow_global.current_rom.bytewise[4],
+                       ow_global.current_rom.bytewise[5],
+                       ow_global.current_rom.bytewise[6],
+                       ow_global.current_rom.bytewise[7]);
 
 #ifdef DEBUG_ECMD_OW_LIST
-            debug_printf("generated %d bytes\n", ret);
+      debug_printf("generated %d bytes\n", ret);
 #endif
 
-            /* set return value that the parser has to be called again */
-            if (ret > 0)
-                ret = ECMD_AGAIN(ret);
+      /* set return value that the parser has to be called again */
+      if (ret > 0)
+        ret = ECMD_AGAIN(ret);
 
 #ifdef DEBUG_ECMD_OW_LIST
-            debug_printf("returning %d\n", ret);
+      debug_printf("returning %d\n", ret);
 #endif
-            return ECMD_FINAL(ret);
+      return ECMD_FINAL(ret);
 
 #ifdef ONEWIRE_DS2502_SUPPORT
-        } else {
-            /* device did not match list type: try again */
-            firstonbus = 0;
-            goto list_next;
-        }
-#endif
     }
-
-#if ONEWIRE_BUSCOUNT > 1
-#ifdef DEBUG_ECMD_OW_LIST
-    if (ret != 0) {
-        debug_printf("no devices on bus %d\n", ow_global.bus);
-    }
-#endif
-    if (ow_global.bus < ONEWIRE_BUSCOUNT - 1) {
-        ow_global.bus++;
-        firstonbus = 1;
-        goto list_next;
-    }
-#endif
-    ow_global.lock = 0;
-    return ECMD_FINAL_OK;
-
-}
-#endif /* ONEWIRE_POLLING_SUPPORT*/
-#endif /* ONEWIRE_DETECT_SUPPORT */
-#ifdef ONEWIRE_POLLING_SUPPORT
-int16_t parse_cmd_onewire_get(char *cmd, char *output, uint16_t len)
-{
-    ow_rom_code_t rom;
-    int16_t ret;
-    ret = parse_ow_rom(cmd, &rom);
-    if (ret < 0)
-        return ECMD_ERR_PARSE_ERROR;
-    if (ow_temp_sensor(&rom)) {
-	/*Search the sensor...*/
-	        for(uint8_t i=0;i<OW_SENSORS_COUNT;i++)
-                {
-			if(ow_sensors[i].ow_rom_code.raw == rom.raw)
-			{
-				/*Found it*/
-				int16_t temp=ow_sensors[i].temp;
-				div_t res = div(temp,10);
-				ret = snprintf_P(output, len, PSTR("%d.%1d"), res.quot,res.rem);
-				return ECMD_FINAL(ret);
-			}
-		}
-		/*Sensor is not in list*/
-		ret = snprintf_P(output, len, PSTR("Sensor not in list!"));
-	        return ECMD_FINAL(ret);
-#ifdef ONEWIRE_DS2502_SUPPORT
-    } else if (ow_eeprom(&rom)) {
-        debug_printf("reading mac\n");
-
-        uint8_t mac[6];
-        ret = ow_eeprom_read(&rom, mac);
-
-        if (ret != 0) {
-            debug_printf("mac read failed: %d\n", ret);
-            return ECMD_ERR_READ_ERROR;
-        }
-
-        debug_printf("successfully read mac\n");
-
-        debug_printf("mac: %02x:%02x:%02x:%02x:%02x:%02x\n",
-                mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
-
-        ret = snprintf_P(output, len,
-                PSTR("mac: %02x:%02x:%02x:%02x:%02x:%02x"),
-                mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
-#endif /* ONEWIRE_DS2502_SUPPORT */
-    } else {
-        debug_printf("unknown sensor type\n");
-#ifdef TEENSY_SUPPORT
-        strcpy_P (output, PSTR("unknown sensor type"));
-        return ECMD_FINAL(strlen(output));
-#else
-        ret = snprintf_P(output, len, PSTR("unknown sensor type"));
-#endif
-    }
-
-    return ECMD_FINAL(ret);
-
-}
-#else
-int16_t parse_cmd_onewire_get(char *cmd, char *output, uint16_t len)
-{
-    ow_rom_code_t rom;
-    int16_t ret;
-
-    while (*cmd == ' ')
-        cmd++;
-    debug_printf("called onewire_get with: \"%s\"\n", cmd);
-
-    ret = parse_ow_rom(cmd, &rom);
-
-    /* check for parse error */
-    if (ret < 0)
-        return ECMD_ERR_PARSE_ERROR;
-
-    if (ow_temp_sensor(&rom)) {
-        debug_printf("reading temperature\n");
-
-        ow_temp_scratchpad_t sp;
-        ret = ow_temp_read_scratchpad(&rom, &sp);
-
-        if (ret != 1) {
-            debug_printf("scratchpad read failed: %d\n", ret);
-            return ECMD_ERR_READ_ERROR;
-        }
-
-        debug_printf("successfully read scratchpad\n");
-
-        int16_t temp = ow_temp_normalize(&rom, &sp);
-
-        debug_printf("temperature: %d.%d\n", HI8(temp), LO8(temp) > 0 ? 5 : 0);
-
-        int8_t sign = (int8_t)(temp < 0);
-
-#ifdef TEENSY_SUPPORT
-        if (sign) {
-            temp = -temp;
-            output[0] = '-';
-        }
-        /* Here sign is 0 or 1 */
-        itoa (HI8(temp), output + sign, 10);
-        char *ptr = output + strlen (output);
-
-        *(ptr ++) = '.';
-        itoa (HI8(((temp & 0x00ff) * 10) + 0x80), ptr, 10);
-        return ECMD_FINAL(strlen(output));
-#else
-        if (sign) temp = -temp;
-        ret = snprintf_P(output, len, PSTR("%s%d.%1d"),
-                         sign?"-":"", (int8_t) HI8(temp), HI8(((temp & 0x00ff) * 10) + 0x80));
-#endif
-
-#ifdef ONEWIRE_DS2502_SUPPORT
-    } else if (ow_eeprom(&rom)) {
-        debug_printf("reading mac\n");
-
-        uint8_t mac[6];
-        ret = ow_eeprom_read(&rom, mac);
-
-        if (ret != 0) {
-            debug_printf("mac read failed: %d\n", ret);
-            return ECMD_ERR_READ_ERROR;
-        }
-
-        debug_printf("successfully read mac\n");
-
-        debug_printf("mac: %02x:%02x:%02x:%02x:%02x:%02x\n",
-                mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
-
-        ret = snprintf_P(output, len,
-                PSTR("mac: %02x:%02x:%02x:%02x:%02x:%02x"),
-                mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
-#endif /* ONEWIRE_DS2502_SUPPORT */
-    } else {
-        debug_printf("unknown sensor type\n");
-#ifdef TEENSY_SUPPORT
-	strcpy_P (output, PSTR("unknown sensor type"));
-	return ECMD_FINAL(strlen(output));
-#else
-        ret = snprintf_P(output, len, PSTR("unknown sensor type"));
-#endif
-    }
-
-    return ECMD_FINAL(ret);
-}
-#endif
-#ifdef ONEWIRE_POLLING_SUPPORT
-int16_t parse_cmd_onewire_convert(char *cmd, char *output, uint16_t len)
-{
-        return ECMD_FINAL_OK;
-}
-#else
-int16_t parse_cmd_onewire_convert(char *cmd, char *output, uint16_t len)
-{
-    int16_t ret;
-
-    while (*cmd == ' ')
-        cmd++;
-    debug_printf("called onewire_convert with: \"%s\"\n", cmd);
-
-    ow_rom_code_t rom, *romptr;
-
-    ret = parse_ow_rom(cmd, &rom);
-
-    /* check for romcode */
-    romptr = (ret < 0) ? NULL : &rom;
-
-    debug_printf("converting temperature...\n");
-
-    ret = ow_temp_start_convert_wait(romptr);
-
-    if (ret == 1)
-        /* done */
-        return ECMD_FINAL_OK;
-    else if (ret == -1)
-        /* no device attached */
-        return ECMD_ERR_READ_ERROR;
     else
-        /* wrong rom family code */
-        return ECMD_ERR_PARSE_ERROR;
+    {
+      /* device did not match list type: try again */
+      firstonbus = 0;
+      goto list_next;
+    }
+#endif
+  }
+
+#if ONEWIRE_BUSCOUNT > 1
+#ifdef DEBUG_ECMD_OW_LIST
+  if (ret != 0)
+  {
+    debug_printf("no devices on bus %d\n", ow_global.bus);
+  }
+#endif
+  if (ow_global.bus < ONEWIRE_BUSCOUNT - 1)
+  {
+    ow_global.bus++;
+    firstonbus = 1;
+    goto list_next;
+  }
+#endif
+  ow_global.lock = 0;
+  return ECMD_FINAL_OK;
+
+}
+#endif /* ONEWIRE_POLLING_SUPPORT */
+#endif /* ONEWIRE_DETECT_SUPPORT */
+
+
+#ifdef ONEWIRE_POLLING_SUPPORT
+int16_t
+parse_cmd_onewire_get(char *cmd, char *output, uint16_t len)
+{
+  ow_rom_code_t rom;
+  int16_t ret;
+  ret = parse_ow_rom(cmd, &rom);
+  if (ret < 0)
+    return ECMD_ERR_PARSE_ERROR;
+  if (ow_temp_sensor(&rom))
+  {
+    /*Search the sensor... */
+    for (uint8_t i = 0; i < OW_SENSORS_COUNT; i++)
+    {
+      if (ow_sensors[i].ow_rom_code.raw == rom.raw)
+      {
+        /*Found it */
+        int16_t temp = ow_sensors[i].temp;
+        div_t res = div(temp, 10);
+        ret = snprintf_P(output, len, PSTR("%d.%1d"), res.quot, res.rem);
+        return ECMD_FINAL(ret);
+      }
+    }
+    /*Sensor is not in list */
+    ret = snprintf_P(output, len, PSTR("sensor not in list!"));
+    return ECMD_FINAL(ret);
+#ifdef ONEWIRE_DS2502_SUPPORT
+  }
+  else if (ow_eeprom(&rom))
+  {
+    debug_printf("reading mac\n");
+
+    uint8_t mac[6];
+    ret = ow_eeprom_read(&rom, mac);
+
+    if (ret != 0)
+    {
+      debug_printf("mac read failed: %d\n", ret);
+      return ECMD_ERR_READ_ERROR;
+    }
+
+    debug_printf("successfully read mac\n");
+
+    debug_printf("mac: %02x:%02x:%02x:%02x:%02x:%02x\n",
+                 mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+
+    ret = snprintf_P(output, len,
+                     PSTR("mac: %02x:%02x:%02x:%02x:%02x:%02x"),
+                     mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+#endif /* ONEWIRE_DS2502_SUPPORT */
+  }
+  else
+  {
+    debug_printf("unknown sensor type\n");
+#ifdef TEENSY_SUPPORT
+    strcpy_P(output, PSTR("unknown sensor type"));
+    return ECMD_FINAL(strlen(output));
+#else
+    ret = snprintf_P(output, len, PSTR("unknown sensor type"));
+#endif
+  }
+
+  return ECMD_FINAL(ret);
+
+}
+#else
+
+
+int16_t
+parse_cmd_onewire_get(char *cmd, char *output, uint16_t len)
+{
+  ow_rom_code_t rom;
+  int16_t ret;
+
+  while (*cmd == ' ')
+    cmd++;
+  debug_printf("called onewire_get with: \"%s\"\n", cmd);
+
+  ret = parse_ow_rom(cmd, &rom);
+
+  /* check for parse error */
+  if (ret < 0)
+    return ECMD_ERR_PARSE_ERROR;
+
+  if (ow_temp_sensor(&rom))
+  {
+    debug_printf("reading temperature\n");
+
+    ow_temp_scratchpad_t sp;
+    ret = ow_temp_read_scratchpad(&rom, &sp);
+
+    if (ret != 1)
+    {
+      debug_printf("scratchpad read failed: %d\n", ret);
+      return ECMD_ERR_READ_ERROR;
+    }
+
+    debug_printf("successfully read scratchpad\n");
+
+    int16_t temp = ow_temp_normalize(&rom, &sp);
+
+    debug_printf("temperature: %d.%d\n", HI8(temp), LO8(temp) > 0 ? 5 : 0);
+
+    int8_t sign = (int8_t) (temp < 0);
+
+#ifdef TEENSY_SUPPORT
+    if (sign)
+    {
+      temp = -temp;
+      output[0] = '-';
+    }
+    /* Here sign is 0 or 1 */
+    itoa(HI8(temp), output + sign, 10);
+    char *ptr = output + strlen(output);
+
+    *(ptr++) = '.';
+    itoa(HI8(((temp & 0x00ff) * 10) + 0x80), ptr, 10);
+    return ECMD_FINAL(strlen(output));
+#else
+    if (sign)
+      temp = -temp;
+    ret = snprintf_P(output, len, PSTR("%s%d.%1d"),
+                     sign ? "-" : "", (int8_t) HI8(temp),
+                     HI8(((temp & 0x00ff) * 10) + 0x80));
+#endif
+
+#ifdef ONEWIRE_DS2502_SUPPORT
+  }
+  else if (ow_eeprom(&rom))
+  {
+    debug_printf("reading mac\n");
+
+    uint8_t mac[6];
+    ret = ow_eeprom_read(&rom, mac);
+
+    if (ret != 0)
+    {
+      debug_printf("mac read failed: %d\n", ret);
+      return ECMD_ERR_READ_ERROR;
+    }
+
+    debug_printf("successfully read mac\n");
+
+    debug_printf("mac: %02x:%02x:%02x:%02x:%02x:%02x\n",
+                 mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+
+    ret = snprintf_P(output, len,
+                     PSTR("mac: %02x:%02x:%02x:%02x:%02x:%02x"),
+                     mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+#endif /* ONEWIRE_DS2502_SUPPORT */
+  }
+  else
+  {
+    debug_printf("unknown sensor type\n");
+#ifdef TEENSY_SUPPORT
+    strcpy_P(output, PSTR("unknown sensor type"));
+    return ECMD_FINAL(strlen(output));
+#else
+    ret = snprintf_P(output, len, PSTR("unknown sensor type"));
+#endif
+  }
+
+  return ECMD_FINAL(ret);
+}
+#endif
+
+
+#ifdef ONEWIRE_POLLING_SUPPORT
+int16_t
+parse_cmd_onewire_convert(char *cmd, char *output, uint16_t len)
+{
+  return ECMD_FINAL_OK;
+}
+#else
+int16_t
+parse_cmd_onewire_convert(char *cmd, char *output, uint16_t len)
+{
+  int16_t ret;
+
+  while (*cmd == ' ')
+    cmd++;
+  debug_printf("called onewire_convert with: \"%s\"\n", cmd);
+
+  ow_rom_code_t rom, *romptr;
+
+  ret = parse_ow_rom(cmd, &rom);
+
+  /* check for romcode */
+  romptr = (ret < 0) ? NULL : &rom;
+
+  debug_printf("converting temperature...\n");
+
+  ret = ow_temp_start_convert_wait(romptr);
+
+  if (ret == 1)
+    /* done */
+    return ECMD_FINAL_OK;
+  else if (ret == -1)
+    /* no device attached */
+    return ECMD_ERR_READ_ERROR;
+  else
+    /* wrong rom family code */
+    return ECMD_ERR_PARSE_ERROR;
 
 }
 #endif

--- a/hardware/onewire/onewire.c
+++ b/hardware/onewire/onewire.c
@@ -2,9 +2,9 @@
  * Simple onewire library implementation
  *
  * Copyright (c) Alexander Neumann <alexander@bumpern.de>
- * Copyright (c) 2012 by Frank Sautter <sautter.com>
  * Copyright (c) 2011 by Maximilian Güntner
  * Copyright (c) 2011 by Erik Kunze <ethersex@erik-kunze.de>
+ * Copyright (c) 2011-2012 by Frank Sautter
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License (either version 2 or
@@ -22,6 +22,7 @@
  * For more information on the GPL, please go to:
  * http://www.gnu.org/copyleft/gpl.html
  */
+
 
 #include <avr/io.h>
 #include <util/atomic.h>
@@ -41,646 +42,740 @@
 ow_global_t ow_global;
 
 /* module local prototypes */
-void noinline ow_set_address_bit(ow_rom_code_t *rom, uint8_t idx, uint8_t val);
+void noinline ow_set_address_bit(ow_rom_code_t * rom, uint8_t idx,
+                                 uint8_t val);
 
-void onewire_init(void)
+
+void
+onewire_init(void)
 {
-    /* configure onewire pin as input */
-    OW_CONFIG_INPUT(ONEWIRE_BUSMASK);
+  /* configure onewire pin as input */
+  OW_CONFIG_INPUT(ONEWIRE_BUSMASK);
 
-    /* release lock */
-    ow_global.lock = 0;
+  /* release lock */
+  ow_global.lock = 0;
 }
+
 
 /* low-level functions */
 
-uint8_t noinline reset_onewire(uint8_t busmask)
+uint8_t noinline
+reset_onewire(uint8_t busmask)
 {
-	uint8_t data1, data2;
-    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-	    /* pull bus low */
-	    OW_CONFIG_OUTPUT(busmask);
-	    OW_LOW(busmask);
-
-	    /* wait 480us */
-	    _delay_loop_2(OW_RESET_TIMEOUT_1);
-
-	    /* release bus */
-	    OW_CONFIG_INPUT(busmask);
-
-	    /* wait 60us (maximal pause) + 30 us (half minimum pulse) */
-	    _delay_loop_2(OW_RESET_TIMEOUT_2);
-
-	    /* sample data */
-	    data1 = OW_GET_INPUT(busmask);
-
-	    /* wait 390us */
-	    _delay_loop_2(OW_RESET_TIMEOUT_3);
-
-	    /* sample data again */
-	    data2 = OW_GET_INPUT(busmask);
-
-	    /* if first sample is low and second sample is high, at least one device is
-	     * attached to this bus */
-	}
-    return (uint8_t)(~data1 & data2 & busmask);
-
-}
-
-void noinline ow_write(uint8_t busmask, uint8_t value)
-{
-    if (value > 0)
-        ow_write_1(busmask);
-    else
-        ow_write_0(busmask);
-}
-
-void noinline ow_write_byte(uint8_t busmask, uint8_t value)
-{
+  uint8_t data1, data2;
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
+  {
+    /* pull bus low */
     OW_CONFIG_OUTPUT(busmask);
-    for (uint8_t i = 0; i < 8; i++) {
-        ow_write(busmask, (uint8_t)(value & _BV(i)));
-    }
+    OW_LOW(busmask);
+
+    /* wait 480us */
+    _delay_loop_2(OW_RESET_TIMEOUT_1);
+
+    /* release bus */
+    OW_CONFIG_INPUT(busmask);
+
+    /* wait 60us (maximal pause) + 30 us (half minimum pulse) */
+    _delay_loop_2(OW_RESET_TIMEOUT_2);
+
+    /* sample data */
+    data1 = OW_GET_INPUT(busmask);
+
+    /* wait 390us */
+    _delay_loop_2(OW_RESET_TIMEOUT_3);
+
+    /* sample data again */
+    data2 = OW_GET_INPUT(busmask);
+
+    /* if first sample is low and second sample is high, at least one device
+     * is attached to this bus */
+  }
+  return (uint8_t) (~data1 & data2 & busmask);
 }
 
-void noinline ow_write_0(uint8_t busmask)
-{
-    /* a write 0 timeslot is initiated by holding the data line low for
-     * approximately 80us */
 
-    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-        OW_LOW(busmask);
-        _delay_loop_2(OW_WRITE_0_TIMEOUT);
-        OW_HIGH(busmask);
-    }
+void noinline
+ow_write(uint8_t busmask, uint8_t value)
+{
+  if (value > 0)
+    ow_write_1(busmask);
+  else
+    ow_write_0(busmask);
 }
 
-uint8_t noinline ow_read(uint8_t busmask)
+
+void noinline
+ow_write_byte(uint8_t busmask, uint8_t value)
 {
-    /* a read timeslot is sent by holding the data line low for
-     * 1us, then wait approximately 14us, then sample data and
-     * wait */
-    /* this is also used as ow_write_1, as the only difference
-     * is that the return value is discarded */
-
-    uint8_t data;
-    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-        OW_CONFIG_OUTPUT(busmask);
-        OW_LOW(busmask);
-
-        _delay_loop_2(OW_READ_TIMEOUT_1);
-
-        OW_HIGH(busmask);
-        OW_CONFIG_INPUT(busmask);
-
-        _delay_loop_2(OW_READ_TIMEOUT_2);
-
-        /* sample data now */
-        data = (uint8_t)(OW_GET_INPUT(busmask) > 0);
-
-        /* wait for remaining slot time */
-        _delay_loop_2(OW_READ_TIMEOUT_3);
-
-        OW_CONFIG_OUTPUT(busmask);
-    }
-    return data;
+  OW_CONFIG_OUTPUT(busmask);
+  for (uint8_t i = 0; i < 8; i++)
+  {
+    ow_write(busmask, (uint8_t) (value & _BV(i)));
+  }
 }
 
-uint8_t noinline ow_read_byte(uint8_t busmask)
+
+void noinline
+ow_write_0(uint8_t busmask)
 {
-    uint8_t data = 0;
+  /* a write 0 timeslot is initiated by holding the data line low for
+   * approximately 80us */
 
-    for (uint8_t i = 0; i < 8; i++) {
-        data |= (uint8_t)(ow_read(busmask) << i);
-    }
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
+  {
+    OW_LOW(busmask);
+    _delay_loop_2(OW_WRITE_0_TIMEOUT);
+    OW_HIGH(busmask);
+  }
+}
 
-    return data;
+
+uint8_t noinline
+ow_read(uint8_t busmask)
+{
+  /* a read timeslot is sent by holding the data line low for 1µs, then wait
+   * approximately 14µs, then sample data and wait. this is also used as
+   * ow_write_1, as the only difference is that the return value is
+   * discarded */
+
+  uint8_t data;
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
+  {
+    OW_CONFIG_OUTPUT(busmask);
+    OW_LOW(busmask);
+
+    _delay_loop_2(OW_READ_TIMEOUT_1);
+
+    OW_HIGH(busmask);
+    OW_CONFIG_INPUT(busmask);
+
+    _delay_loop_2(OW_READ_TIMEOUT_2);
+
+    /* sample data now */
+    data = (uint8_t) (OW_GET_INPUT(busmask) > 0);
+
+    /* wait for remaining slot time */
+    _delay_loop_2(OW_READ_TIMEOUT_3);
+
+    OW_CONFIG_OUTPUT(busmask);
+  }
+  return data;
+}
+
+
+uint8_t noinline
+ow_read_byte(uint8_t busmask)
+{
+  uint8_t data = 0;
+
+  for (uint8_t i = 0; i < 8; i++)
+  {
+    data |= (uint8_t) (ow_read(busmask) << i);
+  }
+  return data;
 }
 
 
 /* mid-level functions */
-int8_t noinline ow_read_rom(ow_rom_code_t *rom)
+
+int8_t noinline
+ow_read_rom(ow_rom_code_t * rom)
 {
 #if ONEWIRE_BUSCOUNT > 1
-    uint8_t busmask = 1 << (ONEWIRE_STARTPIN); // FIXME: currently only on 1st bus
+  // FIXME: currently only on 1st bus
+  uint8_t busmask = 1 << (ONEWIRE_STARTPIN);
 #else
-    uint8_t busmask = ONEWIRE_BUSMASK;
+  uint8_t busmask = ONEWIRE_BUSMASK;
 #endif
-    /* reset the bus */
-    if (!reset_onewire(busmask))
-        return -1;
+  /* reset the bus */
+  if (!reset_onewire(busmask))
+    return -1;
 
-    /* transmit command byte */
-    ow_write_byte(busmask, OW_ROM_READ_ROM);
+  /* transmit command byte */
+  ow_write_byte(busmask, OW_ROM_READ_ROM);
 
-    /* read 64bit rom code */
-    for (uint8_t i = 0; i < 8; i++) {
+  /* read 64bit rom code */
+  for (uint8_t i = 0; i < 8; i++)
+  {
+    /* read byte */
+    rom->bytewise[i] = ow_read_byte(busmask);
+  }
 
-        /* read byte */
-        rom->bytewise[i] = ow_read_byte(busmask);
+  /* check CRC (last byte) */
+  if (rom->crc != crc_checksum(rom->bytewise, 7))
+    return -2;
+
+  return 1;
+}
+
+
+int8_t noinline
+ow_skip_rom(void)
+{
+  /* reset the bus */
+  if (!reset_onewire(ONEWIRE_BUSMASK))
+    return -1;
+
+  /* transmit command byte */
+  ow_write_byte(ONEWIRE_BUSMASK, OW_ROM_SKIP_ROM);
+
+  return 1;
+}
+
+
+int8_t noinline
+ow_match_rom(ow_rom_code_t * rom)
+{
+  /* reset the bus */
+  if (!reset_onewire(ONEWIRE_BUSMASK))
+    return -1;
+
+  /* transmit command byte */
+  ow_write_byte(ONEWIRE_BUSMASK, OW_ROM_MATCH_ROM);
+
+  /* transmit rom code */
+  for (uint8_t i = 0; i < 8; i++)
+  {
+    for (uint8_t j = 0; j < 8; j++)
+    {
+      ow_write(ONEWIRE_BUSMASK, (uint8_t) (rom->bytewise[i] & _BV(j)));
     }
+  }
 
-    /* check CRC (last byte) */
-    if (rom->crc != crc_checksum(rom->bytewise, 7))
-        return -2;
-
-    return 1;
+  return 1;
 }
 
-int8_t noinline ow_skip_rom(void)
+
+void noinline
+ow_set_address_bit(ow_rom_code_t * rom, uint8_t idx, uint8_t val)
 {
-    /* reset the bus */
-    if (!reset_onewire(ONEWIRE_BUSMASK))
-        return -1;
-
-    /* transmit command byte */
-    ow_write_byte(ONEWIRE_BUSMASK, OW_ROM_SKIP_ROM);
-
-    return 1;
+  uint8_t byte = idx / 8;
+  uint8_t bit = (uint8_t) _BV(idx % 8);
+  rom->bytewise[byte] &= (uint8_t) ~ bit;
+  if (val)
+    rom->bytewise[byte] |= bit;
 }
 
-int8_t noinline ow_match_rom(ow_rom_code_t *rom)
-{
-    /* reset the bus */
-    if (!reset_onewire(ONEWIRE_BUSMASK))
-        return -1;
-
-    /* transmit command byte */
-    ow_write_byte(ONEWIRE_BUSMASK, OW_ROM_MATCH_ROM);
-
-    /* transmit rom code */
-    for (uint8_t i = 0; i < 8; i++) {
-        for (uint8_t j = 0; j < 8; j++) {
-            ow_write(ONEWIRE_BUSMASK, (uint8_t)(rom->bytewise[i] & _BV(j)));
-        }
-    }
-
-    return 1;
-}
-
-void noinline ow_set_address_bit(ow_rom_code_t *rom, uint8_t idx, uint8_t val)
-{
-    uint8_t byte = idx / 8;
-    uint8_t bit = (uint8_t)_BV(idx % 8);
-		rom->bytewise[byte] &= (uint8_t)~bit;
-		if (val) rom->bytewise[byte] |= bit;
-}
 
 #ifdef ONEWIRE_DETECT_SUPPORT
 /* high-level functions */
-int8_t noinline ow_search_rom(uint8_t busmask, uint8_t first)
+int8_t noinline
+ow_search_rom(uint8_t busmask, uint8_t first)
 {
-    /* reset discover state machine */
-    if (first) {
-        ow_global.last_discrepancy = -1;
+  /* reset discover state machine */
+  if (first)
+  {
+    ow_global.last_discrepancy = -1;
 
-        /* reset rom code */
-        for (uint8_t i = 0; i < 8; i++)
-            ow_global.current_rom.bytewise[i] = 0;
+    /* reset rom code */
+    for (uint8_t i = 0; i < 8; i++)
+      ow_global.current_rom.bytewise[i] = 0;
+  }
+  else
+  {
+    /* if last_discrepancy is below zero, discovery is done */
+    if (ow_global.last_discrepancy < 0)
+      return 0;
+  }
 
-    } else {
+  int8_t discrepancy = -1;
 
-        /* if last_discrepancy is below zero, discovery is done */
-        if (ow_global.last_discrepancy < 0)
-            return 0;
+  /* reset the bus */
+  if (!reset_onewire(busmask))
+    return -1;
 
+  /* transmit command byte */
+  ow_write_byte(busmask, OW_ROM_SEARCH_ROM);
+
+  for (uint8_t i = 0; i < 64; i++)
+  {
+    /* read bits */
+    uint8_t bit1 = ow_read(busmask);
+    uint8_t bits = (uint8_t) ((ow_read(busmask) << 1) | bit1);
+
+    if (bits == 3)
+    {
+      /* no devices, just return */
+      return 0;
+    }
+    else if (bits == 0)
+    {
+      if (i == ow_global.last_discrepancy)
+      {
+        /* set one */
+        ow_set_address_bit(&ow_global.current_rom, i, 1);
+
+        /* transmit one next time */
+        bit1 = 1;
+      }
+      else if (i > ow_global.last_discrepancy)
+      {
+        /* set zero */
+        ow_set_address_bit(&ow_global.current_rom, i, 0);
+        discrepancy = (int8_t) i;
+      }
+      else
+      {
+        uint8_t rom_bit =
+          (uint8_t) (ow_global.current_rom.bytewise[i / 8] & _BV(i % 8));
+
+        if (rom_bit == 0)
+          discrepancy = (int8_t) i;
+        /* transmit last bit next time */
+        bit1 = rom_bit;
+      }
+    }
+    else
+    {
+      /* normal case, no discrepancy */
+      ow_set_address_bit(&ow_global.current_rom, i, bit1);
     }
 
-    int8_t discrepancy = -1;
+    OW_CONFIG_OUTPUT(busmask);
 
-    /* reset the bus */
-    if (!reset_onewire(busmask))
-        return -1;
+    /* select next bit */
+    ow_write(busmask, bit1);
+  }
 
-    /* transmit command byte */
-    ow_write_byte(busmask, OW_ROM_SEARCH_ROM);
+  ow_global.last_discrepancy = discrepancy;
 
-    for (uint8_t i = 0; i <64; i++) {
-
-        /* read bits */
-        uint8_t bit1 = ow_read(busmask);
-        uint8_t bits = (uint8_t)((ow_read(busmask) << 1) | bit1);
-
-        if (bits == 3) {
-
-            /* no devices, just return */
-            return 0;
-
-        } else if (bits == 0) {
-
-            if (i == ow_global.last_discrepancy) {
-
-                /* set one */
-                ow_set_address_bit(&ow_global.current_rom, i, 1);
-
-                /* transmit one next time */
-                bit1 = 1;
-
-            } else if (i > ow_global.last_discrepancy) {
-
-                /* set zero */
-                ow_set_address_bit(&ow_global.current_rom, i, 0);
-                discrepancy = (int8_t)i;
-
-            } else {
-
-                uint8_t rom_bit = (uint8_t)(ow_global.current_rom.bytewise[i / 8] & _BV(i % 8));
-
-                if (rom_bit == 0)
-                    discrepancy = (int8_t)i;
-
-                /* transmit last bit next time */
-                bit1 = rom_bit;
-
-            }
-
-        } else {
-
-            /* normal case, no discrepancy */
-            ow_set_address_bit(&ow_global.current_rom, i, bit1);
-
-        }
-
-        OW_CONFIG_OUTPUT(busmask);
-
-        /* select next bit */
-        ow_write(busmask, bit1);
-
-    }
-
-    ow_global.last_discrepancy = discrepancy;
-
-    /* new device discovered */
-    return 1;
+  /* new device discovered */
+  return 1;
 }
 #endif /* ONEWIRE_DETECT_SUPPORT */
 
-/*
- * temperature functions
- */
 
-int8_t ow_temp_sensor(ow_rom_code_t *rom)
+/* temperature functions */
+
+int8_t
+ow_temp_sensor(ow_rom_code_t * rom)
 {
+  /* check for known family code */
+  return (int8_t) (rom->family == OW_FAMILY_DS1820 ||
+                   rom->family == OW_FAMILY_DS1822 ||
+                   rom->family == OW_FAMILY_DS18B20);
+}
+
+
+int8_t
+ow_temp_start_convert(ow_rom_code_t * rom, uint8_t wait)
+{
+  int8_t ret;
+
+  if (rom == NULL)
+    ret = ow_skip_rom();
+  else
+  {
     /* check for known family code */
-    return (int8_t)(rom->family == OW_FAMILY_DS1820 ||
-                    rom->family == OW_FAMILY_DS1822 ||
-                    rom->family == OW_FAMILY_DS18B20);
-}
+    if (!ow_temp_sensor(rom))
+      return -2;
 
-int8_t ow_temp_start_convert(ow_rom_code_t *rom, uint8_t wait)
-{
-    int8_t ret;
+    ret = ow_match_rom(rom);
+  }
 
-    if (rom == NULL)
-        ret = ow_skip_rom();
-    else {
+  if (ret < 0)
+    return ret;
 
-        /* check for known family code */
-        if (!ow_temp_sensor(rom))
-            return -2;
+  /* transmit command byte */
+  ow_write_byte(ONEWIRE_BUSMASK, OW_FUNC_CONVERT);
 
-        ret = ow_match_rom(rom);
+  OW_CONFIG_OUTPUT(ONEWIRE_BUSMASK);
+  OW_HIGH(ONEWIRE_BUSMASK);
 
-    }
-
-    if (ret < 0)
-        return ret;
-
-    /* transmit command byte */
-    ow_write_byte(ONEWIRE_BUSMASK, OW_FUNC_CONVERT);
-
-    OW_CONFIG_OUTPUT(ONEWIRE_BUSMASK);
-    OW_HIGH(ONEWIRE_BUSMASK);
-
-    if (!wait)
-        return 0;
-
-    _delay_ms(800); /* the specification says, that we have to wait at
-                       least 500ms in parasite mode for the conversion to complete.
-	                   800ms works more reliably */
-
-    while(!ow_read(ONEWIRE_BUSMASK));
-
-    return 1;
-}
-
-int8_t ow_temp_read_scratchpad(ow_rom_code_t *rom, ow_temp_scratchpad_t *scratchpad)
-{
-    uint8_t busmask;
-    int8_t ret;
-
-    if (rom == NULL)
-        ret = ow_skip_rom();
-    else {
-
-        /* check for known family code */
-        if (!ow_temp_sensor(rom))
-            return -3;
-
-        ret = ow_match_rom(rom);
-    }
-
-    if (ret < 0)
-        return ret;
-
-    /* transmit command byte */
-    ow_write_byte(ONEWIRE_BUSMASK, OW_FUNC_READ_SP);
-
-#if ONEWIRE_BUSCOUNT > 1
-    for (uint8_t bus = 0; bus < ONEWIRE_BUSCOUNT; bus++) {
-        /* read 9 bytes from each onewire bus */
-        busmask = (uint8_t)(1 << (bus + ONEWIRE_STARTPIN));
-#else
-        busmask = ONEWIRE_BUSMASK;
-#endif
-        for (uint8_t i = 0; i < 9; i++) {
-            scratchpad->bytewise[i] = ow_read_byte(busmask);
-        }
-
-        /* check CRC (last byte) */
-        if (scratchpad->crc == crc_checksum(&scratchpad->bytewise, 8)) {
-            /* return if we got a valid response from one device */
-            return 1;
-        }
-#if ONEWIRE_BUSCOUNT > 1
-    }
-#endif
-
-    return -2;
-}
-
-int8_t ow_temp_power(ow_rom_code_t *rom)
-{
-#if ONEWIRE_BUSCOUNT > 1
-    uint8_t busmask = 1 << (ONEWIRE_STARTPIN); // FIXME: currently only on 1st bus
-#else
-    uint8_t busmask = ONEWIRE_BUSMASK;
-#endif
-    int8_t ret;
-
-    if (rom == NULL)
-        ret = ow_skip_rom();
-    else {
-        if (!ow_temp_sensor(rom))
-            return -2;
-
-        ret = ow_match_rom(rom);
-    }
-
-    if (ret < 0)
-        return ret;
-
-    /* transmit command byte */
-    ow_write_byte(busmask, OW_FUNC_READ_POWER);
-
-    return (int8_t)(ow_read(busmask));
-}
-
-int16_t ow_temp_normalize(ow_rom_code_t *rom, ow_temp_scratchpad_t *sp)
-{
-    if (rom->family == OW_FAMILY_DS1820)
-        return (int16_t)((sp->temperature & 0xfffe) << 7) - 0x40 + (((sp->count_per_c - sp->count_remain) << 8) / sp->count_per_c);
-    else if (rom->family == OW_FAMILY_DS1822 || rom->family == OW_FAMILY_DS18B20)
-        return (int16_t)(sp->temperature << 4);
-    else
-        return -1;
-}
-
-/*
- * DS2502 data functions
- */
-
-int8_t ow_eeprom(ow_rom_code_t *rom)
-{
-    /* check for known family code */
-    if (rom->family == OW_FAMILY_DS2502E48)
-        return 1;
-
+  if (!wait)
     return 0;
+
+  /* the specification says, that we have to wait at least 500ms in parasite
+   * mode for the conversion to complete. 800ms works more reliably */
+  _delay_ms(800);
+
+  while (!ow_read(ONEWIRE_BUSMASK));
+
+  return 1;
 }
+
+
+int8_t
+ow_temp_read_scratchpad(ow_rom_code_t * rom,
+                        ow_temp_scratchpad_t * scratchpad)
+{
+  uint8_t busmask;
+  int8_t ret;
+
+  if (rom == NULL)
+    ret = ow_skip_rom();
+  else
+  {
+    /* check for known family code */
+    if (!ow_temp_sensor(rom))
+      return -3;
+
+    ret = ow_match_rom(rom);
+  }
+
+  if (ret < 0)
+    return ret;
+
+  /* transmit command byte */
+  ow_write_byte(ONEWIRE_BUSMASK, OW_FUNC_READ_SP);
+
+#if ONEWIRE_BUSCOUNT > 1
+  for (uint8_t bus = 0; bus < ONEWIRE_BUSCOUNT; bus++)
+  {
+    /* read 9 bytes from each onewire bus */
+    busmask = (uint8_t) (1 << (bus + ONEWIRE_STARTPIN));
+#else
+  {
+    busmask = ONEWIRE_BUSMASK;
+#endif
+
+    for (uint8_t i = 0; i < 9; i++)
+    {
+      scratchpad->bytewise[i] = ow_read_byte(busmask);
+    }
+
+    /* check CRC (last byte) */
+    if (scratchpad->crc == crc_checksum(&scratchpad->bytewise, 8))
+    {
+      /* return if we got a valid response from one device */
+      return 1;
+    }
+  }
+
+  return -2;
+}
+
+
+int8_t
+ow_temp_power(ow_rom_code_t * rom)
+{
+#if ONEWIRE_BUSCOUNT > 1
+  // FIXME: currently only on 1st bus
+  uint8_t busmask = 1 << (ONEWIRE_STARTPIN);
+#else
+  uint8_t busmask = ONEWIRE_BUSMASK;
+#endif
+  int8_t ret;
+
+  if (rom == NULL)
+    ret = ow_skip_rom();
+  else
+  {
+    if (!ow_temp_sensor(rom))
+      return -2;
+
+    ret = ow_match_rom(rom);
+  }
+
+  if (ret < 0)
+    return ret;
+
+  /* transmit command byte */
+  ow_write_byte(busmask, OW_FUNC_READ_POWER);
+
+  return (int8_t) (ow_read(busmask));
+}
+
+
+int16_t
+ow_temp_normalize(ow_rom_code_t * rom, ow_temp_scratchpad_t * sp)
+{
+  if (rom->family == OW_FAMILY_DS1820)
+    return (int16_t) ((sp->temperature & 0xfffe) << 7) - 0x40 +
+      (((sp->count_per_c - sp->count_remain) << 8) / sp->count_per_c);
+  else if (rom->family == OW_FAMILY_DS1822 ||
+           rom->family == OW_FAMILY_DS18B20)
+    return (int16_t) (sp->temperature << 4);
+  else
+    return -1;
+}
+
+
+/* DS2502 data functions */
+
+int8_t
+ow_eeprom(ow_rom_code_t * rom)
+{
+  /* check for known family code */
+  if (rom->family == OW_FAMILY_DS2502E48)
+    return 1;
+
+  return 0;
+}
+
 
 #ifdef ONEWIRE_DS2502_SUPPORT
-
-int8_t ow_eeprom_read(ow_rom_code_t *rom, void *data)
+int8_t
+ow_eeprom_read(ow_rom_code_t * rom, void *data)
 {
 #if ONEWIRE_BUSCOUNT > 1
-    uint8_t busmask = 1 << (ONEWIRE_STARTPIN); // FIXME: currently only on 1st bus
+  // FIXME: currently only on 1st bus
+  uint8_t busmask = 1 << (ONEWIRE_STARTPIN);
 #else
-    uint8_t busmask = ONEWIRE_BUSMASK;
+  uint8_t busmask = ONEWIRE_BUSMASK;
 #endif
-    int8_t ret;
+  int8_t ret;
 
-    if (rom == NULL)
-        ret = ow_skip_rom();
-    else {
+  if (rom == NULL)
+    ret = ow_skip_rom();
+  else
+  {
+    /* check for known family code */
+    if (!(rom->family == OW_FAMILY_DS2502E48))
+      return -2;
 
-        /* check for known family code */
-        if (!(rom->family == OW_FAMILY_DS2502E48))
-            return -2;
+    ret = ow_match_rom(rom);
+  }
 
-        ret = ow_match_rom(rom);
+  if (ret < 0)
+    return ret;
 
-    }
+  /* transmit command byte */
+  ow_write_byte(busmask, OW_FUNC_READ_MEMORY);
 
-    if (ret < 0)
-        return ret;
+  /* transmit address. mac address starts at offset 5 */
+  ow_write_byte(busmask, 5);
+  ow_write_byte(busmask, 0);
 
-    /* transmit command byte */
-    ow_write_byte(busmask, OW_FUNC_READ_MEMORY);
+  /* read back crc sum of the command */
+  uint8_t crc = ow_read_byte(busmask);
 
-    /* transmit address (mac address starts at offset 5 */
-    ow_write_byte(busmask, 5);
-    ow_write_byte(busmask, 0);
+  /* check crc */
+  uint8_t crc2 = 0;
+  crc2 = _crc_ibutton_update(crc2, OW_FUNC_READ_MEMORY);
+  crc2 = _crc_ibutton_update(crc2, 5);
+  crc2 = _crc_ibutton_update(crc2, 0);
 
-    /* read back crc sum of the command */
-    uint8_t crc = ow_read_byte(busmask);
+  if (crc != crc2)
+    return -2;
 
-    /* check crc */
-    uint8_t crc2 = 0;
-    crc2 = _crc_ibutton_update(crc2, OW_FUNC_READ_MEMORY);
-    crc2 = _crc_ibutton_update(crc2, 5);
-    crc2 = _crc_ibutton_update(crc2, 0);
+  uint8_t *p = (uint8_t *) data + 5;
 
-    if (crc != crc2)
-        return -2;
+  /* read 6 byte of data */
+  for (uint8_t i = 0; i < 6; i++)
+    *p-- = ow_read_byte(busmask);
 
-    uint8_t *p = (uint8_t *)data+5;
-
-    /* read 6 byte of data */
-    for (uint8_t i = 0; i < 6; i++)
-        *p-- = ow_read_byte(busmask);
-
-    return 0;
+  return 0;
 }
-
 #endif /* ONEWIRE_DS2502_SUPPORT */
+
+
 #ifdef ONEWIRE_POLLING_SUPPORT
-ow_sensor_t ow_sensors[OW_SENSORS_COUNT] = {{{{0}},0,0,0,0,0}};
+ow_sensor_t ow_sensors[OW_SENSORS_COUNT] = {
+  {{{0}
+    }
+   , 0, 0, 0, 0, 0}
+};
 
-static int8_t ow_discover_sensor(void) {
-	uint8_t firstonbus = 1;
-	int8_t ret = 0;
+
+static int8_t
+ow_discover_sensor(void)
+{
+  uint8_t firstonbus = 1;
+  int8_t ret = 0;
+
 #if ONEWIRE_BUSCOUNT > 1
-	ow_global.bus = 0;
+  ow_global.bus = 0;
 #endif /* ONEWIRE_BUSCOUNT */
+
 #ifdef DEBUG_OW_POLLING
-	debug_printf("starting discovery\n");
+  debug_printf("starting discovery\n");
 #endif /* DEBUG_OW_POLLING */
-	/*Prepare existing sensors*/
-	for (uint8_t i = 0; i < OW_SENSORS_COUNT; i++)
-		ow_sensors[i].present = 0;
+
+  /* prepare existing sensors */
+  for (uint8_t i = 0; i < OW_SENSORS_COUNT; i++)
+    ow_sensors[i].present = 0;
 
 #if ONEWIRE_BUSCOUNT > 1
-	do {
+  do
+  {
 #endif /* ONEWIRE_BUSCOUNT > 1 */
-		do {
+
+    do
+    {
+
 #if ONEWIRE_BUSCOUNT > 1
-				ret = ow_search_rom((uint8_t)(1 << (ow_global.bus + ONEWIRE_STARTPIN)), firstonbus);
+      ret =
+        ow_search_rom((uint8_t) (1 << (ow_global.bus + ONEWIRE_STARTPIN)),
+                      firstonbus);
 #else /* ONEWIRE_BUSCOUNT > 1 */
-				ret = ow_search_rom(ONEWIRE_BUSMASK, firstonbus);
+      ret = ow_search_rom(ONEWIRE_BUSMASK, firstonbus);
 #endif /* ONEWIRE_BUSCOUNT > 1 */
 
-			/* make sure only one conversion happens at a time */
-			ow_global.lock = 1;
+      /* make sure only one conversion happens at a time */
+      ow_global.lock = 1;
 
-			if (ret == 1) {
-				firstonbus = 0;
+      if (ret == 1)
+      {
+        firstonbus = 0;
 #ifdef DEBUG_OW_POLLING
-				debug_printf("discovered device %02x %02x %02x %02x %02x %02x %02x %02x"
+        debug_printf
+          ("discovered device %02x %02x %02x %02x %02x %02x %02x %02x"
 #if ONEWIRE_BUSCOUNT > 1
-				             " on bus %d"
+           " on bus %d"
 #endif /* ONEWIRE_BUSCOUNT > 1 */
-				             "\n",
-				             ow_global.current_rom.bytewise[0],
-				             ow_global.current_rom.bytewise[1],
-				             ow_global.current_rom.bytewise[2],
-				             ow_global.current_rom.bytewise[3],
-				             ow_global.current_rom.bytewise[4],
-				             ow_global.current_rom.bytewise[5],
-				             ow_global.current_rom.bytewise[6],
-				             ow_global.current_rom.bytewise[7]
+           "\n",
+           ow_global.current_rom.bytewise[0],
+           ow_global.current_rom.bytewise[1],
+           ow_global.current_rom.bytewise[2],
+           ow_global.current_rom.bytewise[3],
+           ow_global.current_rom.bytewise[4],
+           ow_global.current_rom.bytewise[5],
+           ow_global.current_rom.bytewise[6],
+           ow_global.current_rom.bytewise[7]
 #if ONEWIRE_BUSCOUNT > 1
-				             ,ow_global.bus
+           , ow_global.bus
 #endif /* ONEWIRE_BUSCOUNT > 1 */
-				            );
+          );
 #endif /* DEBUG_OW_POLLING */
-				if (ow_temp_sensor(&ow_global.current_rom)) {
-					uint8_t already_in = 0;
-					/*Determine whether this sensor is already present in our list*/
-					for (uint8_t i = 0; i < OW_SENSORS_COUNT; i++) {
-						if (ow_global.current_rom.raw == ow_sensors[i].ow_rom_code.raw) {
-							ow_sensors[i].present = 1;
-							already_in = 1;
-							/*We skip everything else to retain a regular update rate*/
-							break;
-						}
-					}
-					if (already_in == 0) {
-						uint8_t i;
-						/* the sensor we found is not in our list, so we search for the first free sensor slot, e.g. the first slot where ow_rom_code is zero */
-						for (i = 0; i < OW_SENSORS_COUNT; i++) {
-							if (ow_sensors[i].ow_rom_code.raw == 0) {
-								/* We found a free slot...storing*/
+        if (ow_temp_sensor(&ow_global.current_rom))
+        {
+          uint8_t already_in = 0;
+          /* determine whether this sensor is already present in our list */
+          for (uint8_t i = 0; i < OW_SENSORS_COUNT; i++)
+          {
+            if (ow_global.current_rom.raw == ow_sensors[i].ow_rom_code.raw)
+            {
+              ow_sensors[i].present = 1;
+              already_in = 1;
+              /* skip everything else to retain a regular update rate */
+              break;
+            }
+          }
+          if (already_in == 0)
+          {
+            uint8_t i;
+            /* the sensor found is not in our list, so search for the first
+             * free sensor slot, e.g. the first slot where ow_rom_code is
+             * zero */
+            for (i = 0; i < OW_SENSORS_COUNT; i++)
+            {
+              if (ow_sensors[i].ow_rom_code.raw == 0)
+              {
+                /* found a free slot... storing */
 #ifdef DEBUG_OW_POLLING
-								debug_printf("stored new sensor in pos %d\n", i);
+                debug_printf("stored new sensor in pos %d\n", i);
 #endif /* DEBUG_OW_POLLING */
-								ow_sensors[i].ow_rom_code.raw = ow_global.current_rom.raw;
-								ow_sensors[i].present = 1;
-								ow_sensors[i].read_delay = 1; /* read temperature asap - note: we will check for eeprom later */
-								break;
-							}
-						}
+                ow_sensors[i].ow_rom_code.raw = ow_global.current_rom.raw;
+                ow_sensors[i].present = 1;
+                /* read temperature asap
+                 * eeproms will be checked for later */
+                ow_sensors[i].read_delay = 1;
+                break;
+              }
+            }
 #ifdef DEBUG_OW_POLLING
-						if (i == OW_SENSORS_COUNT - 1)
-							debug_printf("number of sensors exceeds list size of %d\n", OW_SENSORS_COUNT);
+            if (i == OW_SENSORS_COUNT - 1)
+              debug_printf("number of sensors exceeds list size of %d\n",
+                           OW_SENSORS_COUNT);
 #endif /* DEBUG_OW_POLLING */
-					}
+          }
 #ifdef DEBUG_OW_POLLING
-				} else {
-					debug_printf("not a temperature sensor\n");
+        }
+        else
+        {
+          debug_printf("not a temperature sensor\n");
 #endif /* DEBUG_OW_POLLING */
-				}
-			}
-		} while (ret > 0);
+        }
+      }
+    }
+    while (ret > 0);
 #if ONEWIRE_BUSCOUNT > 1
-		ow_global.bus++;
-		firstonbus = 1;
-	} while (ow_global.bus < ONEWIRE_BUSCOUNT);
+    ow_global.bus++;
+    firstonbus = 1;
+  }
+  while (ow_global.bus < ONEWIRE_BUSCOUNT);
 #endif /* ONEWIRE_BUSCOUNT > 1 */
-	ow_global.lock = 0;
-	/*We finished the discovery process. Now we delete all removed sensors*/
-	for (uint8_t i = 0; i < OW_SENSORS_COUNT; i++) {
-		/*Mark the slot as free*/
-		if (ow_sensors[i].present == 0)
-			ow_sensors[i].ow_rom_code.raw = 0;
-	}
-	return 0;
+  ow_global.lock = 0;
+  /* finished the discovery process. now delete all removed sensors */
+  for (uint8_t i = 0; i < OW_SENSORS_COUNT; i++)
+  {
+    /* mark the slot as free */
+    if (ow_sensors[i].present == 0)
+      ow_sensors[i].ow_rom_code.raw = 0;
+  }
+  return 0;
 }
 
-/*This function will be called every 800 ms*/
-void ow_periodic(void) {
-	/* perform an initial bus discovery on startup */
-	static uint16_t discover_delay = 3;
-	if (--discover_delay == 0) {
-		discover_delay = OW_DISCOVER_DELAY;
-		ow_discover_sensor();
-#ifdef DEBUG_OW_POLLING
-		for (uint8_t i = 0, k = 0; i < OW_SENSORS_COUNT; i++) {
-			if (ow_sensors[i].ow_rom_code.raw != 0) {
-				debug_printf("sensor #%d in list is: %02x %02x %02x %02x %02x %02x %02x %02x\n",
-						++k,
-						ow_sensors[i].ow_rom_code.bytewise[0],
-						ow_sensors[i].ow_rom_code.bytewise[1],
-						ow_sensors[i].ow_rom_code.bytewise[2],
-						ow_sensors[i].ow_rom_code.bytewise[3],
-						ow_sensors[i].ow_rom_code.bytewise[4],
-						ow_sensors[i].ow_rom_code.bytewise[5],
-						ow_sensors[i].ow_rom_code.bytewise[6],
-						ow_sensors[i].ow_rom_code.bytewise[7]);
-			}
-		}
-#endif /* DEBUG_OW_POLLING */
-	}
-	for (uint8_t i = 0; i < OW_SENSORS_COUNT; i++) {
-		if (ow_temp_sensor(&ow_sensors[i].ow_rom_code)) {
-			if (ow_sensors[i].converted == 1) {
-				if (ow_sensors[i].convert_delay == 1)
-					ow_sensors[i].convert_delay = 0;
-				else {
-#ifdef DEBUG_OW_POLLING
-					debug_printf("reading temperature\n");
-#endif /* DEBUG_OW_POLLING */
-					int8_t ret;
-					ow_temp_scratchpad_t sp;
-					ret = ow_temp_read_scratchpad(&ow_sensors[i].ow_rom_code, &sp);
 
-					if (ret != 1) {
+/* this function will be called every 800 ms */
+void
+ow_periodic(void)
+{
+  /* perform an initial bus discovery on startup */
+  static uint16_t discover_delay = 3;
+  if (--discover_delay == 0)
+  {
+    discover_delay = OW_DISCOVER_DELAY;
+    ow_discover_sensor();
 #ifdef DEBUG_OW_POLLING
-						debug_printf("scratchpad read failed: %d\n", ret);
+    for (uint8_t i = 0, k = 0; i < OW_SENSORS_COUNT; i++)
+    {
+      if (ow_sensors[i].ow_rom_code.raw != 0)
+      {
+        debug_printf
+          ("sensor #%d in list is: %02x %02x %02x %02x %02x %02x %02x %02x\n",
+           ++k, ow_sensors[i].ow_rom_code.bytewise[0],
+           ow_sensors[i].ow_rom_code.bytewise[1],
+           ow_sensors[i].ow_rom_code.bytewise[2],
+           ow_sensors[i].ow_rom_code.bytewise[3],
+           ow_sensors[i].ow_rom_code.bytewise[4],
+           ow_sensors[i].ow_rom_code.bytewise[5],
+           ow_sensors[i].ow_rom_code.bytewise[6],
+           ow_sensors[i].ow_rom_code.bytewise[7]);
+      }
+    }
 #endif /* DEBUG_OW_POLLING */
-						return;
-					}
+  }
+  for (uint8_t i = 0; i < OW_SENSORS_COUNT; i++)
+  {
+    if (ow_temp_sensor(&ow_sensors[i].ow_rom_code))
+    {
+      if (ow_sensors[i].converted == 1)
+      {
+        if (ow_sensors[i].convert_delay == 1)
+          ow_sensors[i].convert_delay = 0;
+        else
+        {
 #ifdef DEBUG_OW_POLLING
-					debug_printf("scratchpad read succeeded\n");
+          debug_printf("reading temperature\n");
 #endif /* DEBUG_OW_POLLING */
-					int16_t temp = ow_temp_normalize(&ow_sensors[i].ow_rom_code, &sp);
+          int8_t ret;
+          ow_temp_scratchpad_t sp;
+          ret = ow_temp_read_scratchpad(&ow_sensors[i].ow_rom_code, &sp);
+
+          if (ret != 1)
+          {
 #ifdef DEBUG_OW_POLLING
-					debug_printf("temperature: %d.%d\n", HI8(temp), LO8(temp) > 0 ? 5 : 0);
+            debug_printf("scratchpad read failed: %d\n", ret);
 #endif /* DEBUG_OW_POLLING */
-					ow_sensors[i].temp = ((int8_t) HI8(temp)) * 10 + HI8(((temp & 0x00ff) * 10) + 0x80);
-					ow_sensors[i].converted = 0;
-				}
-			}
-			if (--ow_sensors[i].read_delay == 0 && ow_sensors[i].converted == 0) {
-				ow_sensors[i].read_delay = OW_READ_DELAY;
-				ow_temp_start_convert_nowait(&ow_sensors[i].ow_rom_code);
-				ow_sensors[i].convert_delay = 1;
-				ow_sensors[i].converted = 1;
-			}
-		}
-	}
+            return;
+          }
+#ifdef DEBUG_OW_POLLING
+          debug_printf("scratchpad read succeeded\n");
+#endif /* DEBUG_OW_POLLING */
+          int16_t temp = ow_temp_normalize(&ow_sensors[i].ow_rom_code, &sp);
+#ifdef DEBUG_OW_POLLING
+          debug_printf("temperature: %d.%d\n", HI8(temp),
+                       LO8(temp) > 0 ? 5 : 0);
+#endif /* DEBUG_OW_POLLING */
+          ow_sensors[i].temp =
+            ((int8_t) HI8(temp)) * 10 + HI8(((temp & 0x00ff) * 10) + 0x80);
+          ow_sensors[i].converted = 0;
+        }
+      }
+      if (--ow_sensors[i].read_delay == 0 && ow_sensors[i].converted == 0)
+      {
+        ow_sensors[i].read_delay = OW_READ_DELAY;
+        ow_temp_start_convert_nowait(&ow_sensors[i].ow_rom_code);
+        ow_sensors[i].convert_delay = 1;
+        ow_sensors[i].converted = 1;
+      }
+    }
+  }
 }
 #endif /* ONEWIRE_POLLING_SUPPORT */
+
 
 /*
   -- Ethersex META --

--- a/hardware/onewire/onewire.h
+++ b/hardware/onewire/onewire.h
@@ -28,7 +28,7 @@
 #ifndef ONEWIRE_H
 #define ONEWIRE_H
 
-/* For an introduction to the onewire bus protocol see
+/* for an introduction to the onewire bus protocol see
  * http://www.ibutton.com/ibuttons/standard.pdf and the ds18s20 datasheet */
 
 /* configuration:
@@ -40,12 +40,12 @@
  * #define ONEWIRE_PIN PIND
  * #define ONEWIRE_PORT PORTD
  * #define ONEWIRE_DDR DDRD
- *
  */
 
 #include <stdint.h>
 
 #ifdef ONEWIRE_SUPPORT
+
 
 /* rom commands */
 #define OW_ROM_SEARCH_ROM 0xF0
@@ -54,6 +54,7 @@
 #define OW_ROM_SKIP_ROM 0xCC
 #define OW_ROM_ALARM_SEARCH 0xEC
 
+
 /* families */
 #define OW_FAMILY_DS1820 0x10
 #define OW_FAMILY_DS18B20 0x28
@@ -61,7 +62,11 @@
 #define OW_FAMILY_DS2502E48 0x89
 #define OW_FAMILY_DS2502 0x09
 
-/* ds18s20 functions commands */
+
+/*
+ * ds18s20 functions commands
+ */
+
 
 /* temperature */
 #define OW_FUNC_CONVERT 0x44
@@ -71,154 +76,201 @@
 #define OW_FUNC_RECALL_EE 0xB8
 #define OW_FUNC_READ_POWER 0xB4
 
+
 /* data (only reading data is supported so far) */
 #define OW_FUNC_READ_MEMORY 0xF0
 #define OW_FUNC_READ_STATUS 0xAA
 #define OW_FUNC_READ_DATA_CRC 0xC3
 
-/* timing constants */
-/* onewire needs a 480us reset timeout, suitable for use with the delay_loop() functions */
+/*
+ * timing constants
+ */
+
+/* onewire needs a 480µs reset timeout, suitable for use with the
+ * delay_loop() functions */
 #define OW_RESET_TIMEOUT_1 (F_CPU / 1000000 * 480 / 4)
-/* we wait 90us before sampling data for the low-pulse detection */
+/* wait 90µs before sampling data for the low-pulse detection */
 #define OW_RESET_TIMEOUT_2 (F_CPU / 1000000 * 90 / 4)
-/* and wait 480us - 90us = 390us before initiating the next onewire command */
+/* wait 480µs - 90µs = 390µs before initiating the next onewire command */
 #define OW_RESET_TIMEOUT_3 (F_CPU / 1000000 * 390 / 4)
 
 #if OW_RESET_TIMEOUT_1 > 65535
 #error "OW_CONFIG_TIMEOUT_1 bigger than 64k?!"
 #endif
 
+
 /* a write 0 timeslot is initiated by holding the data line low for
- * approximately 80us */
+ * approximately 80µs */
 #define OW_WRITE_0_TIMEOUT (F_CPU / 1000000 * 84 / 4)
 
+
 /* a write 1 timeslot is initiated by holding the data line low for
- * approximately 4us and then waiting at least 60us */
+ * approximately 4µs and then waiting at least 60µs */
 #define OW_WRITE_1_TIMEOUT_1 (F_CPU / 1000000 *  4 / 4)
 #define OW_WRITE_1_TIMEOUT_2 (F_CPU / 1000000 * 80 / 4)
 
-/* a read timeslot is initiated by holding the data line low for 1us and
- * sampling data after 14us and wait for the remaining slot time */
+
+/* a read timeslot is initiated by holding the data line low for 1µs and
+ * sampling data after 14µs and wait for the remaining slot time */
 #define OW_READ_TIMEOUT_1 (F_CPU / 1000000 * 1 / 4)
 #define OW_READ_TIMEOUT_2 (F_CPU / 1000000 * 14 / 4)
 #define OW_READ_TIMEOUT_3 (F_CPU / 1000000 * 65 / 4)
-/* */
 
-/* macros */
-#define OW_CONFIG_INPUT(busmask)			\
-  /* enable pullup */					\
-  ONEWIRE_PORT = (uint8_t)(ONEWIRE_PORT | busmask);	\
-  /* configure as input */				\
+
+/*
+ * macros
+ */
+#define OW_CONFIG_INPUT(busmask)                              \
+  /* enable pullup */                                         \
+  ONEWIRE_PORT = (uint8_t)(ONEWIRE_PORT | busmask);           \
+  /* configure as input */                                    \
   ONEWIRE_DDR = (uint8_t)(ONEWIRE_DDR & (uint8_t)~busmask);
 
-#define OW_CONFIG_OUTPUT(busmask)			\
-  /* configure as output */				\
+#define OW_CONFIG_OUTPUT(busmask)                             \
+  /* configure as output */                                   \
   ONEWIRE_DDR = (uint8_t)(ONEWIRE_DDR | busmask);
 
-#define OW_LOW(busmask)					\
-  /* drive pin low */					\
+#define OW_LOW(busmask)                                       \
+  /* drive pin low */                                         \
   ONEWIRE_PORT = (uint8_t)(ONEWIRE_PORT & (uint8_t)~busmask);
 
-#define OW_HIGH(busmask)				\
-  /* drive pin high */					\
+#define OW_HIGH(busmask)                                      \
+  /* drive pin high */                                        \
   ONEWIRE_PORT = (uint8_t)(ONEWIRE_PORT | busmask);
 
-#define OW_PULLUP(busmask)				\
-  /* pull up resistor */				\
+#define OW_PULLUP(busmask)                                    \
+  /* pull up resistor */                                      \
   ONEWIRE_PORT = (uint8_t)(ONEWIRE_PORT | busmask);
 
-#define OW_GET_INPUT(busmask)				\
+#define OW_GET_INPUT(busmask)                                 \
   (ONEWIRE_PIN & busmask)
 
 /* symbolic names for the restriction of the list comamnd to certain types.
- * These values are used only to filter the output of the list command */
-#define OW_LIST_TYPE_ALL		0
-#define OW_LIST_TYPE_TEMP_SENSOR	1
-#define OW_LIST_TYPE_EEPROM		2
+ * these values are used only to filter the output of the list command */
+#define OW_LIST_TYPE_ALL            0
+#define OW_LIST_TYPE_TEMP_SENSOR    1
+#define OW_LIST_TYPE_EEPROM         2
 
 
-/* structures */
-typedef struct {
-    union {
-        uint64_t raw;
-        uint8_t bytewise[8];
-        struct {
-            uint8_t family;
-            uint8_t code[6];
-            uint8_t crc;
-        };
+/*
+ * structures
+ */
+typedef struct
+{
+  union
+  {
+    uint64_t raw;
+    uint8_t bytewise[8];
+    struct
+    {
+      uint8_t family;
+      uint8_t code[6];
+      uint8_t crc;
     };
+  };
 } ow_rom_code_t;
 
-typedef struct {
-    union {
-        uint8_t bytewise[9];
-        struct {
-            union {
-                struct {
-                    uint8_t temperature_low;
-                    uint8_t temperature_high;
-                };
-                uint16_t temperature;
-            };
-
-            uint8_t th;
-            uint8_t tl;
-            uint8_t reserved1;
-            uint8_t reserved2;
-            uint8_t count_remain;
-            uint8_t count_per_c;
-            uint8_t crc;
+typedef struct
+{
+  union
+  {
+    uint8_t bytewise[9];
+    struct
+    {
+      union
+      {
+        struct
+        {
+          uint8_t temperature_low;
+          uint8_t temperature_high;
         };
+        uint16_t temperature;
+      };
+
+      uint8_t th;
+      uint8_t tl;
+      uint8_t reserved1;
+      uint8_t reserved2;
+      uint8_t count_remain;
+      uint8_t count_per_c;
+      uint8_t crc;
     };
+  };
 } ow_temp_scratchpad_t;
 
-/*Polling Support*/
+
+/*
+ * polling support
+ */
 #ifdef ONEWIRE_POLLING_SUPPORT
-typedef struct {
-	/*May be just store the code and calculate the crc with each call + hardcode the family, would save 16bytes*/
-	ow_rom_code_t ow_rom_code;
-	/*We just store the temperature in order to keep memory footfrint as low as possible. We store in deci degrees (DD) => 36.4° == 364*/
-	int16_t temp;
-	uint16_t read_delay;   /*time between polling the sensor*/
-	uint8_t convert_delay; /*we need to wait 800ms for the sensor to convert the temperatures*/
-	uint8_t converted; /*when this is set, we will wait convert_delay to be 0 and then read the scratchpad*/
-	uint8_t present; /*this is set during discovery - all sensors with present == 0 will be deleted after the discovery*/
+typedef struct
+{
+  //FIXME: just storing the code and calculate the crc with each call and
+  //       hardcoding the family, would save 16bytes
+  ow_rom_code_t ow_rom_code;
+  /* just storing the temperature in order to keep memory footfrint as low as
+   * possible. storing temperature in deci degrees (DD) => 36.4° == 364 */
+  int16_t temp;
+  /* time between polling the sensor */
+  uint16_t read_delay;
+  /* need to wait 800ms for the sensor to convert the temperatures */
+  uint8_t convert_delay;
+  /* when this is set, we will wait convert_delay to be 0 and then read the
+   * scratchpad */
+  uint8_t converted;
+  /* this is set during discovery - all sensors with present == 0 will be
+   * deleted after the discovery */
+  uint8_t present;
 } ow_sensor_t;
-/* */
+
 
 extern ow_sensor_t ow_sensors[OW_SENSORS_COUNT];
 #endif
 
-/* global variables */
-typedef struct {
-    uint8_t lock;
-    int8_t last_discrepancy;
+/*
+ * global variables
+ */
+typedef struct
+{
+  uint8_t lock;
+  int8_t last_discrepancy;
 #ifdef ONEWIRE_DS2502_SUPPORT
-    int8_t list_type;
+  int8_t list_type;
 #endif
-    ow_rom_code_t current_rom;
+  ow_rom_code_t current_rom;
 #if ONEWIRE_BUSCOUNT > 1
-    uint8_t bus;
+  uint8_t bus;
 #endif
 } ow_global_t;
 
 extern ow_global_t ow_global;
 
-/* prototypes */
+/*
+ * prototypes
+ */
 void onewire_init(void);
 
-/* low level functions */
+
+/*
+ * low level functions
+ */
 uint8_t reset_onewire(uint8_t busmask);
+
 void ow_write_0(uint8_t busmask);
+
 #define ow_write_1(busmask) ow_read(busmask)
 
 void ow_write(uint8_t busmask, uint8_t value);
+
 void ow_write_byte(uint8_t busmask, uint8_t value);
+
 uint8_t ow_read(uint8_t busmask);
+
 uint8_t ow_read_byte(uint8_t busmask);
 
-/* high level functions */
+/*
+ * high level functions
+ */
 
 /* tries to read the code of the attached device, if there is only one
  *
@@ -227,10 +279,11 @@ uint8_t ow_read_byte(uint8_t busmask);
  *   -1: no presence pulse has been detected, no device connected?
  *   -2: crc check failed, multiple devices on the same bus? use search_rom()
  */
-int8_t ow_read_rom(ow_rom_code_t *rom);
+int8_t ow_read_rom(ow_rom_code_t * rom);
 
-/* skip rom addressing, only works if there is exactly one device on the bus or
- * if this command should go to ALL onewire devices!
+
+/* skip rom addressing, only works if there is exactly one device on the bus
+ * or if this command should go to ALL onewire devices!
  *
  * return values:
  *    1: skip rom command issued successfully
@@ -238,13 +291,15 @@ int8_t ow_read_rom(ow_rom_code_t *rom);
  */
 int8_t ow_skip_rom(void);
 
+
 /* address one sensor.
  *
  * return values:
  *    1: match rom command issued successfully
  *   -1: no presence pulse has been detected, no device connected?
  */
-int8_t ow_match_rom(ow_rom_code_t *rom);
+int8_t ow_match_rom(ow_rom_code_t * rom);
+
 
 /* detect rom codes on the onewire bus. call ow_search_rom_first() for initial
  * search, ow_search_rom_next() for next device, until 0 is returned.
@@ -260,9 +315,7 @@ int8_t ow_search_rom(uint8_t busmask, uint8_t first);
 
 
 /*
- *
  * temperature functions (DS1820, DS1822)
- *
  */
 
 /* check if a node is a temperature sensor
@@ -271,12 +324,13 @@ int8_t ow_search_rom(uint8_t busmask, uint8_t first);
  *  0: other node
  *  1: temperature sensor (DS1820 or DS1822)
  */
-int8_t ow_temp_sensor(ow_rom_code_t *rom);
+int8_t ow_temp_sensor(ow_rom_code_t * rom);
 
-/* start temperature conversion on sensor with given id, or to all sensors (via
- * skip_rom) if NULL.  If wait is set, busy-loop until conversion is done on all
- * adressed sensors.  If rom is not NULL, the rom family code is checked for known
- * temperature sensors.
+
+/* start temperature conversion on sensor with given id, or to all sensors
+ * (via skip_rom) if NULL.  If wait is set, busy-loop until conversion is
+ * done on all adressed sensors.  If rom is not NULL, the rom family code is
+ * checked for known temperature sensors.
  *
  * return values:
  *    0: conversion initiated (but not done)
@@ -286,11 +340,12 @@ int8_t ow_temp_sensor(ow_rom_code_t *rom);
  */
 #define ow_temp_start_convert_wait(rom) ow_temp_start_convert(rom, 1)
 #define ow_temp_start_convert_nowait(rom) ow_temp_start_convert(rom, 0)
-int8_t ow_temp_start_convert(ow_rom_code_t *rom, uint8_t wait);
+int8_t ow_temp_start_convert(ow_rom_code_t * rom, uint8_t wait);
+
 
 /* read scratchpad memory of sensor with given id (may be null, if only one
- * sensor is connected). If rom is not NULL, the rom family code is checked for
- * known temperature sensors.
+ * sensor is connected). If rom is not NULL, the rom family code is checked
+ * for known temperature sensors.
  *
  * return values:
  *    1: memory read
@@ -298,9 +353,12 @@ int8_t ow_temp_start_convert(ow_rom_code_t *rom, uint8_t wait);
  *   -2: crc check failed, multiple devices on the same bus?
  *   -3: family code is unknown
  */
-int8_t ow_temp_read_scratchpad(ow_rom_code_t *rom, ow_temp_scratchpad_t *scratchpad);
+int8_t ow_temp_read_scratchpad(ow_rom_code_t * rom,
+                               ow_temp_scratchpad_t * scratchpad);
 
-/* check for parasite powered devices, if rom is NULL, all devices are queried.
+
+/* check for parasite powered devices, if rom is NULL, all devices are
+ * queried.
  *
  * return values:
  *    0: device(s) parasite powered
@@ -308,7 +366,7 @@ int8_t ow_temp_read_scratchpad(ow_rom_code_t *rom, ow_temp_scratchpad_t *scratch
  *   -1: no presence pulse has been detected, no device connected?
  *   -2: given rom code is no temperature sensor
  */
-int8_t ow_temp_power(ow_rom_code_t *rom);
+int8_t ow_temp_power(ow_rom_code_t * rom);
 
 
 /* return normalized temperature for device
@@ -317,37 +375,36 @@ int8_t ow_temp_power(ow_rom_code_t *rom);
  * int16_t, 8.8 fixpoint value
  * 0xffff on error (eg unknown device)
  */
-int16_t ow_temp_normalize(ow_rom_code_t *rom, ow_temp_scratchpad_t *sp);
+int16_t ow_temp_normalize(ow_rom_code_t * rom, ow_temp_scratchpad_t * sp);
 
 
 /*
- *
  * DS2502 data functions
- *
  */
+
 
 /* check if a node is an eeprom
  *
  * return values:
- *  0: other node
- *  1: eeprom
+ *    0: other node
+ *    1: eeprom
  */
-int8_t ow_eeprom(ow_rom_code_t *rom);
+int8_t ow_eeprom(ow_rom_code_t * rom);
+
 
 /* read 6 bit (48 byte) of eeprom memory
  *
  * return values:
- * 0: read successful
- * -1: no device responded
- * -2: crc error
- * -3: unknown rom family code
+ *    0: read successful
+ *   -1: no device responded
+ *   -2: crc error
+ *   -3: unknown rom family code
  */
-int8_t ow_eeprom_read(ow_rom_code_t *rom, void *data);
+int8_t ow_eeprom_read(ow_rom_code_t * rom, void *data);
+
 
 /*
- *
  * ECMD functions
- *
  */
 
 /* parse an onewire rom address in cmd string
@@ -355,10 +412,10 @@ int8_t ow_eeprom_read(ow_rom_code_t *rom, void *data);
  * *rom: contains parsed rom adress after sucessul parsing
  *
  * return values:
- * 0: parsing successful
- * -1: string could not be parsed
+ *    0: parsing successful
+ *   -1: string could not be parsed
  */
-int8_t parse_ow_rom(char *cmd, ow_rom_code_t *rom);
+int8_t parse_ow_rom(char *cmd, ow_rom_code_t * rom);
 
 
 /* list onewiredevices of requested type on all OW-buses */


### PR DESCRIPTION
only the timing of each bit/bus reset needs irq protection.
responsiveness of the system should be highly improved.

the code has been tested in several configurations and environments.
please pull.
