### PR TITLE
set and compare timer with the same variable

### DIFF
--- a/control6/lang.d/20_timers.m4
+++ b/control6/lang.d/20_timers.m4
@@ -7,19 +7,19 @@ divert(timer_divert) -1,dnl
 divert(old_divert)dnl
 define(`timer_$1', timer_count)dnl
 define(`timer_count', incr(timer_count))')')
-define(`TIMER_START', `TIMER_NEW($1)  timers[timer_$1] = currentTime;')
+define(`TIMER_START', `TIMER_NEW($1)  timers[timer_$1] = current_time;')
 
 define(`TIMER', `ifdef(`timer_used', `', `dnl
 define(`old_divert', divnum)dnl
-divert(globals_divert)uint32_t currentTime;
+divert(globals_divert)uint32_t current_time;
 #ifndef CLOCK_SUPPORT
 #error Please define clock support
 #endif
 
-divert(normal_start_divert)currentTime = clock_get_uptime();
+divert(normal_start_divert)current_time = clock_get_uptime();
 define(`timer_used')dnl
 divert(old_divert)')dnl
-(currentTime - timers[timer_$1])')
+(current_time - timers[timer_$1])')
 
 define(`TIMER_WAIT', `PT_WAIT_UNTIL(pt, TIMER($1) >= $2);')
 define(`WAIT', `TIMER_START(`timer_on_'action_thread_ident); TIMER_WAIT(`timer_on_'action_thread_ident, ($1));')


### PR DESCRIPTION
currentTime (was act_time) is set at the beginning of the control6 mainloop.
If the uptime now changes (++) during the control6 mainloop, the timers will
consequently be initialized with uptime-1.
This causes the wait/delay condition PT_WAIT_UNTIL(pt, TIMER($1) >= $2)
to fail since the resulting expression of TIMER($1) will be

uptime-1 - uptime

which is of course -1.
Due to the unsignedness of currentTime/uptime this results in

PT_WAIT_UNTIL(pt, 2^32 >= $2)

which is true (at least until 2038). So the THREAD won't be delayed as
expected.

Signed-off-by: Maximilian Güntner maximilian.guentner@gmail.com
