### PR TITLE
Unify bootloader startup between TFTPOMATIC and BOOTP

### DIFF
--- a/services/tftp/tftp-bootload.c
+++ b/services/tftp/tftp-bootload.c
@@ -219,11 +219,7 @@ tftp_handle_packet(void)
 	if(uip_datalen() < TFTP_BLOCK_SIZE + 4) {
 	    uip_udp_conn->appstate.tftp.finished = 1;
 
-#           ifdef TFTPOMATIC_SUPPORT
             bootload_delay = 1;                      /* ack, then start app */
-#           else
-            bootload_delay = CONF_BOOTLOAD_DELAY;    /* Restart bootloader. */
-#           endif
 
             debug_putstr("end\n");
 	}


### PR DESCRIPTION
...application code by setting bootload_delay to 1.

Previously, there used to be a distinction between TFTPOMATIC (bootloader with fixed parameters), where the
  app was immediately started, and bootloader via bootp, where the app was started after CONF_BOOTLOADER_DELAY.
  However, there appears to be no functional reason for that and I suspect this was unintentional --
  CONF_BOOTLOADER_DELAY is supposed to be the fallback delay before the app is started when the bootp/tftp
  process _fails_ for some reason. The comment after the #else clause hints at that
  ("Restart bootloader", which it doesn't, it also launches the app, just after 5s delay...)
