### PR TITLE
__startup() moved to init3

### DIFF
--- a/ethersex.c
+++ b/ethersex.c
@@ -55,7 +55,7 @@ uint8_t mcusr_mirror __attribute__ ((section (".noinit")));
 
 void __start (void) __attribute__ ((naked))
                     __attribute__ ((used))
-                    __attribute__ ((section (".init1")));
+                    __attribute__ ((section (".init3")));
 void __start ()
 {
   /* Clear the watchdog register to avoid endless wdreset loops */


### PR DESCRIPTION
Reset of MCUSR does not work as expected in init1, because r1 is not initialized to zero (will be done in init2). Timer registers are reset, but only because wdt_disable() is generated inline and has a "clr r1" at the end.
init3 is a better place to live for __startup().
