### PR TITLE
initialize the variable argument list properly

### DIFF
--- a/protocols/httplog/httplog.c
+++ b/protocols/httplog/httplog.c
@@ -161,6 +161,7 @@ httplog(const char *message, ...)
   if (result)
   {
     va_list va;
+    va_start(va, message);
     vsnprintf(httplog_tmp_buf, HTTPLOG_BUFFER_LEN, message, va);
     va_end(va);
     httplog_tmp_buf[HTTPLOG_BUFFER_LEN - 1] = 0;
@@ -177,6 +178,7 @@ httplog_P(const char *message, ...)
   if (result)
   {
     va_list va;
+    va_start(va, message);
     vsnprintf_P(httplog_tmp_buf, HTTPLOG_BUFFER_LEN, message, va);
     va_end(va);
     httplog_tmp_buf[HTTPLOG_BUFFER_LEN - 1] = 0;


### PR DESCRIPTION
a va_list needs to be initialized with va_start()
before it can be used.

Signed-off-by: Maximilian Güntner maximilian.guentner@gmail.com
