### PR TITLE
- itoa_fixedpoint would not create a leading 0 for decimal-only values

### DIFF
--- a/core/util/fixedpoint.c
+++ b/core/util/fixedpoint.c
@@ -45,7 +45,7 @@ uint8_t itoa_fixedpoint(int16_t n, uint8_t fixeddigits, char s[])
     {
         /* generate digits in reverse order */
         s[i++] = n % 10 + '0';   /* get next digit */
-        if (i == fixeddigits && fixeddigits != 0)
+        if (i == fixeddigits)
             s[i++]='.';
     }
     while ((n /= 10) > 0);     /* delete it */


### PR DESCRIPTION
itoa_fixedpoint(-9,1,buff)

  Before: -.9
  After: -0.9
