### PR TITLE
delay the discovery of sensors after powerup

### DIFF
--- a/hardware/onewire/onewire.c
+++ b/hardware/onewire/onewire.c
@@ -89,9 +89,6 @@ onewire_init(void)
   ow_names_restore();
 #endif
 
-#if ONEWIRE_POLLING_SUPPORT
-  ow_periodic();
-#endif
 }
 
 


### PR DESCRIPTION
Calling ow_periodic() from onewire_init() only works when
DEBUG_OW_POLLING is enabled. OW_DEBUG_POLL inside ow_periodic()
delays the discovery for some time and the discovery then works.
Without DEBUG_OW_POLLING, the discovery is not being delayed and
fails for some reason.
To solve this, ow_periodic() will be first called after 50*20ms = 1s.

Signed-off-by: Maximilian Güntner maximilian.guentner@gmail.com
