### PR TITLE
fix DST offset calculation

### DIFF
--- a/services/clock/clock_ecmd_date.c
+++ b/services/clock/clock_ecmd_date.c
@@ -44,7 +44,7 @@
 #define _TZ_FORMAT_STRING " +%d:%02d"
 #define _TZ_OFFSET        (TZ_OFFSET)
 #define _DST_OFFSET       (DST_OFFSET)
-#elif _DST_OFFSET > 0
+#elif DST_OFFSET > 0
 #define _TZ_FORMAT_STRING " +%d:%02d"
 #define _TZ_OFFSET        (TZ_OFFSET)
 #define _DST_OFFSET       (DST_OFFSET)
@@ -58,7 +58,7 @@ static int16_t
 generate_time_string(clock_datetime_t * date, char *output, uint16_t len)
 {
   const char *dow = clock_dow_string(date->dow);
-  div_t tz = div(_TZ_OFFSET + (date->isdst ? DST_OFFSET : 0), 60);
+  div_t tz = div(_TZ_OFFSET + (date->isdst ? _DST_OFFSET : 0), 60);
   return ECMD_FINAL(snprintf_P(output, len,
                                PSTR("%c%c%c %02d.%02d.%04d %02d:%02d:%02d"
                                     _TZ_FORMAT_STRING


### PR DESCRIPTION
Due to a typo the DST offset calculation for TZ = 0:00 was not always working.
