### PR TITLE
add a network activity watchdog

### DIFF
--- a/config.in
+++ b/config.in
@@ -330,6 +330,7 @@ source services/lome6/config.in
 source services/projectors/sanyoZ700/config.in
 source services/freqcount/config.in
 source services/tanklevel/config.in
+source services/net_activity_watchdog/config.in
 endmenu
 
 ###############################################################################

--- a/doc/Configure.help
+++ b/doc/Configure.help
@@ -964,6 +964,10 @@ NET_ACTIVITY_WATCHDOG_SUPPORT
 
   Watches for received network packets. If none were received within
   60s, reboots the MCU.
+  
+  Be aware that the reboot method is different in DEBUG mode: normally, a
+  watchdog reset is triggered by an endless loop; in DEBUG however, a jump to
+  address 0 is taken.
 
 Simple Network Managment Protocol support (snmp)
 SNMP_SUPPORT

--- a/doc/Configure.help
+++ b/doc/Configure.help
@@ -965,9 +965,9 @@ NET_ACTIVITY_WATCHDOG_SUPPORT
   Watches for received network packets. If none were received within
   60s, reboots the MCU.
   
-  Be aware that the reboot method is different in DEBUG mode: normally, a
-  watchdog reset is triggered by an endless loop; in DEBUG however, a jump to
-  address 0 is taken.
+  Be aware that the reboot method is different in DEBUG and TEENSY_SUPPORT
+  mode: normally, a watchdog reset is triggered by an endless loop; in DEBUG
+  and TEENSY_SUPPORT however, a jump to address 0 is taken.
 
 Simple Network Managment Protocol support (snmp)
 SNMP_SUPPORT

--- a/doc/Configure.help
+++ b/doc/Configure.help
@@ -957,6 +957,14 @@ WATCHCAT_SUPPORT
   For example you can configure a ECMD to be sent to another host if
   there is a falling edge on PA1.
 
+Watch for received network packets (and reboot if none)
+NET_ACTIVITY_WATCHDOG_SUPPORT
+  Depends on:
+   * Networking support (UIP_SUPPORT)
+
+  Watches for received network packets. If none were received within
+  60s, reboots the MCU.
+
 Simple Network Managment Protocol support (snmp)
 SNMP_SUPPORT
   Depends on:

--- a/protocols/uip/uip.c
+++ b/protocols/uip/uip.c
@@ -91,6 +91,10 @@
 #include "uip_neighbor.h"
 #endif /* UIP_CONF_IPV6 */
 
+#ifdef NET_ACTIVITY_WATCHDOG_SUPPORT
+#include "services/net_activity_watchdog/net_activity_watchdog.h"
+#endif
+
 #include <string.h>
 
 #define noinline __attribute__((noinline))
@@ -825,6 +829,11 @@ uip_process(u8_t flag)
 
   /* This is where the input processing starts. */
   UIP_STAT(++uip_stat.ip.recv);
+
+#ifdef NET_ACTIVITY_WATCHDOG_SUPPORT
+  /* we received something... */
+  net_activity_watchdog_feed();
+#endif
 
   /* Start of IP input header processing code. */
 

--- a/services/Makefile
+++ b/services/Makefile
@@ -25,6 +25,7 @@ SUBSUBDIRS += services/curtain
 SUBSUBDIRS += services/glcdmenu
 SUBSUBDIRS += services/lome6
 SUBSUBDIRS += services/projectors/sanyoZ700
+SUBSUBDIRS += services/net_activity_watchdog
 
 # generic fluff
 include $(TOPDIR)/scripts/rules.mk

--- a/services/net_activity_watchdog/Makefile
+++ b/services/net_activity_watchdog/Makefile
@@ -1,0 +1,10 @@
+TOPDIR ?= ../..
+include $(TOPDIR)/.config
+
+$(NET_ACTIVITY_WATCHDOG_SUPPORT)_SRC += services/net_activity_watchdog/net_activity_watchdog.c
+
+##############################################################################
+# generic fluff
+include $(TOPDIR)/scripts/rules.mk
+
+##############################################################################

--- a/services/net_activity_watchdog/config.in
+++ b/services/net_activity_watchdog/config.in
@@ -1,0 +1,5 @@
+dep_bool_menu "Watch incoming network packets (and reboot if none)" NET_ACTIVITY_WATCHDOG_SUPPORT $UIP_SUPPORT
+	if [ "$NET_ACTIVITY_WATCHDOG_SUPPORT" = "y" ]; then
+		int "Inactivity timeout in minutes" NET_ACTIVITY_WATCHDOG_INTERVAL 31
+	fi
+endmenu

--- a/services/net_activity_watchdog/net_activity_watchdog.c
+++ b/services/net_activity_watchdog/net_activity_watchdog.c
@@ -38,7 +38,14 @@ void net_activity_watchdog_periodic(void)
 		if (net_activity_detected) {
 			net_activity_detected = false;
 		} else {
+			/* be careful, the reboot method is different in DEBUG */
+#ifdef DEBUG
+			/* jump to address 0, since there is no watchdog in DEBUG */
+			void (*reboot)(void) = 0;
+			reboot();
+#else
 			while(1); /* let the watchdog reboot us */
+#endif
 		}
 	};
 }

--- a/services/net_activity_watchdog/net_activity_watchdog.c
+++ b/services/net_activity_watchdog/net_activity_watchdog.c
@@ -1,0 +1,50 @@
+/*
+ *
+ * Copyright (c) 2013 by Alexander Wuerstlein <arw@arw.name>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License (either version 2 or
+ * version 3) as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ * For more information on the GPL, please go to:
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#include "config.h"
+#include "net_activity_watchdog.h"
+#include <stdbool.h>
+
+static volatile bool net_activity_detected = true;
+static int minutes;
+
+void net_activity_watchdog_feed(void)
+{
+	net_activity_detected = true;
+}
+
+void net_activity_watchdog_periodic(void)
+{
+	if (++minutes >= NET_ACTIVITY_WATCHDOG_INTERVAL) {
+		minutes = 0;
+		if (net_activity_detected) {
+			net_activity_detected = false;
+		} else {
+			while(1); /* let the watchdog reboot us */
+		}
+	};
+}
+
+/*
+  -- Ethersex META --
+  header(services/net_activity_watchdog/net_activity_watchdog.h)
+  timer(300, net_activity_watchdog_periodic())
+*/

--- a/services/net_activity_watchdog/net_activity_watchdog.c
+++ b/services/net_activity_watchdog/net_activity_watchdog.c
@@ -52,7 +52,7 @@ void net_activity_watchdog_periodic(void)
 #endif /* DEBUG */
 #endif /* TEENSY_SUPPORT */
 		}
-	};
+	}
 }
 
 /*

--- a/services/net_activity_watchdog/net_activity_watchdog.h
+++ b/services/net_activity_watchdog/net_activity_watchdog.h
@@ -1,0 +1,33 @@
+/*
+ *
+ * Copyright (c) 2013 by Alexander Wuerstlein <arw@arw.name>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License (either version 2 or
+ * version 3) as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ * For more information on the GPL, please go to:
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#ifndef _NET_ACTIVITY_WATCHDOG_H
+#define _NET_ACTIVITY_WATCHDOG_H
+#include <stdbool.h>
+
+/* Feed the watchdog. If the watchdog is not regularly fed with
+ * some network packets, it will get angry and reboot the MCU. */
+void net_activity_watchdog_feed(void);
+
+/* periodically called by static cron entry */
+void net_activity_watchdog_periodic(void);
+
+#endif /* _NET_ACTIVITY_WATCHDOG_H */


### PR DESCRIPTION
The net_activity_watchdog looks out for received network packets. If no
packets are received within a configurable interval (default 31min), the
watchdog resets the MCU.
