### PR TITLE
scripts/size: dont throw an error, if data-section is empty

### DIFF
--- a/scripts/size
+++ b/scripts/size
@@ -7,6 +7,7 @@ maxper=30
 for i in ".text" ".data" ".bss"
 do
 	val[$j]=$(avr-size -A $1 | ${SED} -e "/$i/!d;s/^$i *//g;s/^\([^ ]*\).*/\1/")
+	[ -z "${val[$j]}" ] && val[$j]=0	# e.g. no .data-section
 	let j=$j+1
 done
 


### PR DESCRIPTION
when data-section is empty, the size-script cannot build a valid variable and later calculations throw mysterious errors. correct this with at least setting the size-var to 0.
