### PR TITLE
Artnet: Use uip_ipaddr_t instead of uint64 + uip_ipaddr_copy instead of ...

### DIFF
--- a/protocols/artnet/artnet.h
+++ b/protocols/artnet/artnet.h
@@ -208,7 +208,7 @@ struct artnet_dmx
   uint16_t universe;
   uint8_t lengthHi;
   uint8_t length;
-  uint8_t dataStart;
+  uint8_t dataStart[];
 };
 
 void artnet_init(void);


### PR DESCRIPTION
Code readability improvement and ipv6 requirement:
- Use uip_ipaddr_t instead of uint64
- Use "uip_ipaddr_copy(target,all_ones_addr)" to address all hosts in a subnet (aka broadcast in ipv4, multicast in ipv6)
- Use "uip_ipaddr_copy" instead of direct assignments
