### PR TITLE
Support for Cygwin

### DIFF
--- a/scripts/osdefaults.sh
+++ b/scripts/osdefaults.sh
@@ -21,6 +21,11 @@ case "$THIS_OS" in
 		SED=gsed
 		M4=m4
 		;;
+	CYGWIN*)
+		AWK=awk
+		SED=sed
+		M4=m4
+		;;
 	*)
 		echo "$0: Unknown Platform. Trying to use GNU-userland." >2
 		;;


### PR DESCRIPTION
On Cygwin based systems the GNU tools are named without the prefix 'g'.
