### PR TITLE
itoa_fixedpoint: combined digit loop

### DIFF
--- a/core/util/fixedpoint.c
+++ b/core/util/fixedpoint.c
@@ -41,7 +41,7 @@ itoa_fixedpoint(int16_t n, uint8_t fixeddigits, char s[])
   }
 
   /* Number of digits to output */
-  /* if fixeddigits, then output at least fixeddigits + 1 digits */
+  /* Output at least fixeddigits + 1 digits */
   uint8_t digits = 1;
   int16_t m = 1;
   while ((m <= n / 10) || (digits < fixeddigits + 1))


### PR DESCRIPTION
Hi,

I have combined the leading-0, normal digits, and fixeddigits code into one loop.
This reduces code size by ~75 bytes.

I have tested the code using a test main program, not in ethersex.

Thanks,
    John

```
#include <stdio.h>
#include "fixedpoint.h"

void
test (int n)
{
    int digits, len;
    char s[20];
    printf("n=%d : ", n);
    for (digits = 0; digits <= 4; digits++) {
        len = itoa_fixedpoint (n, digits, s);
        printf("%d => '%*s', ", digits, len, s);
    }
    printf("\n");
}

main ()
{
test(-1);
test(0);
test(1);
test(10);
test(100);
test(1000);
test(9999);
test(10000);
test(10001);
test(32767);
test(-32767);
}
```
