### PR TITLE
e6 issue 344 - change and cleanup for proper handling of the different debug output choices

### DIFF
--- a/config.in
+++ b/config.in
@@ -94,16 +94,68 @@ fi
 	define_string GIT_VERSION "$(scripts/get-git-version)"
 
 	bool 'Debug: Discard some packets' DEBUG_DISCARD_SOME
-	dep_bool_menu "Enable Debugging" DEBUG y
-		choice 'Debug USART channel' "$(usart_choice DEBUG)" 0
-		usart_process_choice DEBUG
-		int "UART Baudrate" DEBUG_BAUDRATE 115200
-		dep_bool 'Use SYSLOG instead UART' DEBUG_USE_SYSLOG $SYSLOG_SUPPORT $DEBUG
-		dep_bool 'Software Uart (Output only)' SOFT_UART_SUPPORT $DEBUG $ARCH_AVR
-		comment  'Debugging Flags'
-		dep_bool 'Hooks' DEBUG_HOOK $DEBUG
-		dep_bool 'Reset Reason' DEBUG_RESET_REASON $DEBUG
-	endmenu
+  dep_bool_menu "Enable Debugging" DEBUG y
+      comment "Debugging output"
+      usart_count_used
+      if [ "$DEBUG_SERIAL_USART_SUPPORT" = y \
+          -o "$ECMD_SERIAL_USART_SUPPORT" = y \
+        -o $USARTS -gt $USARTS_USED ]; then
+        debug_output_choices="USART	usart "
+        debug_output_default="USART"
+      else
+        comment "USART (RS232/RS485) not available. No free usart. ($USARTS_USED/$USARTS)"
+      fi
+    
+      if [ "$ARCH_AVR" = y ]; then
+        debug_output_choices+="Software-UART soft_uart "
+        test -n "$debug_output_default" || debug_output_default="Software-UART"
+      fi
+      
+      if [ "$SYSLOG_SUPPORT" = y ]; then
+        debug_output_choices+="SYSLOG syslog "
+        test -n "$debug_output_default" || debug_output_default="SYSLOG"
+      fi
+
+      if [ "$DEBUG" = y -a -n "$debug_output_choices" ]; then
+      choice 'Debug output channel' \
+        "$debug_output_choices" \
+        "$debug_output_default" DEBUG_OUTPUT
+      fi
+
+    case "$DEBUG_OUTPUT" in
+      "usart")
+        define_bool DEBUG_SERIAL_USART_SUPPORT $DEBUG
+        define_bool SOFT_UART_SUPPORT n
+        define_bool DEBUG_USE_SYSLOG n
+        ;;
+      "soft_uart")
+        define_bool SOFT_UART_SUPPORT $DEBUG $ARCH_AVR
+        define_bool DEBUG_SERIAL_USART_SUPPORT n
+        define_bool DEBUG_USE_SYSLOG n				
+        ;;
+      "syslog")
+        define_bool DEBUG_USE_SYSLOG $DEBUG $SYSLOG_SUPPORT 
+        define_bool DEBUG_SERIAL_USART_SUPPORT n
+        define_bool SOFT_UART_SUPPORT n
+        ;;
+      *)
+        define_bool DEBUG_USE_SYSLOG $DEBUG n 
+        define_bool DEBUG_SERIAL_USART_SUPPORT n
+        define_bool SOFT_UART_SUPPORT n
+        ;;
+    esac
+
+    if [ "$DEBUG_SERIAL_USART_SUPPORT" = y ]; then
+      choice 'Debug USART channel' "$(usart_choice DEBUG)"
+      usart_process_choice DEBUG
+      int "USART Baudrate" DEBUG_BAUDRATE 115200
+    elif [ "$SOFT_UART_SUPPORT" = y ]; then
+      int "Software-UART Baudrate" DEBUG_BAUDRATE 19200
+    fi
+    comment  'Debugging Flags'
+    dep_bool 'Hooks' DEBUG_HOOK $DEBUG
+    dep_bool 'Reset Reason' DEBUG_RESET_REASON $DEBUG
+  endmenu
 
 	source core/config.in
 	source core/crypto/config.in

--- a/core/debug.h
+++ b/core/debug.h
@@ -26,7 +26,11 @@
 #include <stdio.h>
 #include <avr/pgmspace.h>
 #include "core/global.h"
+
+#ifdef DEBUG_USE_SYSLOG
+#include "protocols/syslog/syslog.h"
 #include "protocols/syslog/syslog_debug.h"
+#endif
 
 #define noinline __attribute__((noinline))
 
@@ -50,7 +54,6 @@
 #define debug_putchar(ch) debug_uart_put (ch, NULL)
 #define debug_putstr(s) debug_uart_putstr(s)
 #endif /* not DEBUG_USE_SYSLOG */
-
 #else /* not DEBUG */
 #define debug_init(...) do { } while(0)
 #define debug_printf(s, args...) do {} while(0)

--- a/core/soft_uart.c
+++ b/core/soft_uart.c
@@ -18,10 +18,15 @@
  * http://www.gnu.org/copyleft/gpl.html
  */
 
-#include <stdio.h>
-#include "core/debug.h"
+#include <stdint.h>
+
 #include "config.h"
 
+#include "core/soft_uart.h"
+
+/*
+ * ref. Atmel application note AVR305
+ */
 void 
 soft_uart_putchar(uint8_t c)
 {
@@ -64,7 +69,5 @@ soft_uart_putchar(uint8_t c)
                  [port] "I" (_SFR_IO_ADDR(SOFT_UART_PORT(SOFT_UART_TX_PORT))), 
                  [pin] "I" (SOFT_UART_TX_PIN), [delay] "M" (BIT_DELAY)
                );
-  
-
 }
 

--- a/core/soft_uart.h
+++ b/core/soft_uart.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright(c) 2009 by Christian Dietrich <stettberger@dokucode.de.de>
+ * Copyright(c) 2014 by Michael Brakemeier <michael@brakemeier.de>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 or later
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ * For more information on the GPL, please go to:
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+
+#ifndef _SOFT_UART_H
+#define _SOFT_UART_H
+
+#include <stdint.h>
+
+void soft_uart_putchar(uint8_t c);
+
+#endif /* _SOFT_UART_H */

--- a/scripts/usart-config.sh
+++ b/scripts/usart-config.sh
@@ -1,6 +1,12 @@
 
 get_usart_count() {
-  USARTS=$(( $(echo "#include <avr/io.h>" | avr-gcc -mmcu=$MCU -C -E -dD - | sed -n 's/.* UDR\([0-9]*\).*/\1/p' | sort -n -r | sed -n 1p) + 1 ))
+  local USARTS_NUMTXT=$(echo "#include <avr/io.h>" | avr-gcc -mmcu=$MCU -E -dD - | sed -n 's/.* UDR\([0-9]*\).*/\1/p' | sort -n -r | sed -n 1p)
+
+  if [ "x$USARTS_NUMTXT" == "x" ]; then
+	let USARTS=0
+  else
+	USARTS=$(( ${USARTS_NUMTXT} + 1 ))
+  fi
 }
 
 usart_choice() {
@@ -30,28 +36,11 @@ usart_count_used() {
   # Possible combinations of Debug, Syslog and ECMD.
   # Result is the number of USARTS in use.
   #
-  #      Sys- De-
-  # ECMD log  bug Result
-  #  n    n    n   0
-  #  n    n    y   1
-  #  n    y    n   0 *1
-  #  n    y    y   0
-  #  y    n    n   1
-  #  y    n    y   1
-  #  y    y    n   1 *2
-  #  y    y    y   1
-  #
-  # *1 Syslog without debug should not happen, but can be achieved.
-  # *2 Again invalid syslog/debug combination, ECMD is valid.
-
-  # The two following if statements are position dependent!
-  if [ "$DEBUG" = y ] || [ "$ECMD_SERIAL_USART_SUPPORT" = y ] ; then
+  # Allow parallel usage of debug and ecmd on one port.
+  # If the user configures to different ports, we're lost.
+  if [ "$DEBUG_SERIAL_USART_SUPPORT" = y ] || [ "$ECMD_SERIAL_USART_SUPPORT" = y ] ; then
     USARTS_USED=$(($USARTS_USED + 1))
   fi
-  if [ "$ECMD_SERIAL_USART_SUPPORT" != y ] && [ "$DEBUG_USE_SYSLOG" = y ] && [ "$DEBUG" = y ] ; then
-    USARTS_USED=$(($USARTS_USED - 1))
-  fi
-
   if [ "$DC3840_SUPPORT" = y ]; then
     USARTS_USED=$(($USARTS_USED + 1))
   fi


### PR DESCRIPTION
1. Modified config.in to really reflect the mutual exclusive options for debug output.
2. Modified debug.{c,h} to not generate superfluous code if no USART is uses and to compile without errors for controllers without USART.
3. Modified usart-config.sh to properly detect zero USARTs if a controller has none.
4. General cleanup of #include-directives.

This patch introduces new config symbols. Please regenerate your profiles.

Review and comment please.
