### PR TITLE
vfs_open/vfs_unlink will use the file found first in any VFS device

### DIFF
--- a/core/vfs/vfs.c
+++ b/core/vfs/vfs.c
@@ -74,15 +74,16 @@ vfs_open(const char *filename)
 struct vfs_file_handle_t *
 vfs_create(const char *name)
 {
-  for (uint8_t i = 0; i < VFS_LAST; i++)
+  struct vfs_file_handle_t *fh = NULL;
+  for (uint8_t i = 0; fh == NULL && i < VFS_LAST; i++)
   {
     struct vfs_func_t funcs;
     memcpy_P(&funcs, &vfs_funcs[i], sizeof(struct vfs_func_t));
     if (funcs.create)
-      return funcs.create(name);
+      fh = funcs.create(name);
   }
 
-  return NULL;
+  return fh;
 }
 
 /* flag: 0=read, 1=write, 2=size */


### PR DESCRIPTION
Restored functionality that got lost with 2a8c7990f7dfea68fb7d39553f101cc1ceb5ef7a and f8e76ff37a16a055f035d3a331ad26196491dd67.
