### PR TITLE
Ds1337 fix

### DIFF
--- a/hardware/i2c/master/i2c_ds13x7.c
+++ b/hardware/i2c/master/i2c_ds13x7.c
@@ -1,6 +1,6 @@
 /* 
- * Copyright (c) 2009 by Dirk Tostmann <tostmann@busware.de>
- * Copyright (c) 2010 by Thomas Kaiser
+ * Copyright (c) 2009 Dirk Tostmann <tostmann@busware.de>
+ * Copyright (c) 2010 Thomas Kaiser
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by 
@@ -211,5 +211,5 @@ i2c_ds13x7_init(void)
 /*
   -- Ethersex META --
   header(hardware/i2c/master/i2c_ds13x7.h)
-  ifdef(`conf_CLOCK_SUPPORT',`init(i2c_ds13x7_init)')
+  ifdef(`conf_CLOCK',`init(i2c_ds13x7_init)')
 */

--- a/hardware/i2c/master/i2c_ds13x7.h
+++ b/hardware/i2c/master/i2c_ds13x7.h
@@ -1,6 +1,5 @@
 /*
- *
- * Copyright (c) 2009 by Dirk Tostmann <tostmann@busware.de>
+ * Copyright (c) 2009 Dirk Tostmann <tostmann@busware.de>
  * Copyright (c) 2010 Thomas Kaiser
  *
  * This program is free software; you can redistribute it and/or
@@ -21,35 +20,32 @@
  * http://www.gnu.org/copyleft/gpl.html
  */
 
-#ifndef _I2C_DS13X7_H
-#define _I2C_DS13X7_H
+#ifndef __I2C_DS13X7_H
+#define __I2C_DS13X7_H
 
 #define I2C_SLA_DS13X7 0x68
 
-uint16_t i2c_ds13x7_set(uint8_t reg, uint8_t data);
-uint16_t i2c_ds13x7_get(uint8_t reg);
-
-uint8_t i2c_ds13x7_set_block(uint8_t addr, char *data, uint8_t len);
-uint8_t i2c_ds13x7_get_block(uint8_t addr, char *data, uint8_t len);
-
-void i2c_ds13x7_sync(uint32_t timestamp);
-
-uint32_t  i2c_ds13x7_read(void);
-
-struct ds13x7_reg {
-    uint8_t ch  : 1;
-	uint8_t sec : 7;
-    uint8_t min;
-    uint8_t hour;
-    uint8_t day;
-    uint8_t date;
-    uint8_t century : 1;
-    uint8_t month   : 7;
-    uint8_t year;
-} __attribute__((__packed__));
+struct ds13x7_reg
+{
+  uint8_t sec:7;
+  uint8_t ch:1;
+  uint8_t min;
+  uint8_t hour;
+  uint8_t day;
+  uint8_t date;
+  uint8_t month:7;
+  uint8_t century:1;
+  uint8_t year;
+} __attribute__ ((__packed__));
 
 typedef struct ds13x7_reg ds13x7_reg_t;
 
+uint16_t i2c_ds13x7_set(uint8_t reg, uint8_t data);
+uint16_t i2c_ds13x7_get(uint8_t reg);
+uint8_t i2c_ds13x7_set_block(uint8_t addr, char *data, uint8_t len);
+uint8_t i2c_ds13x7_get_block(uint8_t addr, char *data, uint8_t len);
+void i2c_ds13x7_sync(uint32_t timestamp);
+uint32_t i2c_ds13x7_read(void);
 void i2c_ds13x7_init(void);
 
-#endif /* _I2C_ds13x7_H */
+#endif /* __I2C_ds13x7_H */


### PR DESCRIPTION
A master must signal an end of data to the slave by not generating
an acknowledge bit on the last byte that has been clocked out of
the slave.
