### PR TITLE
Add support for pinout of Arduino I2C-LCD interface

### DIFF
--- a/hardware/lcd/config.in
+++ b/hardware/lcd/config.in
@@ -27,6 +27,10 @@ mainmenu_option next_comment
       dep_bool "Multiple ENABLE support" HD44780_MULTIENSUPPORT $HD44780_DIREKT $HD44780_SUPPORT
       dep_bool "Backlight support" HD44780_BACKLIGHT_SUPPORT $HD44780_SUPPORT
     elif [ "$HD44780_I2CSUPPORT" = "y" ]; then
+      choice 'I2C Pinout PCF LCD'                                \
+                "Pollin                   HD44780_I2C_POLLIN       \
+                 Arduino                  HD44780_I2C_ARDUINO"      \
+                'Pollin'                  HD44780_I2C_TYPE
       dep_bool "Readback support" HD44780_READBACK $HD44780_SUPPORT
       int "PCF8574 Address" HD44780_PCF8574_ADR 32
       define_bool I2C_MASTER_SUPPORT y

--- a/hardware/lcd/hd44780.h
+++ b/hardware/lcd/hd44780.h
@@ -39,6 +39,9 @@
 #define HD44780_SERLCD 17
 #define HD44780_I2CSUPPORT 18
 
+#define HD44780_I2C_POLLIN 1
+#define HD44780_I2C_ARDUINO 2
+
 
 /*Definition for different display types
   Add some new Displays here*/


### PR DESCRIPTION
IIC I2C TWI Serial LCD Module Display Arduino compatible mostly sold over ebay or adafruit has different pinout then the already supported Pollin version.
