### PR TITLE
allow parallel selection of USART for ecmd and debug

### DIFF
--- a/protocols/ecmd/config.in
+++ b/protocols/ecmd/config.in
@@ -17,7 +17,9 @@ dep_bool_menu "ECMD (Ethersex Command) support" ECMD_PARSER_SUPPORT
   dep_bool "Log commands via SYSLOG" ECMD_LOG_VIA_SYSLOG $ECMD_PARSER_SUPPORT $SYSLOG_SUPPORT
   comment "ECMD interfaces"
   usart_count_used
-  if [ "$ECMD_SERIAL_USART_SUPPORT" = y -o $USARTS -gt $USARTS_USED ]; then
+  if [ "$ECMD_SERIAL_USART_SUPPORT" = y \
+    -o "$DEBUG_SERIAL_USART_SUPPORT" = y \
+    -o $USARTS -gt $USARTS_USED ]; then
     dep_bool "USART (RS232/RS485)" ECMD_SERIAL_USART_SUPPORT $ECMD_PARSER_SUPPORT
     if [ "$ECMD_SERIAL_USART_SUPPORT" = y ]; then
       choice '  Ecmd usart select' "$(usart_choice ECMD_SERIAL_USART)"


### PR DESCRIPTION
Allow parallel selection of USART for ECMD and sebug.

Fix issue where parallel selection of USART is possible if ECMD is selected before debug, but not if debug is selected before ECMD.
