### PR TITLE
fixed compiler warning and sd ecmd commands

### DIFF
--- a/hardware/storage/sd_reader/ecmd.c
+++ b/hardware/storage/sd_reader/ecmd.c
@@ -20,6 +20,7 @@
  * http://www.gnu.org/copyleft/gpl.html
  */
 
+#include <stdio.h>
 #include <avr/pgmspace.h>
 
 #include "config.h"


### PR DESCRIPTION
I get this warning when compiling ethersex with sd info and sd dir ecmd commands enabled:

```
hardware/storage/sd_reader/ecmd.c: In function 'parse_cmd_sd_info':
hardware/storage/sd_reader/ecmd.c:41:5: warning: implicit declaration of function 'snprintf_P' [-Wimplicit-function-declaration]
     return ECMD_FINAL(snprintf_P(output, len, PSTR("read error")));
     ^
```

This causes the commands to output garbage:

```
version
ethersex 4ea5869 built on Oct 12 2014 12:08:03
sd info
ethersex 4ea
sd dir
et
et
rsex 4ea
69 built on Oct 12 2014 12:08:03
^@^@^@^@sd dir^W^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@<B6>^A^@&<9E>^A ^A^H^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@
^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@<92><BD><81><BD><F8><9A><99>'<80><B5>^H<95>&/<F9><99><FE><CF>^_<BA><92><BD><81><BD> <BD>^O<B6><F8><94><FA><9A><F9><9A>^O<BE>^A<96>^H<95><A0><E0><B0><E0><ED><E4><FA><E3><CF>
<U+008B>^Aa^Uq^E!<F0><DB>^A<8C><93><96><9C><93><EC>^A^^A<BF><EF><AB>^Z<BB>
u^AȀ<8C>-<90>et
rsex 4ea
...
```

Adding the include solves this:

```
sd info
 TM  SA02G 9/2009 1967MB 0 0 0
sd dir
                                  0
                          idx.ht  4217
                        tank.log  94
OK
version
ethersex 446d857 built on Oct 12 2014 11:54:07
```
