### PR TITLE
missing USART_UDRE_vect definition

### DIFF
--- a/pinning/internals/hackery_atmega168.m4
+++ b/pinning/internals/hackery_atmega168.m4
@@ -1,5 +1,6 @@
 
 #define _ATMEGA168
+#define USART0_UDRE_vect USART_UDRE_vect
 #define USART0_RX_vect USART_RX_vect
 #define USART0_TX_vect USART_TX_vect
 

--- a/pinning/internals/hackery_atmega168p.m4
+++ b/pinning/internals/hackery_atmega168p.m4
@@ -1,5 +1,6 @@
 
 #define _ATMEGA168P
+#define USART0_UDRE_vect USART_UDRE_vect
 #define USART0_RX_vect USART_RX_vect
 #define USART0_TX_vect USART_TX_vect
 


### PR DESCRIPTION
The hardware specific files for atmega168(p) were missing the USART_UDRE_vect definition.