### PR TITLE
fixed One-wire SNMP build error

### DIFF
--- a/protocols/snmp/snmp.c
+++ b/protocols/snmp/snmp.c
@@ -227,7 +227,7 @@ ow_temp_reaction(uint8_t * ptr, struct snmp_varbinding * bind, void *userdata)
   }
   uint8_t i = bind->data[0];
 
-  return encode_short(ptr, SNMP_TYPE_INTEGER, ow_sensors[i].temp);
+  return encode_short(ptr, SNMP_TYPE_INTEGER, ow_sensors[i].temp.val);
 }
 
 uint8_t

--- a/protocols/snmp/snmp.c
+++ b/protocols/snmp/snmp.c
@@ -227,7 +227,10 @@ ow_temp_reaction(uint8_t * ptr, struct snmp_varbinding * bind, void *userdata)
   }
   uint8_t i = bind->data[0];
 
-  return encode_short(ptr, SNMP_TYPE_INTEGER, ow_sensors[i].temp.val);
+  // always return as twodigits - even if not accurate enough for second
+  // digit. Simply multiply temp by 10.
+  return encode_short(ptr, SNMP_TYPE_INTEGER, ow_sensors[i].temp.twodigits ?
+		      ow_sensors[i].temp.val : ow_sensors[i].temp.val * 10);
 }
 
 uint8_t


### PR DESCRIPTION
The SNMP module always threw errors during compile after enabling One-wire and SNMP.

Temperatures of one-wire sensors were stored in structures of
typedef struct
{
  int16_t val:15;
  uint8_t twodigits:1;
} ow_temp_t;
but the SNMP function just pointed to the structure instead to structure.value.
