### PR TITLE
Snmpfix dht fixes build errors when using SNMP with DHT sensors

### DIFF
--- a/protocols/snmp/snmp.c
+++ b/protocols/snmp/snmp.c
@@ -284,37 +284,40 @@ tank_next(uint8_t * ptr, struct snmp_varbinding * bind)
 uint8_t
 dht_polling_delay_reaction(uint8_t * ptr, struct snmp_varbinding * bind, void *userdata)
 {
-  if (bind->len == 1 && bind->data[0] == 0) {
-    return encode_short(ptr, SNMP_TYPE_INTEGER, dht_global.polling_delay);
-  } else {
+  if (bind->len != 1 && bind->data[0] >= dht_sensors_count) {
     return 0;
   }
+  uint8_t i = bind->data[0];
+
+  return encode_short(ptr, SNMP_TYPE_INTEGER, dht_sensors[i].polling_delay);
 }
 
 uint8_t
 dht_temp_reaction(uint8_t * ptr, struct snmp_varbinding * bind, void *userdata)
 {
-  if (bind->len == 1 && bind->data[0] == 0) {
-    return encode_short(ptr, SNMP_TYPE_INTEGER, dht_global.temp);
-  } else {
+  if (bind->len != 1 && bind->data[0] >= dht_sensors_count) {
     return 0;
   }
+  uint8_t i = bind->data[0];
+
+  return encode_short(ptr, SNMP_TYPE_INTEGER, dht_sensors[i].temp);
 }
 
 uint8_t
 dht_humid_reaction(uint8_t * ptr, struct snmp_varbinding * bind, void *userdata)
 {
-  if (bind->len == 1 && bind->data[0] == 0) {
-    return encode_short(ptr, SNMP_TYPE_INTEGER, dht_global.humid);
-  } else {
+  if (bind->len != 1 && bind->data[0] >= dht_sensors_count) {
     return 0;
   }
+  uint8_t i = bind->data[0];
+
+  return encode_short(ptr, SNMP_TYPE_INTEGER, dht_sensors[i].humid);
 }
 
 uint8_t
 dht_next(uint8_t * ptr, struct snmp_varbinding * bind)
 {
-  return onelevel_next(ptr, bind, 1);
+  return onelevel_next(ptr, bind, dht_sensors_count);
 }
 #endif
 


### PR DESCRIPTION
dht_global was nowehere defined and thus raised an error during build.

I modified the code, so that it should work like the code for one-wire devices. The code itself is untested, as I did not yet have the time to connect a DHT sensor to my device.
At least it compiles without error.