### PR TITLE
Support for the wireless interconnectable smoke detectors

### DIFF
--- a/doc/Configure.help
+++ b/doc/Configure.help
@@ -319,6 +319,18 @@ PROTO_INTERTECHNO_SL_SUPPORT
     - Klik aan Klik uit
     - ...
 
+Flamingo FA20RF/ELRO KD101 
+PROTO_FA20RF_SUPPORT
+  Depends on: 
+   * Radio outlets (433MHz) (PROTO_ASK_SUPPORT)
+
+  Enable support for the wireless interconnectable smoke detectors
+  Flamingo FA20RF, ELRO KD101, and compatible.
+
+  Each detector or a group of interconnected detectors has a uniq
+  24bit id. By sending this id the smoke detector switches to alarm
+  mode for five seconds. 
+
 RFM12 ASK external filter enables external filter Support
 RFM12_ASK_EXTERNAL_FILTER_SUPPORT
   Depends on:

--- a/hardware/radio/rfm12/rfm12.c
+++ b/hardware/radio/rfm12/rfm12.c
@@ -119,6 +119,7 @@ rfm12_setfreq(uint16_t freq)
   return rfm12_trans(RFM12_CMD_FREQUENCY | freq);
 }
 
+#ifdef RFM12_IP_SUPPORT
 uint16_t
 rfm12_setbaud(uint16_t baud)
 {
@@ -143,6 +144,7 @@ rfm12_setpower(uint8_t power, uint8_t mod)
                              (uint8_t) ((mod & 15) << 4));
   return rfm12_trans(RFM12_CMD_TXCONF | param);
 }
+#endif /* RFM12_IP_SUPPORT */
 #endif /* !TEENSY_SUPPORT */
 
 uint16_t

--- a/hardware/radio/rfm12/rfm12_fs20.c
+++ b/hardware/radio/rfm12/rfm12_fs20.c
@@ -266,9 +266,14 @@ rfm12_fs20_init(void)
   RFM12_DEBUG("rfm12_fs20/init: %x", result);
 #endif
 
+#ifdef TEENSY_SUPPORT
+  rfm12_trans(RFM12_CMD_FREQUENCY | RFM12FREQ(RFM12_FREQ_868300));
+  rfm12_trans(RFM12_CMD_RXCTRL | 0x0431);
+#else
   rfm12_setfreq(RFM12FREQ(RFM12_FREQ_868300));
   /* bandwidth, gain, drssi */
   rfm12_setbandwidth(1, 2, 1);
+#endif
 
   rfm12_epilogue();
 

--- a/protocols/radio/ask/Makefile
+++ b/protocols/radio/ask/Makefile
@@ -9,6 +9,7 @@ $(PROTO_TEVION_SUPPORT)_ECMD_SRC += protocols/radio/ask/ask_tevion_ecmd.c
 $(PROTO_INTERTECHNO_SUPPORT)_ECMD_SRC += protocols/radio/ask/ask_intertechno_ecmd.c
 $(PROTO_INTERTECHNO_SL_SUPPORT)_ECMD_SRC += protocols/radio/ask/ask_intertechno_sl_ecmd.c
 $(PROTO_OASEFMMASTER_SUPPORT)_ECMD_SRC += protocols/radio/ask/ask_oasefmmaster_ecmd.c
+$(PROTO_SMOKEDETECTOR_SUPPORT)_ECMD_SRC += protocols/radio/ask/ask_smokedetector_ecmd.c
 
 
 ##############################################################################

--- a/protocols/radio/ask/ask.h
+++ b/protocols/radio/ask/ask.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Gregor B.
  * Copyright (c) 2009 Dirk Pannenbecker <dp@sd-gp.de>
- * Copyright (c) 2012-14 by Erik Kunze <ethersex@erik-kunze.de>
+ * Copyright (c) 2012-15 by Erik Kunze <ethersex@erik-kunze.de>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -32,5 +32,6 @@ void ask_1527_send(uint8_t *, uint8_t, uint8_t);
 void ask_intertechno_send(uint8_t, uint8_t, uint8_t, uint8_t);
 void ask_intertechno_sl_send(uint32_t, uint8_t, uint8_t, int8_t);
 void ask_oase_send(uint8_t *, uint8_t, uint8_t);
+void ask_fa20rf_send(uint32_t, uint8_t);
 
 #endif /* __ASK_H */

--- a/protocols/radio/ask/ask_smokedetector_ecmd.c
+++ b/protocols/radio/ask/ask_smokedetector_ecmd.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2015 Erik Kunze <ethersex@erik-kunze.de>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License (version 3)
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ *
+ * For more information on the GPL, please go to:
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#include <stdio.h>
+#include <avr/pgmspace.h>
+
+#include "config.h"
+#include "core/debug.h"
+
+#include "protocols/radio/ask/ask.h"
+#include "protocols/ecmd/ecmd-base.h"
+
+
+int16_t
+parse_cmd_ask_fa20rf_send(char *cmd, char *output, uint16_t len)
+{
+  (void) output;
+  (void) len;
+
+  uint32_t device;
+  uint8_t repeat = 10;
+  int ret = sscanf_P(cmd, PSTR("%lx %hhu"), &device, &repeat);
+  if (ret < 1)
+    return ECMD_ERR_PARSE_ERROR;
+
+  ask_fa20rf_send(device, repeat);
+  return ECMD_FINAL_OK;
+}
+
+/*
+  -- Ethersex META --
+  block([[ASK]])
+  ecmd_feature(ask_fa20rf_send, "ask fa20rf", DEVICE [REPEAT], )
+*/

--- a/protocols/radio/ask/config.in
+++ b/protocols/radio/ask/config.in
@@ -17,5 +17,11 @@ dep_bool_menu "Radio outlets (433MHz)" PROTO_ASK_SUPPORT $RADIO_HW_ASK $ARCH_AVR
   dep_bool "Intertechno ITS-150" PROTO_INTERTECHNO_SUPPORT $PROTO_ASK_SUPPORT
   dep_bool "Intertechno Self Learning" PROTO_INTERTECHNO_SL_SUPPORT $PROTO_ASK_SUPPORT
   dep_bool "Oase FM Master" PROTO_OASEFMMASTER_SUPPORT $PROTO_ASK_SUPPORT
+  dep_bool "Flamingo FA20RF/ELRO KD101 " PROTO_FA20RF_SUPPORT $PROTO_ASK_SUPPORT
+  if [ "$PROTO_FA20RF_SUPPORT" = "y" ]; then
+    define_bool PROTO_SMOKEDETECTOR_SUPPORT y
+  else
+    define_bool PROTO_SMOKEDETECTOR_SUPPORT n
+  fi
 
 endmenu 


### PR DESCRIPTION
Flamingo FA20RF, ELRO KD101, and compatible.

Each detector or a group of interconnected detectors has a uniq 24bit id. By sending this id the smoke detector switches to alarm mode for five seconds.
