### PR TITLE
Fix to avoid 8 bit overflow in EMS

### DIFF
--- a/protocols/ems/ems_uart.c
+++ b/protocols/ems/ems_uart.c
@@ -49,7 +49,7 @@
 #define STATE_TX_DATA_WAIT_ECHO  4
 #define STATE_TX_BREAK           5
 
-#define PRESCALE 8
+#define PRESCALE 32
 #define BIT_TIME  ((uint8_t)((F_CPU / BAUD) / PRESCALE))
 #define TX_TIMEOUT 10 /* x100ms = 1 second */
 
@@ -90,7 +90,7 @@ ems_uart_init(void)
   /* DDR_CONFIG_OUT(TXDn) */
   DDR_CHAR(usart(TXD, _PORT)) |= _BV(usart(TXD, _PIN));
 
-  TC2_PRESCALER_8;
+  TC2_PRESCALER_32;
   TC2_MODE_CTC;
 }
 


### PR DESCRIPTION
When running CPU on 20 MHz, an 8 bit overflow occured