### PR TITLE
Fix simultaneously send/receive of serial data (frames were dropped)

### DIFF
--- a/protocols/yport/yport_net.c
+++ b/protocols/yport/yport_net.c
@@ -85,7 +85,8 @@ yport_net_main(void)
     if (yport_conn == uip_conn)
       yport_conn = NULL;
   }
-  else if (uip_newdata())
+  
+  if (uip_newdata())
   {
     if (uip_len <= YPORT_BUFFER_LEN &&
         yport_rxstart(uip_appdata, uip_len) != 0)


### PR DESCRIPTION
I wrote a simple test which justs sends 4 bytes and then receives 4 bytes. It will do this twice, after this, the last sent packet is dismissed by EtherSex (but acked according to Wireshark!). You need to wait around 40msec to send another packet - if you do not, the next packet is dismissed.

This is due to a simple bug in yport_net.c:

```diff
diff --git a/protocols/yport/yport_net.c b/protocols/yport/yport_net.c
index 6eb27a8..a1a10cf 100755
--- a/protocols/yport/yport_net.c
+++ b/protocols/yport/yport_net.c
@@ -85,8 +85,10 @@ yport_net_main(void)
     if (yport_conn == uip_conn)
       yport_conn = NULL;
   }
-  else if (uip_newdata())
+  
+  if (uip_newdata())
   {
+
     if (uip_len <= YPORT_BUFFER_LEN &&
         yport_rxstart(uip_appdata, uip_len) != 0)
     {
```
Explanation: When you just sent a packet and get the ACK and newdata, you will only run into the ACK path, and the newdata path is ignored. Removing the **else** takes care of that.

With a short grep I found more (possibly) errors:

```grep
protocols/ems/ems_net.c:  } else if (uip_newdata()) {
protocols/modbus/modbus_net.c:  } else if (uip_newdata()) {
protocols/mqtt/mqtt.c:  else if (uip_newdata() && uip_len) {
protocols/irc/irc.c:    else if (uip_newdata() && uip_len) {
protocols/bsbport/bsbport_net.c:  else if (uip_newdata())
```