### PR TITLE
Avoiding conditional directives that split up parts of statements.

### DIFF
--- a/services/tftp/tftp-bootload.c
+++ b/services/tftp/tftp-bootload.c
@@ -113,6 +113,7 @@ tftp_handle_packet(void)
   uint16_t i;
   flash_base_t base;
   struct tftp_hdr *pk = uip_appdata;
+  int finish_transfer;
 
   switch (HTONS(pk->type))
   {
@@ -153,10 +154,11 @@ tftp_handle_packet(void)
 
       /* base overflowed ! */
 #if FLASHEND == UINT16_MAX
-      if (uip_udp_conn->appstate.tftp.transfered && base == 0)
+      finish_transfer = uip_udp_conn->appstate.tftp.transfered && base == 0;
 #else
-      if (base > FLASHEND)
+      finish_transfer = base > FLASHEND;
 #endif
+      if (finish_transfer)
       {
         uip_udp_send(4);        /* send empty packet to finish transfer */
         uip_udp_conn->appstate.tftp.finished = 1;


### PR DESCRIPTION
A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.
- https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
- https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness.
