### PR TITLE
print correct built date and time from debug and ecmd version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,8 @@ OBJECTS += $(patsubst %.c,%.o,${AUTOGEN_SRC} ${y_AUTOGEN_SRC})
 OBJECTS += $(patsubst %.S,%.o,${ASRC} ${y_ASRC})
 
 $(TARGET): $(OBJECTS)
-	$(CC) $(LDFLAGS) -o $@ $(OBJECTS) -lm -lc # Pixie Dust!!! (Bug in avr-binutils)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(TARGET_ARCH) -c buildtime.c
+	$(CC) $(LDFLAGS) -o $@ $(OBJECTS) buildtime.o -lm -lc # Pixie Dust!!! (Bug in avr-binutils)
 
 SIZEFUNCARG ?= -e printf -e scanf -e divmod
 size-check: $(OBJECTS) ethersex

--- a/buildtime.c
+++ b/buildtime.c
@@ -1,0 +1,28 @@
+/*
+ * buildtime.c - export build time and version info as a global symbol.
+ *
+ * Copyright (c) 2016 Michael Brakemeier <michael@brakemeier.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ * For more information on the GPL, please go to:
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#include <avr/pgmspace.h>
+
+#include "config.h"
+
+const char PROGMEM pstr_VERSION_STRING_LONG[] = VERSION_STRING_LONG;

--- a/buildtime.h
+++ b/buildtime.h
@@ -1,0 +1,26 @@
+/*
+ * buildtime.h - export build time and version info as a global symbol.
+ *
+ * Copyright (c) 2016 Michael Brakemeier <michael@brakemeier.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ * For more information on the GPL, please go to:
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#include <avr/pgmspace.h>
+
+extern const char PROGMEM pstr_VERSION_STRING_LONG[];

--- a/config.h
+++ b/config.h
@@ -22,8 +22,6 @@
 #ifndef _CONFIG_H
 #define _CONFIG_H
 
-#include <avr/pgmspace.h>
-
 /* define these menu choices before including autoconf.h */
 #define BMP085_OSS_0 0
 #define BMP085_OSS_1 1
@@ -41,8 +39,6 @@
 
 #define VERSION_STRING GIT_VERSION
 #define VERSION_STRING_LONG GIT_VERSION " built on " __DATE__ " " __TIME__
-/* exported from buildtime.c */
-extern const char PROGMEM pstr_VERSION_STRING_LONG[];
 
 /* configure duplex mode */
 #define NET_FULL_DUPLEX 0

--- a/config.h
+++ b/config.h
@@ -22,6 +22,8 @@
 #ifndef _CONFIG_H
 #define _CONFIG_H
 
+#include <avr/pgmspace.h>
+
 /* define these menu choices before including autoconf.h */
 #define BMP085_OSS_0 0
 #define BMP085_OSS_1 1
@@ -39,6 +41,8 @@
 
 #define VERSION_STRING GIT_VERSION
 #define VERSION_STRING_LONG GIT_VERSION " built on " __DATE__ " " __TIME__
+/* exported from buildtime.c */
+extern const char PROGMEM pstr_VERSION_STRING_LONG[];
 
 /* configure duplex mode */
 #define NET_FULL_DUPLEX 0

--- a/ethersex.c
+++ b/ethersex.c
@@ -137,7 +137,7 @@ main (void)
 
   //FIXME: zum ethersex meta system hinzufügen, aber vor allem anderem initalisieren
   debug_init();
-  debug_printf("ethersex " VERSION_STRING_LONG " (Debug mode)\n");
+  debug_printf("ethersex %S (Debug mode)\n", pstr_VERSION_STRING_LONG);
 
 #ifdef DEBUG_RESET_REASON
   if (bit_is_set (mcusr_mirror, BORF))

--- a/ethersex.c
+++ b/ethersex.c
@@ -43,6 +43,8 @@
 
 #include "autoconf.h"
 
+#include "buildtime.h"
+
 /* global configuration */
 global_status_t status;
 

--- a/protocols/ecmd/parser.c
+++ b/protocols/ecmd/parser.c
@@ -28,6 +28,7 @@
 #include <avr/eeprom.h>
 
 #include "config.h"
+#include "buildtime.h"
 #include "core/debug.h"
 #include "core/heartbeat.h"
 #include "protocols/uip/uip.h"

--- a/protocols/ecmd/parser.c
+++ b/protocols/ecmd/parser.c
@@ -222,7 +222,7 @@ parse_cmd_version(char *cmd, char *output, uint16_t len)
 {
   (void) cmd;
 
-  return ECMD_FINAL(snprintf_P(output, len, PSTR("ethersex " VERSION_STRING_LONG)));
+  return ECMD_FINAL(snprintf_P(output, len, PSTR("ethersex %S"),  pstr_VERSION_STRING_LONG));
 }
 
 int16_t


### PR DESCRIPTION
Fixes issue #448.

Add built date and time during link time of the ethersex binary ensuring up to date information from debug boot-time message and ecmd version command regardless of the files changed during compilation.

Doing this at link time only avoids unnecessary dependencies and thus unwanted compile cycles.