### PR TITLE
fix issue 448 - print correct built date and time from debug and ecmd…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,8 +146,11 @@ OBJECTS += $(patsubst %.c,%.o,${SRC} ${y_SRC} meta.c)
 OBJECTS += $(patsubst %.c,%.o,${AUTOGEN_SRC} ${y_AUTOGEN_SRC})
 OBJECTS += $(patsubst %.S,%.o,${ASRC} ${y_ASRC})
 
+# Do not add version.c to SRC or OBJECTS!
+# Compile version.c at link time ensures correct built time, ref. issue #448
 $(TARGET): $(OBJECTS)
-	$(CC) $(LDFLAGS) -o $@ $(OBJECTS) -lm -lc # Pixie Dust!!! (Bug in avr-binutils)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(TARGET_ARCH) -c version.c
+	$(CC) $(LDFLAGS) -o $@ $(OBJECTS) version.o -lm -lc # Pixie Dust!!! (Bug in avr-binutils)
 
 SIZEFUNCARG ?= -e printf -e scanf -e divmod
 size-check: $(OBJECTS) ethersex

--- a/config.h
+++ b/config.h
@@ -35,11 +35,6 @@
 #define ENC28J60_REV5_WORKAROUND
 #define ENC28J60_REV6_WORKAROUND  /* rev is 6; but microchip calls it B7 */
 
-/* global version defines */
-
-#define VERSION_STRING GIT_VERSION
-#define VERSION_STRING_LONG GIT_VERSION " built on " __DATE__ " " __TIME__
-
 /* configure duplex mode */
 #define NET_FULL_DUPLEX 0
 

--- a/ethersex.c
+++ b/ethersex.c
@@ -43,6 +43,8 @@
 
 #include "autoconf.h"
 
+#include "version.h"
+
 /* global configuration */
 global_status_t status;
 
@@ -137,7 +139,7 @@ main (void)
 
   //FIXME: zum ethersex meta system hinzufügen, aber vor allem anderem initalisieren
   debug_init();
-  debug_printf("ethersex " VERSION_STRING_LONG " (Debug mode)\n");
+  debug_printf("%S (Debug mode)\n", pstr_E6_VERSION_STRING_LONG);
 
 #ifdef DEBUG_RESET_REASON
   if (bit_is_set (mcusr_mirror, BORF))

--- a/hardware/lcd/s1d15g10/s1d15g10.c
+++ b/hardware/lcd/s1d15g10/s1d15g10.c
@@ -47,6 +47,7 @@
 #include <avr/interrupt.h>
 #include <avr/wdt.h>
 #include "config.h"
+#include "version.h"
 #include "s1d15g10.h"
 #include "core/spi.h"
 

--- a/protocols/ecmd/parser.c
+++ b/protocols/ecmd/parser.c
@@ -28,6 +28,7 @@
 #include <avr/eeprom.h>
 
 #include "config.h"
+#include "version.h"
 #include "core/debug.h"
 #include "core/heartbeat.h"
 #include "protocols/uip/uip.h"
@@ -222,7 +223,9 @@ parse_cmd_version(char *cmd, char *output, uint16_t len)
 {
   (void) cmd;
 
-  return ECMD_FINAL(snprintf_P(output, len, PSTR("ethersex " VERSION_STRING_LONG)));
+  strncpy_P(output, pstr_E6_VERSION_STRING_LONG, len);
+
+  return ECMD_FINAL(strlen(output));
 }
 
 int16_t

--- a/services/jabber/jabber.c
+++ b/services/jabber/jabber.c
@@ -28,6 +28,7 @@
 #include <string.h>
 
 #include "config.h"
+#include "version.h"
 #include "protocols/uip/uip.h"
 #include "core/eeprom.h"
 #include "jabber.h"

--- a/version.c
+++ b/version.c
@@ -1,0 +1,28 @@
+/*
+ * version.c - export build time and version info as global symbols.
+ *
+ * Copyright (c) 2016 Michael Brakemeier <michael@brakemeier.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ * For more information on the GPL, please go to:
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#include <avr/pgmspace.h>
+
+#include "version.h"
+
+const char PROGMEM pstr_E6_VERSION_STRING_LONG[] = E6_VERSION_STRING_LONG;

--- a/version.h
+++ b/version.h
@@ -1,0 +1,38 @@
+/*
+ * version.h - export build time and version info as a global symbol.
+ *
+ * Copyright (c) 2016 Michael Brakemeier <michael@brakemeier.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ * For more information on the GPL, please go to:
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+/**
+ * Provide version info and build date and time for ethersex.
+ */
+
+#include <avr/pgmspace.h>
+
+#include "autoconf.h"
+
+/* global version defines */
+#define VERSION_STRING          GIT_VERSION
+#define VERSION_STRING_LONG     GIT_VERSION " built on " __DATE__ " " __TIME__
+#define E6_VERSION_STRING_LONG  "ethersex " VERSION_STRING_LONG
+
+/* one global version string in program space, saves flash */
+extern const char PROGMEM pstr_E6_VERSION_STRING_LONG[];


### PR DESCRIPTION
Fixes issue #448.

Add built date and time at link time of the ethersex binary ensuring up to date information from debug boot-time message and ecmd version command regardless of the files changed during compilation.

Doing this at link time only avoids unnecessary dependencies and thus unwanted compile cycles.