### PR TITLE
fix issue 413 - proper dependencies for meta.c/.h and avoid unnecessa…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,14 +99,6 @@ debug:
 ${ECMD_PARSER_SUPPORT}_SRC += ${y_ECMD_SRC}
 ${SOAP_SUPPORT}_SRC += ${y_SOAP_SRC}
 
-meta.m4: ${SRC} ${y_SRC} .config
-	@echo "Build meta files"
-	$(SED) -ne '/Ethersex META/{n;:loop p;n;/\*\//!bloop }' ${SRC} ${y_SRC} > $@.tmp
-	@echo "Copying to meta.m4"
-	@if [ ! -e $@ ]; then cp $@.tmp $@; fi
-	@if ! diff $@.tmp $@ >/dev/null; then cp $@.tmp $@; fi
-	@$(RM) -f $@.tmp
-
 $(ECMD_PARSER_SUPPORT)_NP_SIMPLE_META_SRC = protocols/ecmd/ecmd_defs.m4 ${named_pin_simple_files}
 $(SOAP_SUPPORT)_NP_SIMPLE_META_SRC = protocols/ecmd/ecmd_defs.m4 ${named_pin_simple_files}
 
@@ -121,18 +113,27 @@ y_META_SRC += meta.m4
 $(ECMD_PARSER_SUPPORT)_META_SRC += protocols/ecmd/ecmd_defs.m4 ${named_pin_simple_files}
 y_META_SRC += $(y_NP_SIMPLE_META_SRC)
 
+meta.m4: ${SRC} ${y_SRC} .config
+	@echo "Build meta files"
+	$(SED) -ne '/Ethersex META/{n;:loop p;n;/\*\//!bloop }' ${SRC} ${y_SRC} > $@.tmp
+	@echo "Copying to meta.m4"
+	@if [ ! -e $@ ]; then cp -v $@.tmp $@; \
+		elif ! diff $@.tmp $@ >/dev/null; then cp -v $@.tmp $@; else echo "$@ unaltered"; fi
+	@$(RM) -f $@.tmp
+
 meta.defines: autoconf.h pinning.c
 	scripts/m4-defines > $@.tmp
 	$(SED) -e "/^#define [A-Z].*_PIN /!d" -e "s/^#define \([^ 	]*\)_PIN.*/-Dpin_\1/;s/[()]/_/g" pinning.c >> $@.tmp
-	$(SED) -e ':a' -e 'N' -e '$$!ba' -e 's/\n/ /g' $@.tmp > $@
-	$(RM) $@.tmp
+	$(SED) -e ':a' -e 'N' -e '$$!ba' -e 's/\n/ /g' $@.tmp > $@.new
+	@echo "Copying to meta.defines"
+	@if [ ! -e $@ ]; then cp -v $@.new $@; \
+		elif ! diff $@.new $@ >/dev/null; then cp -v $@.new $@; else echo "$@ unaltered"; fi
+	@$(RM) -f $@.tmp $@.new
 
-$(y_META_SRC): meta.defines
-
-meta.c: $(y_META_SRC)
+meta.c: $(y_META_SRC) meta.defines
 	$(M4) $(M4FLAGS) `cat meta.defines` $^ > $@
 
-meta.h: scripts/meta_header_magic.m4 meta.m4
+meta.h: scripts/meta_header_magic.m4 meta.m4 meta.defines
 	$(M4) `cat meta.defines` $^ > $@
 
 ##############################################################################

--- a/core/Makefile
+++ b/core/Makefile
@@ -34,7 +34,7 @@ $(STATUSLED_HB_ACT_SUPPORT)_SRC += core/heartbeat.c
 
 $(ARCH_AVR)_AUTOGEN_SRC += core/periodic_milliticks.c
 
-core/periodic_milliticks.c: scripts/meta_periodic_milliticks.m4 meta.m4
+core/periodic_milliticks.c: scripts/meta_periodic_milliticks.m4 meta.m4 meta.defines
 	$(M4) `cat meta.defines` $^ > $@
 
 ##############################################################################


### PR DESCRIPTION
Fix issue #413.

Add proper dependencies for meta.c/.h and core/periodic_milliticks.c.
Avoid unnecessary rebuilds if meta sources are not altered by config changes.

