### PR TITLE
Artnet: Send poll reply to source, allow directed data

### DIFF
--- a/doc/Configure.help
+++ b/doc/Configure.help
@@ -2577,10 +2577,23 @@ CONF_ARTNET_PORT
 
   on which UDP port ethersex listens for artnet data
 
+Output IP
+CONF_ARTNET_OUTPUT_IP
+
+  the target for artnet data
+
+Send Poll Reply
+CONF_ARTNET_SEND_POLL_REPLY
+
+  When true, an acknowledge poll reply will be sent after
+  each data frame.
+  Set to false to reduce traffic.
+
 Art-Net Node
 ARTNET_SUPPORT
   Depends on:
    * DMX Storage (DMX_STORAGE_SUPPORT)
+   * UDP broadcast support (BROADCAST_SUPPORT)
    * UDP support (UDP_SUPPORT)
    * NET_MAX_FRAME_LENGTH > 571
 

--- a/protocols/artnet/artnet.c
+++ b/protocols/artnet/artnet.c
@@ -100,8 +100,8 @@ artnet_init(void)
   strcpy_P(artnet_shortName, PSTR("e6ArtNode"));
   strcpy_P(artnet_longName, PSTR("e6ArtNode hostname: " CONF_HOSTNAME));
 
-  uip_ipaddr_copy(artnet_pollReplyTarget,all_ones_addr);
-  
+  uip_ipaddr_copy(artnet_pollReplyTarget, all_ones_addr);
+
   /* dmx storage connection */
   artnet_conn_id = dmx_storage_connect(artnet_inputUniverse);
   if (artnet_conn_id != -1)
@@ -234,7 +234,8 @@ artnet_sendDmxPacket(void)
   msg->lengthHi = HI8(DMX_STORAGE_CHANNELS);
   msg->length = LO8(DMX_STORAGE_CHANNELS);
   for (uint8_t i = 0; i < DMX_STORAGE_CHANNELS; i++)
-	msg->dataStart[i] = get_dmx_channel_slot(artnet_inputUniverse, i, artnet_conn_id);
+    msg->dataStart[i] =
+      get_dmx_channel_slot(artnet_inputUniverse, i, artnet_conn_id);
   /* broadcast the packet */
   artnet_send(sizeof(struct artnet_dmx) + DMX_STORAGE_CHANNELS);
 }
@@ -254,14 +255,14 @@ processPollPacket(struct artnet_poll *poll)
   else
     artnet_sendPollReplyOnChange = FALSE;
   if ((poll->talkToMe & 1) == 1)
-	  uip_ipaddr_copy(artnet_pollReplyTarget,uip_hostaddr);
+    uip_ipaddr_copy(artnet_pollReplyTarget, uip_hostaddr);
   else
-	  uip_ipaddr_copy(artnet_pollReplyTarget,all_ones_addr);
+    uip_ipaddr_copy(artnet_pollReplyTarget, all_ones_addr);
   artnet_sendPollReply();
-  
+
   /* we send a dmx packet on a poll packet, if artnet_sendPollReplyOnChange is active */
   if (artnet_sendPollReplyOnChange)
-	  artnet_sendDmxPacket();
+    artnet_sendDmxPacket();
 }
 
 void
@@ -316,7 +317,8 @@ artnet_get(void)
         if (artnet_dmxDirection == 0)
         {
           uint16_t len = ((dmx->lengthHi << 8) + dmx->length);
-          set_dmx_channels((const uint8_t *)&dmx->dataStart, artnet_outputUniverse, 0, len);
+          set_dmx_channels((const uint8_t *) &dmx->dataStart,
+                           artnet_outputUniverse, 0, len);
           if (artnet_sendPollReplyOnChange == TRUE)
           {
             artnet_pollReplyCounter++;

--- a/protocols/artnet/artnet.c
+++ b/protocols/artnet/artnet.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2009 by Stefan Krupop <mail@stefankrupop.de>
  * Copyright (c) 2009 by Dirk Pannenbecker <dp@sd-gp.de>
- * Copyright (c) 2011-2012 by Maximilian Güntner <maximilian.guentner@gmail.com>
+ * Copyright (c) 2011-2016 by Maximilian Güntner <maximilian.guentner@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -43,6 +43,7 @@
 #include "services/dmx-storage/dmx_storage.h"
 #ifdef ARTNET_SUPPORT
 
+#define BUF ((struct uip_udpip_hdr *) (uip_appdata - UIP_IPUDPH_LEN))
 
 /* ----------------------------------------------------------------------------
  *global variables
@@ -51,8 +52,8 @@
 uint8_t artnet_subNet = SUBNET_DEFAULT;
 uint8_t artnet_outputUniverse;
 uint8_t artnet_inputUniverse;
-uint8_t artnet_sendPollReplyOnChange = TRUE;
-uip_ipaddr_t artnet_pollReplyTarget;
+uip_ipaddr_t artnet_outputTarget;
+uint8_t artnet_sendPollReplyOnChange;
 uint32_t artnet_pollReplyCounter = 0;
 uint8_t artnet_status = RC_POWER_OK;
 char artnet_shortName[18] = { '\0' };
@@ -97,10 +98,15 @@ artnet_init(void)
   artnet_subNet = SUBNET_DEFAULT;
   artnet_inputUniverse = CONF_ARTNET_INUNIVERSE;
   artnet_outputUniverse = CONF_ARTNET_OUTUNIVERSE;
+#ifdef CONF_ARTNET_SEND_POLL_REPLY
+  artnet_sendPollReplyOnChange = 1;
+#else
+  artnet_sendPollReplyOnChange = 0;
+#endif
   strcpy_P(artnet_shortName, PSTR("e6ArtNode"));
   strcpy_P(artnet_longName, PSTR("e6ArtNode hostname: " CONF_HOSTNAME));
 
-  uip_ipaddr_copy(artnet_pollReplyTarget, all_ones_addr);
+  set_CONF_ARTNET_OUTPUT_IP(&artnet_outputTarget);
 
   /* dmx storage connection */
   artnet_conn_id = dmx_storage_connect(artnet_inputUniverse);
@@ -121,7 +127,7 @@ artnet_init(void)
 
   /* annouce that we are here  */
   ARTNET_DEBUG("send PollReply\n");
-  artnet_sendPollReply();
+  artnet_sendPollReply(&all_ones_addr);
 
   /* enable PollReply on changes */
   artnet_sendPollReplyOnChange = TRUE;
@@ -130,10 +136,10 @@ artnet_init(void)
 }
 
 static void
-artnet_send(uint16_t len)
+artnet_send(const uip_ipaddr_t *dest, uint16_t len)
 {
   uip_udp_conn_t artnet_conn;
-  uip_ipaddr_copy(artnet_conn.ripaddr, artnet_pollReplyTarget);
+  uip_ipaddr_copy(&(artnet_conn.ripaddr), dest);
   artnet_conn.rport = HTONS(artnet_port);
   artnet_conn.lport = HTONS(artnet_port);
   uip_udp_conn = &artnet_conn;
@@ -150,7 +156,7 @@ artnet_send(uint16_t len)
  * send an ArtPollReply packet
  */
 void
-artnet_sendPollReply(void)
+artnet_sendPollReply(const uip_ipaddr_t *dest)
 {
 
   /* prepare artnet PollReply packet */
@@ -202,8 +208,8 @@ artnet_sendPollReply(void)
 
   memcpy(msg->mac, uip_ethaddr.addr, 6);
 
-  /* broadcast the packet */
-  artnet_send(sizeof(struct artnet_pollreply));
+  /* send packet to dest */
+  artnet_send(dest, sizeof(struct artnet_pollreply));
 }
 
 /* ----------------------------------------------------------------------------
@@ -236,29 +242,30 @@ artnet_sendDmxPacket(void)
   for (uint8_t i = 0; i < DMX_STORAGE_CHANNELS; i++)
     msg->dataStart[i] =
       get_dmx_channel_slot(artnet_inputUniverse, i, artnet_conn_id);
-  /* broadcast the packet */
-  artnet_send(sizeof(struct artnet_dmx) + DMX_STORAGE_CHANNELS);
+  /* send packet to artnet_outputTarget */
+  artnet_send(&artnet_outputTarget, sizeof(struct artnet_dmx) + DMX_STORAGE_CHANNELS);
 }
 
 int16_t
 parse_cmd_artnet_pollreply(int8_t * cmd, int8_t * output, uint16_t len)
 {
-  artnet_sendPollReply();
+  artnet_sendPollReply(&all_ones_addr);
   return ECMD_FINAL_OK;
 }
 
 void
 processPollPacket(struct artnet_poll *poll)
 {
+  uip_ipaddr_t poll_reply_target;
   if ((poll->talkToMe & 2) == 2)
     artnet_sendPollReplyOnChange = TRUE;
   else
     artnet_sendPollReplyOnChange = FALSE;
   if ((poll->talkToMe & 1) == 1)
-    uip_ipaddr_copy(artnet_pollReplyTarget, uip_hostaddr);
+    uip_ipaddr_copy(poll_reply_target, uip_hostaddr);
   else
-    uip_ipaddr_copy(artnet_pollReplyTarget, all_ones_addr);
-  artnet_sendPollReply();
+    uip_ipaddr_copy(poll_reply_target, all_ones_addr);
+  artnet_sendPollReply(&poll_reply_target);
 
   /* we send a dmx packet on a poll packet, if artnet_sendPollReplyOnChange is active */
   if (artnet_sendPollReplyOnChange)
@@ -307,10 +314,12 @@ artnet_get(void)
       ARTNET_DEBUG("Received artnet poll reply packet!\r\n");
       break;
     case OP_OUTPUT:;
+      uip_ipaddr_t artnet_pollReplyTarget;
       struct artnet_dmx *dmx;
 
       ARTNET_DEBUG("Received artnet output packet!\r\n");
       dmx = (struct artnet_dmx *) uip_appdata;
+      uip_ipaddr_copy(&artnet_pollReplyTarget, BUF->srcipaddr);
 
       if (dmx->universe == ((artnet_subNet << 4) | artnet_outputUniverse))
       {
@@ -322,7 +331,7 @@ artnet_get(void)
           if (artnet_sendPollReplyOnChange == TRUE)
           {
             artnet_pollReplyCounter++;
-            artnet_sendPollReply();
+            artnet_sendPollReply(&artnet_pollReplyTarget);
           }
         }
       }

--- a/protocols/artnet/artnet.h
+++ b/protocols/artnet/artnet.h
@@ -32,6 +32,7 @@
 #include <avr/io.h>
 #include <avr/pgmspace.h>
 #include "config.h"
+#include "protocols/uip/uip.h"
 #include "protocols/artnet/artnet_net.h"
 #ifndef _ARTNET_H
 #define _ARTNET_H
@@ -212,7 +213,7 @@ struct artnet_dmx
 };
 
 void artnet_init(void);
-void artnet_sendPollReply(void);
+void artnet_sendPollReply(const uip_ipaddr_t *dest);
 void artnet_main(void);
 void artnet_get(void);
 

--- a/protocols/artnet/config.in
+++ b/protocols/artnet/config.in
@@ -4,11 +4,13 @@ else
   define_bool NET_MAX_FRAME_LENGTH_GT_571 n
 fi
 
-dep_bool_menu "Art-Net Node" ARTNET_SUPPORT $NET_MAX_FRAME_LENGTH_GT_571 $DMX_STORAGE_SUPPORT $UDP_SUPPORT
+dep_bool_menu "Art-Net Node" ARTNET_SUPPORT $NET_MAX_FRAME_LENGTH_GT_571 $DMX_STORAGE_SUPPORT $UDP_SUPPORT $BROADCAST_SUPPORT
   int "UDP Port" CONF_ARTNET_PORT 6454
   comment "Universe Settings"
   int "Input Universe" CONF_ARTNET_INUNIVERSE "1"
   int "Output Universe" CONF_ARTNET_OUTUNIVERSE "0"
+  ip "Output IP" CONF_ARTNET_OUTPUT_IP "192.168.0.255"
+  bool "Send Poll Reply" CONF_ARTNET_SEND_POLL_REPLY "1"
   comment  "Debugging Flags"
   dep_bool 'ARTNET' DEBUG_ARTNET $DEBUG
 endmenu


### PR DESCRIPTION
When receiving a data frame, the poll reply will be sent
back to the source instead of the broadcast address.
Moreover acknowledgement poll replies can be disabled
to reduce traffic.

The destination for the input universe can now be supplied
in menuconfig instead of broadcasting the data.

Please pull :muscle: 