### PR TITLE
Move mqtt debug macros to mqtt.c

### DIFF
--- a/protocols/mqtt/mqtt.c
+++ b/protocols/mqtt/mqtt.c
@@ -99,6 +99,21 @@
 #include "protocols/uip/uip.h"
 #include "mqtt.h"
 #include "mqtt_state.h"
+#include "core/debug.h"
+
+// DEBUG MACROS
+
+#ifdef MQTT_DEBUG
+#define MQTTDEBUG(...) debug_printf(__VA_ARGS__)
+#else
+#define MQTTDEBUG(...)
+#endif
+
+#ifdef MQTT_PARSE_DEBUG
+#define MQTTPARSEDEBUG(...) debug_printf(__VA_ARGS__)
+#else
+#define MQTTPARSEDEBUG(...)
+#endif
 
 
 #define STATE (&mqtt_con_state)

--- a/protocols/mqtt/mqtt.h
+++ b/protocols/mqtt/mqtt.h
@@ -30,21 +30,6 @@
 #include <stdbool.h>
 
 
-// DEBUG MACROS
-
-#ifdef MQTT_DEBUG
-#define MQTTDEBUG(...) debug_printf(__VA_ARGS__)
-#else
-#define MQTTDEBUG(...)
-#endif
-
-#ifdef MQTT_PARSE_DEBUG
-#define MQTTPARSEDEBUG(...) debug_printf(__VA_ARGS__)
-#else
-#define MQTTPARSEDEBUG(...)
-#endif
-
-
 // KEEP ALIVE
 
 #ifndef MQTT_KEEPALIVE


### PR DESCRIPTION
As suggested by eku in #457 moved debug macros to mqtt.c