### PR TITLE
issue 461 fix meta.defines prerequisite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,11 +130,11 @@ meta.defines: autoconf.h pinning.c
 		elif ! diff $@.new $@ >/dev/null; then cp -v $@.new $@; else echo "$@ unaltered"; fi
 	@$(RM) -f $@.tmp $@.new
 
-meta.c: $(y_META_SRC) meta.defines
-	$(M4) $(M4FLAGS) `cat meta.defines` $^ > $@
+meta.c: meta.defines $(y_META_SRC)
+	$(M4) $(M4FLAGS) `cat meta.defines` $(filter-out $<,$^) > $@
 
-meta.h: scripts/meta_header_magic.m4 meta.m4 meta.defines
-	$(M4) `cat meta.defines` $^ > $@
+meta.h: meta.defines scripts/meta_header_magic.m4 meta.m4
+	$(M4) `cat meta.defines` $(filter-out $<,$^) > $@
 
 ##############################################################################
 

--- a/core/Makefile
+++ b/core/Makefile
@@ -34,8 +34,8 @@ $(STATUSLED_HB_ACT_SUPPORT)_SRC += core/heartbeat.c
 
 $(ARCH_AVR)_AUTOGEN_SRC += core/periodic_milliticks.c
 
-core/periodic_milliticks.c: scripts/meta_periodic_milliticks.m4 meta.m4 meta.defines
-	$(M4) `cat meta.defines` $^ > $@
+core/periodic_milliticks.c: meta.defines scripts/meta_periodic_milliticks.m4 meta.m4
+	$(M4) `cat meta.defines` $(filter-out $<,$^) > $@
 
 ##############################################################################
 # generic fluff


### PR DESCRIPTION
Contents of meta.defines was literally copied to the make target under certain circumstances. Fixes issue #461.

Please test and report.