### PR TITLE
Crash on ECMD command

### DIFF
--- a/protocols/ecmd/parser.c
+++ b/protocols/ecmd/parser.c
@@ -224,6 +224,7 @@ parse_cmd_version(char *cmd, char *output, uint16_t len)
   (void) cmd;
 
   strncpy_P(output, pstr_E6_VERSION_STRING_LONG, len);
+  output[len - 1] = '\0';
 
   return ECMD_FINAL(strlen(output));
 }


### PR DESCRIPTION
The version string might be longer than the output buffer, so terminate with null byte.