### PR TITLE
Fix for CPP from GCC 5.x and newer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ ifeq ($(CRC_PAD_SUPPORT),y)
 endif
 
 embed/%: embed/%.cpp
-	@if ! avr-cpp -xc -DF_CPU=$(FREQ) -I$(TOPDIR) -include autoconf.h $< 2> /dev/null > $@.tmp; \
+	@if ! avr-cpp -xc -P -DF_CPU=$(FREQ) -I$(TOPDIR) -include autoconf.h $< 2> /dev/null > $@.tmp; \
 	  then $(RM) $@; echo "--> Don't include $@ ($<)"; \
 	  else $(SED) '/^$$/d; /^#[^#]/d' <$@.tmp > $@; echo "--> Include $@ ($<)";  \
 	fi

--- a/config.in
+++ b/config.in
@@ -48,7 +48,7 @@ if [ "$ARCH_AVR" = "y" ]; then
 
 
 	# get the flash size according to the cpu type
-	FLASH_SIZE=$((`echo -e "#include <avr/io.h>\nFLASHEND" | avr-cpp -mmcu=$MCU | sed '$!d'` + 1 ))
+	FLASH_SIZE=$((`echo -e "#include <avr/io.h>\nFLASHEND" | avr-cpp -P -mmcu=$MCU | sed '$!d'` + 1 ))
 
 	# set the default bootloader bytes according to cpu flash size
 	if [ "$BOOTLOADER_SIZE" = "" ] ; then
@@ -71,10 +71,10 @@ if [ "$ARCH_AVR" = "y" ]; then
 	define_hex BOOTLOADER_START_ADDRESS "$(printf '0x%X\n' $(($FLASH_SIZE - $BOOTLOADER_SIZE)))"
 
 	define_hex FLASH_SIZE "$(printf '0x%X\n' $FLASH_SIZE)"
-	define_hex EEPROM_SIZE "$(printf '0x%X\n' $((`echo -e "#include <avr/io.h>\nE2END" | avr-cpp -mmcu=$MCU | sed '$!d'` + 1)))"
-	define_hex RAM_SIZE "$(printf '0x%X\n' $((`echo -e "#include <avr/io.h>\nRAMEND-RAMSTART" | avr-cpp -mmcu=$MCU | sed '$!d'` + 1)))"
-	define_hex FLASH_PAGESIZE "$(printf '0x%X\n' $((`echo -e "#include <avr/io.h>\nSPM_PAGESIZE" | avr-cpp -mmcu=$MCU | sed '$!d'`)))"
-	define_hex EEPROM_PAGESIZE "$(printf '0x%X\n' $((`echo -e "#include <avr/io.h>\nE2PAGESIZE" | avr-cpp -mmcu=$MCU | sed '$!d'`)))"
+	define_hex EEPROM_SIZE "$(printf '0x%X\n' $((`echo -e "#include <avr/io.h>\nE2END" | avr-cpp -P -mmcu=$MCU | sed '$!d'` + 1)))"
+	define_hex RAM_SIZE "$(printf '0x%X\n' $((`echo -e "#include <avr/io.h>\nRAMEND-RAMSTART" | avr-cpp -P -mmcu=$MCU | sed '$!d'` + 1)))"
+	define_hex FLASH_PAGESIZE "$(printf '0x%X\n' $((`echo -e "#include <avr/io.h>\nSPM_PAGESIZE" | avr-cpp -P -mmcu=$MCU | sed '$!d'`)))"
+	define_hex EEPROM_PAGESIZE "$(printf '0x%X\n' $((`echo -e "#include <avr/io.h>\nE2PAGESIZE" | avr-cpp -P -mmcu=$MCU | sed '$!d'`)))"
 
 	source core/crc/config.in
 fi

--- a/core/scheduler/config.in
+++ b/core/scheduler/config.in
@@ -2,5 +2,5 @@ comment "Scheduler"
 dep_bool "Enable timer/task scheduler" SCHEDULER_SUPPORT
 dep_bool "Enable dynamic timers/tasks" SCHEDULER_DYNAMIC_SUPPORT $SCHEDULER_SUPPORT
 int "Maximum number of dynamic timers/tasks" CONF_SCHEDULER_NUM_DYNAMIC_TIMERS \
-  $(( ( $(echo -e "#include <avr/io.h>\nRAMEND" | avr-cpp -mmcu=$MCU | sed '$!d') / 256 ) > 32 ? 32 : 8 ))
+  $(( ( $(echo -e "#include <avr/io.h>\nRAMEND" | avr-cpp -P -mmcu=$MCU | sed '$!d') / 256 ) > 32 ? 32 : 8 ))
 dep_bool "Enable scheduler debugging" DEBUG_SCHEDULER_SUPPORT $DEBUG

--- a/scripts/eeprom-usage
+++ b/scripts/eeprom-usage
@@ -34,7 +34,7 @@ if [ -z "$ee_used" ]; then
   exit 0
 fi
 
-ee_size=$(echo $(( `echo -e "#include <avr/io.h>\nE2END" | avr-cpp $2 | ${SED} '$!d'` + 1 )))
+ee_size=$(echo $(( `echo -e "#include <avr/io.h>\nE2END" | avr-cpp -P $2 | ${SED} '$!d'` + 1 )))
 ee_pct=$(${AWK} "BEGIN {printf(\"%.2f\", $ee_used.0 / $ee_size.0 * 100.0);}")
 
 echo "EEPROM usage: $ee_used/$ee_size bytes (${ee_pct}%)"

--- a/scripts/size
+++ b/scripts/size
@@ -11,7 +11,7 @@ query_mcutype2flashsize()
 {
 	local mcu_type="$1"
 	local hello_world="#include <avr/io.h>\nFLASHEND"
-	local imagesize=$( echo -e "$hello_world" | avr-cpp -mmcu="$mcu_type" | tail -n1 )
+	local imagesize=$( echo -e "$hello_world" | avr-cpp -P -mmcu="$mcu_type" | tail -n1 )
 
 	# e.g. 0xFFFF + 1 = 65536
 	echo $(( $imagesize + 1 ))


### PR DESCRIPTION
Ethersex scripts use AVR-CPP to retrieve constant values from AVR header files.

With GCC 4 the following instruction
```bash
echo -e "#include <avr/io.h>\nRAMEND-RAMSTART" | ./avr-cpp -mmcu=atmega2560
```
prints
```c
# 2 "<stdin>" 2
0x21FF -0x200
```

But with GCC 5 it prints
```c
# 2 "<stdin>" 2
0x21FF
# 2 "<stdin>"
     -
# 2 "<stdin>" 3
      0x200
```

This breaks the calculation. If we add option ```-P``` to the call of CPP the result is fine again.

```c
0x21FF -0x200
```
