### PR TITLE
modbus 8e1 support + mb options to menuconfig

### DIFF
--- a/contrib/autotest/profiles/openvpn-cast5-md5-ipv6
+++ b/contrib/autotest/profiles/openvpn-cast5-md5-ipv6
@@ -23,6 +23,7 @@ MCU=atmega644
 atmega644=y
 # atmega644p is not set
 # atmega1284p is not set
+# atmega2560 is not set
 # at90can32 is not set
 # at90can64 is not set
 # at90can128 is not set
@@ -32,6 +33,7 @@ FREQ=20000000
 # antares_IO is not set
 # antares_O is not set
 # Arduino_Duemilanove is not set
+# arduino_mega2560_r3 is not set
 # beteigeuze is not set
 # conrad_probot is not set
 # ehaserl is not set
@@ -74,7 +76,7 @@ EEPROM_PAGESIZE=0x8
 # SPI_TIMEOUT is not set
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="ac826dc"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 DEBUG=y
 DEBUG_OUTPUT=usart
@@ -88,6 +90,23 @@ DEBUG_USE_USART=0
 DEBUG_BAUDRATE=115200
 # DEBUG_HOOK is not set
 # DEBUG_RESET_REASON is not set
+
+#
+# Periodic / Scheduler
+#
+CONF_MTICKS_PER_SEC=50
+# PERIODIC_TIMER3_SUPPORT is not set
+CONF_PERIODIC_USE_TIMER=1
+# PERIODIC_TIMER_API_SUPPORT is not set
+# PERIODIC_ADJUST_SUPPORT is not set
+# DEBUG_PERIODIC is not set
+# DEBUG_PERIODIC_ECMD_SUPPORT is not set
+# DEBUG_PERIODIC_WAVEFORMS_SUPPORT is not set
+# DEBUG_PERIODIC_OC1A_SUPPORT is not set
+# SCHEDULER_SUPPORT is not set
+# SCHEDULER_DYNAMIC_SUPPORT is not set
+CONF_SCHEDULER_NUM_DYNAMIC_TIMERS=8
+# DEBUG_SCHEDULER_SUPPORT is not set
 # STATUSLEDS is not set
 # STATUSLED_POWER_SUPPORT is not set
 # STATUSLED_BOOTED_SUPPORT is not set
@@ -257,7 +276,6 @@ CONF_OPENVPN_PORT=1194
 DEBUG_OPENVPN=y
 DEBUG_ROUTER=y
 # DEBUG_UIP is not set
-# DEBUG_NTP is not set
 # DEBUG_UNKNOWN_PACKETS is not set
 
 #
@@ -317,6 +335,8 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD Displays
 #
 # HD44780_SUPPORT is not set
+# HD44780_BACKLIGHT_SUPPORT is not set
+# HD44780_MULTIENSUPPORT is not set
 # HD44780_BACKLIGHT_INV is not set
 # HR20_LCD_SUPPORT_FULL is not set
 # S1D15G10_SUPPORT is not set
@@ -326,6 +346,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD_SUPPORT is not set
 # DEBUG_HD44780 is not set
 # DEBUG_LCD_MENU is not set
+# DEBUG_HD44780_I2C is not set
 
 #
 # Storage
@@ -353,6 +374,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # I2C_PCF8574X_SUPPORT is not set
 # I2C_PCA9555_SUPPORT is not set
 # I2C_MAX7311_SUPPORT is not set
+# I2C_MCP23017_SUPPORT is not set
 # I2C_UDP_SUPPORT is not set
 # DEBUG_I2C is not set
 # I2C_SLAVE_SUPPORT is not set
@@ -441,26 +463,6 @@ REMOTE_IRMP_PORT=10001
 # DEBUG_IRMP is not set
 # DEBUG_REMOTE_IRMP is not set
 # PSB2186_SUPPORT is not set
-# PWM_SUPPORT is not set
-# PWM_GENERAL_SUPPORT is not set
-# PWM_GENERAL_INVERT_SUPPORT is not set
-# PWM_GENERAL_FADING_SUPPORT is not set
-# CH_A_PWM_GENERAL_SUPPORT is not set
-# CH_B_PWM_GENERAL_SUPPORT is not set
-# CH_C_PWM_GENERAL_SUPPORT is not set
-# PWM_WAV_SUPPORT is not set
-# VFS_PWM_WAV_SUPPORT is not set
-# PWM_MELODY_SUPPORT is not set
-# ENTCHEN_PWM_MELODY_SUPPORT is not set
-# TETRIS_PWM_MELODY_SUPPORT is not set
-# PWM_SERVO_SUPPORT is not set
-PWM_SERVOS=1
-# PWM_SERVO_INVERT is not set
-# PWM_SERVO_DEFAULT_ENABLED is not set
-# PWM_FREQ_SUPPORT is not set
-# PWM_DTMF_SUPPORT is not set
-# DEBUG_PWM is not set
-# DEBUG_PWM_SERVO is not set
 # ONEWIRE_SUPPORT is not set
 # ONEWIRE_DETECT_SUPPORT is not set
 # ONEWIRE_DS2502_SUPPORT is not set
@@ -492,6 +494,9 @@ PWM_SERVOS=1
 # ULTRASONIC_SUPPORT is not set
 # DEBUG_ULTRASONIC is not set
 # HBRIDGE_SUPPORT is not set
+# DUAL_HBRIDGE_SUPPORT is not set
+# SHARE_ENABLE_HBRIDGE_SUPPORT is not set
+# HBRIDGE_INVERTER_SUPPORT is not set
 # DEBUG_HBRIDGE is not set
 # MCUF_SUPPORT is not set
 # MCUF_SERIAL_SUPPORT is not set
@@ -536,6 +541,8 @@ NET_MAX_FRAME_LENGTH_GT_571=y
 CONF_ARTNET_PORT=6454
 CONF_ARTNET_INUNIVERSE=1
 CONF_ARTNET_OUTUNIVERSE=0
+CONF_ARTNET_OUTPUT_IP=""
+# CONF_ARTNET_SEND_POLL_REPLY is not set
 # DEBUG_ARTNET is not set
 # DALI_SUPPORT is not set
 # DALI_RAW_SUPPORT is not set
@@ -547,6 +554,7 @@ ECMD_PARSER_SUPPORT=y
 # ECMD_PAM_SUPPORT is not set
 # ECMD_SCRIPT_SUPPORT is not set
 # ECMD_LOG_VIA_SYSLOG is not set
+# ECMD_SERIAL_USART_SUPPORT is not set
 ECMD_TCP_SUPPORT=y
 ECMD_TCP_PORT=2701
 # ECMD_UDP_SUPPORT is not set
@@ -575,12 +583,6 @@ ECMD_TCP_PORT=2701
 # DEBUG_ECMD_SCRIPT is not set
 # ELTAKOMS_SUPPORT is not set
 # EMS_SUPPORT is not set
-EMS_BUFFER_LEN=64
-EMS_PORT=7950
-# EMS_DEBUG_STATS is not set
-# EMS_PROTO_DEBUG is not set
-# EMS_IO_DEBUG is not set
-# EMS_ERROR_DEBUG is not set
 # FNORDLICHT_SUPPORT is not set
 # HTTPLOG_SUPPORT is not set
 CONF_HTTPLOG_SERVICE="volkszaehler.org"
@@ -601,6 +603,11 @@ CONF_IRC_REALNAME="Ethersex Wollmilchsau"
 # DEBUG_IRC is not set
 # MDNS_SD_SUPPORT is not set
 # MODBUS_SUPPORT is not set
+# MQTT_SUPPORT is not set
+MQTT_CALLBACK_SLOTS=1
+# MQTT_STATIC_CONF is not set
+# MQTT_DEBUG is not set
+# MQTT_PARSE_DEBUG is not set
 # MYSQL_SUPPORT is not set
 CONF_MYSQL_IP="2001:6f8:1209:f0:230:5ff:fe23:3f8"
 CONF_MYSQL_USERNAME="root"
@@ -634,6 +641,8 @@ CONF_NETSTAT_API="/~habo/stat/"
 # PROTO_INTERTECHNO_SUPPORT is not set
 # PROTO_INTERTECHNO_SL_SUPPORT is not set
 # PROTO_OASEFMMASTER_SUPPORT is not set
+# PROTO_FA20RF_SUPPORT is not set
+# PROTO_SMOKEDETECTOR_SUPPORT is not set
 # SIP_SUPPORT is not set
 CONF_SIP_PROXY_IP=""
 CONF_SIP_FROM="621"
@@ -710,15 +719,17 @@ CW_WPM=12
 # CLOCK_SUPPORT is not set
 # CLOCK_DATETIME_SUPPORT is not set
 # CLOCK_CRYSTAL_SUPPORT is not set
-# CLOCK_CPU_SUPPORT is not set
-# CLOCK_NTP_ADJUST_SUPPORT is not set
+# CLOCK_PERIODIC_SUPPORT is not set
 # DCF77_SUPPORT is not set
 # DEBUG_DCF77 is not set
 # NTP_SUPPORT is not set
+NTP_SERVER_IP="2001:638:902:1:0:0:0:10"
+NTP_PORT=123
+NTP_QUERY_INTERVAL=1800
+# DEBUG_NTP is not set
 # NTPD_SUPPORT is not set
 # WHM_SUPPORT is not set
 # UPTIME_SUPPORT is not set
-# DEBUG_NTP_ADJUST is not set
 # CRON_SUPPORT is not set
 # CRON_DEFAULT_UTC is not set
 # CRON_SUPPORT_TEST is not set
@@ -742,6 +753,7 @@ DMX_FXSLOT_AMOUNT=4
 # DMX_FX_RANDOM is not set
 # DMX_FX_FIRE is not set
 # DMX_FX_WATER is not set
+# DMX_FX_RGB is not set
 # UDP_ECHO_NET_SUPPORT is not set
 # WOL_SUPPORT is not set
 # MOTD_SUPPORT is not set
@@ -785,6 +797,7 @@ STELLA_FADE_STEP_INIT=10
 STELLA_FADE_FUNCTION_INIT=stella_fade_func_0
 stella_fade_func_0=y
 # stella_fade_func_1 is not set
+# STELLA_USE_CIE1931 is not set
 # DEBUG_STELLA is not set
 # STARBURST_SUPPORT is not set
 # STARBURST_PCA9685 is not set
@@ -890,13 +903,6 @@ CONF_TIME2PRESS_POWER=40
 CONF_TIME2PRESS_POWERL=3
 # PROJECTOR_SANYO_Z700_SUPPORT is not set
 # FREQCOUNT_SUPPORT is not set
-FREQCOUNT_CHANNELS=1
-# FREQCOUNT_BOOT_ON is not set
-FREQCOUNT_AVERAGE=8
-# FREQCOUNT_NOSLOW_SUPPORT is not set
-# FREQCOUNT_DUTY_SUPPORT is not set
-# FREQCOUNT_MOVING_AVERAGE_SUPPORT is not set
-# FREQCOUNT_DEBUGGING is not set
 # TANKLEVEL_SUPPORT is not set
 TANKLEVEL_ADC_CHANNEL=0
 # TANKLEVEL_STARTUP is not set
@@ -916,10 +922,12 @@ TANKLEVEL_HOLD_TIME=20
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -934,12 +942,15 @@ avrispmkII=y
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -949,6 +960,8 @@ avrispmkII=y
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -959,13 +972,22 @@ avrispmkII=y
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -981,6 +1003,7 @@ avrispmkII=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set

--- a/contrib/autotest/profiles/rs485-modbus-dmx-onewire-compile-test
+++ b/contrib/autotest/profiles/rs485-modbus-dmx-onewire-compile-test
@@ -22,6 +22,7 @@ ARCH_AVR=y
 # atmega644 is not set
 # atmega644p is not set
 # atmega1284p is not set
+# atmega2560 is not set
 # at90can32 is not set
 # at90can64 is not set
 MCU=at90can128
@@ -32,6 +33,7 @@ FREQ=16000000
 # antares_IO is not set
 # antares_O is not set
 # Arduino_Duemilanove is not set
+# arduino_mega2560_r3 is not set
 HARDWARE=beteigeuze
 beteigeuze=y
 # conrad_probot is not set
@@ -65,7 +67,7 @@ BOOTLOADER_SIZE=0
 BOOTLOADER_START_ADDRESS=0x20000
 FLASH_SIZE=0x20000
 EEPROM_SIZE=0x1000
-RAM_SIZE=0x1000
+RAM_SIZE=0x1100
 FLASH_PAGESIZE=0x100
 EEPROM_PAGESIZE=0x8
 # CRC_PAD_SUPPORT is not set
@@ -74,21 +76,35 @@ EEPROM_PAGESIZE=0x8
 # SPI_TIMEOUT is not set
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="ac826dc"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 DEBUG=y
-# soft_uart is not set
-DEBUG_OUTPUT=syslog
-syslog=y
-# soft_uart is not set
+DEBUG_OUTPUT=soft_uart
+soft_uart=y
 # syslog is not set
-# soft_uart is not set
-# syslog is not set
-DEBUG_USE_SYSLOG=y
+SOFT_UART_SUPPORT=y
 # DEBUG_SERIAL_USART_SUPPORT is not set
-# SOFT_UART_SUPPORT is not set
+# DEBUG_USE_SYSLOG is not set
+DEBUG_BAUDRATE=19200
 # DEBUG_HOOK is not set
 # DEBUG_RESET_REASON is not set
+
+#
+# Periodic / Scheduler
+#
+CONF_MTICKS_PER_SEC=50
+# PERIODIC_TIMER3_SUPPORT is not set
+CONF_PERIODIC_USE_TIMER=1
+# PERIODIC_TIMER_API_SUPPORT is not set
+# PERIODIC_ADJUST_SUPPORT is not set
+# DEBUG_PERIODIC is not set
+# DEBUG_PERIODIC_ECMD_SUPPORT is not set
+# DEBUG_PERIODIC_WAVEFORMS_SUPPORT is not set
+# DEBUG_PERIODIC_OC1A_SUPPORT is not set
+# SCHEDULER_SUPPORT is not set
+# SCHEDULER_DYNAMIC_SUPPORT is not set
+CONF_SCHEDULER_NUM_DYNAMIC_TIMERS=8
+# DEBUG_SCHEDULER_SUPPORT is not set
 # STATUSLEDS is not set
 # STATUSLED_POWER_SUPPORT is not set
 # STATUSLED_BOOTED_SUPPORT is not set
@@ -263,7 +279,6 @@ CONF_OPENVPN_PORT=1194
 # DEBUG_OPENVPN is not set
 # DEBUG_ROUTER is not set
 # DEBUG_UIP is not set
-# DEBUG_NTP is not set
 # DEBUG_UNKNOWN_PACKETS is not set
 
 #
@@ -324,6 +339,8 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD Displays
 #
 # HD44780_SUPPORT is not set
+# HD44780_BACKLIGHT_SUPPORT is not set
+# HD44780_MULTIENSUPPORT is not set
 # HD44780_BACKLIGHT_INV is not set
 # HR20_LCD_SUPPORT_FULL is not set
 # S1D15G10_SUPPORT is not set
@@ -333,6 +350,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD_SUPPORT is not set
 # DEBUG_HD44780 is not set
 # DEBUG_LCD_MENU is not set
+# DEBUG_HD44780_I2C is not set
 
 #
 # Storage
@@ -360,6 +378,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # I2C_PCF8574X_SUPPORT is not set
 # I2C_PCA9555_SUPPORT is not set
 # I2C_MAX7311_SUPPORT is not set
+# I2C_MCP23017_SUPPORT is not set
 # I2C_UDP_SUPPORT is not set
 # DEBUG_I2C is not set
 # I2C_SLAVE_SUPPORT is not set
@@ -448,26 +467,6 @@ REMOTE_IRMP_PORT=10001
 # DEBUG_IRMP is not set
 # DEBUG_REMOTE_IRMP is not set
 # PSB2186_SUPPORT is not set
-# PWM_SUPPORT is not set
-# PWM_GENERAL_SUPPORT is not set
-# PWM_GENERAL_INVERT_SUPPORT is not set
-# PWM_GENERAL_FADING_SUPPORT is not set
-# CH_A_PWM_GENERAL_SUPPORT is not set
-# CH_B_PWM_GENERAL_SUPPORT is not set
-# CH_C_PWM_GENERAL_SUPPORT is not set
-# PWM_WAV_SUPPORT is not set
-# VFS_PWM_WAV_SUPPORT is not set
-# PWM_MELODY_SUPPORT is not set
-# ENTCHEN_PWM_MELODY_SUPPORT is not set
-# TETRIS_PWM_MELODY_SUPPORT is not set
-# PWM_SERVO_SUPPORT is not set
-PWM_SERVOS=1
-# PWM_SERVO_INVERT is not set
-# PWM_SERVO_DEFAULT_ENABLED is not set
-# PWM_FREQ_SUPPORT is not set
-# PWM_DTMF_SUPPORT is not set
-# DEBUG_PWM is not set
-# DEBUG_PWM_SERVO is not set
 ONEWIRE_SUPPORT=y
 ONEWIRE_DETECT_SUPPORT=y
 ONEWIRE_DS2502_SUPPORT=y
@@ -505,6 +504,9 @@ DEBUG_OW_POLLING=y
 # ULTRASONIC_SUPPORT is not set
 # DEBUG_ULTRASONIC is not set
 # HBRIDGE_SUPPORT is not set
+# DUAL_HBRIDGE_SUPPORT is not set
+# SHARE_ENABLE_HBRIDGE_SUPPORT is not set
+# HBRIDGE_INVERTER_SUPPORT is not set
 # DEBUG_HBRIDGE is not set
 # MCUF_SUPPORT is not set
 # MCUF_SERIAL_SUPPORT is not set
@@ -549,6 +551,8 @@ MCUF_MODUL_DISPLAY_MODE_RANDOM=y
 CONF_ARTNET_PORT=6454
 CONF_ARTNET_INUNIVERSE=1
 CONF_ARTNET_OUTUNIVERSE=0
+CONF_ARTNET_OUTPUT_IP="192.168.0.255"
+# CONF_ARTNET_SEND_POLL_REPLY is not set
 # DEBUG_ARTNET is not set
 # DALI_SUPPORT is not set
 # DALI_RAW_SUPPORT is not set
@@ -591,12 +595,6 @@ DEBUG_ECMD_OW_ROM=y
 # DEBUG_ECMD_SCRIPT is not set
 # ELTAKOMS_SUPPORT is not set
 # EMS_SUPPORT is not set
-EMS_BUFFER_LEN=64
-EMS_PORT=7950
-# EMS_DEBUG_STATS is not set
-# EMS_PROTO_DEBUG is not set
-# EMS_IO_DEBUG is not set
-# EMS_ERROR_DEBUG is not set
 # FNORDLICHT_SUPPORT is not set
 # HTTPLOG_SUPPORT is not set
 CONF_HTTPLOG_SERVICE="volkszaehler.org"
@@ -620,9 +618,18 @@ MODBUS_SUPPORT=y
 # MODBUS_USART_0 is not set
 MODBUS_USART_1=y
 MODBUS_USE_USART=1
+MODBUS_BAUDRATE=9600
+# MODBUS_USART_CONFIG_8N1 is not set
+MODBUS_USART_CONFIG=MODBUS_USART_CONFIG_8E1
+MODBUS_USART_CONFIG_8E1=y
 MODBUS_CLIENT_SUPPORT=y
 MODBUS_ADDRESS=240
 MODBUS_BROADCAST=255
+# MQTT_SUPPORT is not set
+MQTT_CALLBACK_SLOTS=1
+# MQTT_STATIC_CONF is not set
+# MQTT_DEBUG is not set
+# MQTT_PARSE_DEBUG is not set
 # MYSQL_SUPPORT is not set
 CONF_MYSQL_IP="192.168.23.254"
 CONF_MYSQL_USERNAME="root"
@@ -656,6 +663,8 @@ CONF_NETSTAT_API="/~habo/stat/"
 # PROTO_INTERTECHNO_SUPPORT is not set
 # PROTO_INTERTECHNO_SL_SUPPORT is not set
 # PROTO_OASEFMMASTER_SUPPORT is not set
+# PROTO_FA20RF_SUPPORT is not set
+# PROTO_SMOKEDETECTOR_SUPPORT is not set
 # SIP_SUPPORT is not set
 CONF_SIP_PROXY_IP="192.168.178.1"
 CONF_SIP_FROM="621"
@@ -732,15 +741,17 @@ CW_WPM=12
 # CLOCK_SUPPORT is not set
 # CLOCK_DATETIME_SUPPORT is not set
 # CLOCK_CRYSTAL_SUPPORT is not set
-# CLOCK_CPU_SUPPORT is not set
-# CLOCK_NTP_ADJUST_SUPPORT is not set
+# CLOCK_PERIODIC_SUPPORT is not set
 # DCF77_SUPPORT is not set
 # DEBUG_DCF77 is not set
 # NTP_SUPPORT is not set
+NTP_SERVER_IP="192.53.103.108"
+NTP_PORT=123
+NTP_QUERY_INTERVAL=1800
+# DEBUG_NTP is not set
 # NTPD_SUPPORT is not set
 # WHM_SUPPORT is not set
 # UPTIME_SUPPORT is not set
-# DEBUG_NTP_ADJUST is not set
 # CRON_SUPPORT is not set
 # CRON_DEFAULT_UTC is not set
 # CRON_SUPPORT_TEST is not set
@@ -764,6 +775,7 @@ DMX_FX_RAINBOW=y
 DMX_FX_RANDOM=y
 DMX_FX_FIRE=y
 DMX_FX_WATER=y
+# DMX_FX_RGB is not set
 # UDP_ECHO_NET_SUPPORT is not set
 # WOL_SUPPORT is not set
 # MOTD_SUPPORT is not set
@@ -809,6 +821,7 @@ stella_fade_func_0=y
 # stella_fade_func_1 is not set
 STELLA_UNIVERSE=1
 STELLA_UNIVERSE_OFFSET=0
+# STELLA_USE_CIE1931 is not set
 # DEBUG_STELLA is not set
 # STARBURST_SUPPORT is not set
 # STARBURST_PCA9685 is not set
@@ -914,13 +927,6 @@ CONF_TIME2PRESS_POWER=40
 CONF_TIME2PRESS_POWERL=3
 # PROJECTOR_SANYO_Z700_SUPPORT is not set
 # FREQCOUNT_SUPPORT is not set
-FREQCOUNT_CHANNELS=1
-# FREQCOUNT_BOOT_ON is not set
-FREQCOUNT_AVERAGE=8
-# FREQCOUNT_NOSLOW_SUPPORT is not set
-# FREQCOUNT_DUTY_SUPPORT is not set
-# FREQCOUNT_MOVING_AVERAGE_SUPPORT is not set
-# FREQCOUNT_DEBUGGING is not set
 # TANKLEVEL_SUPPORT is not set
 TANKLEVEL_ADC_CHANNEL=0
 # TANKLEVEL_STARTUP is not set
@@ -942,10 +948,12 @@ IPV4_SUPPORT=y
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -960,12 +968,15 @@ avrispmkII=y
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -975,6 +986,8 @@ avrispmkII=y
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -985,13 +998,22 @@ avrispmkII=y
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -1007,6 +1029,7 @@ avrispmkII=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set

--- a/contrib/autotest/profiles/whale-ipv6
+++ b/contrib/autotest/profiles/whale-ipv6
@@ -23,6 +23,7 @@ ARCH_AVR=y
 MCU=atmega644p
 atmega644p=y
 # atmega1284p is not set
+# atmega2560 is not set
 # at90can32 is not set
 # at90can64 is not set
 # at90can128 is not set
@@ -32,6 +33,7 @@ FREQ=20000000
 # antares_IO is not set
 # antares_O is not set
 # Arduino_Duemilanove is not set
+# arduino_mega2560_r3 is not set
 # beteigeuze is not set
 # conrad_probot is not set
 # ehaserl is not set
@@ -74,7 +76,7 @@ EEPROM_PAGESIZE=0x8
 # SPI_TIMEOUT is not set
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="ac826dc"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 DEBUG=y
 DEBUG_OUTPUT=usart
@@ -90,6 +92,23 @@ DEBUG_USE_USART=0
 DEBUG_BAUDRATE=115200
 # DEBUG_HOOK is not set
 # DEBUG_RESET_REASON is not set
+
+#
+# Periodic / Scheduler
+#
+CONF_MTICKS_PER_SEC=50
+# PERIODIC_TIMER3_SUPPORT is not set
+CONF_PERIODIC_USE_TIMER=1
+# PERIODIC_TIMER_API_SUPPORT is not set
+# PERIODIC_ADJUST_SUPPORT is not set
+# DEBUG_PERIODIC is not set
+# DEBUG_PERIODIC_ECMD_SUPPORT is not set
+# DEBUG_PERIODIC_WAVEFORMS_SUPPORT is not set
+# DEBUG_PERIODIC_OC1A_SUPPORT is not set
+# SCHEDULER_SUPPORT is not set
+# SCHEDULER_DYNAMIC_SUPPORT is not set
+CONF_SCHEDULER_NUM_DYNAMIC_TIMERS=8
+# DEBUG_SCHEDULER_SUPPORT is not set
 # STATUSLEDS is not set
 # STATUSLED_POWER_SUPPORT is not set
 # STATUSLED_BOOTED_SUPPORT is not set
@@ -278,7 +297,6 @@ DEBUG_NET_IP6=y
 DEBUG_OPENVPN=y
 DEBUG_ROUTER=y
 DEBUG_UIP=y
-DEBUG_NTP=y
 DEBUG_UNKNOWN_PACKETS=y
 
 #
@@ -291,10 +309,11 @@ PORTIO_FULL_FEATURED=y
 # PORTIO_SIMPLE_SUPPORT is not set
 PORTIO_SUPPORT=y
 NAMED_PIN_SUPPORT=y
+# Jackalope is not set
+# arduino_mega2560 is not set
 # conrad_probot is not set
 _NP_CONFIG=default
 default=y
-# Jackalope is not set
 # netio_k8io is not set
 # radig_web is not set
 NP_CONFIG=pinning/named_pin/default
@@ -359,9 +378,9 @@ HD44780_DIREKT=y
 # HD44780_I2CSUPPORT is not set
 # HD44780_SERLCD is not set
 # HD44780_2WIRE is not set
-# HD44780_READBACK is not set
-# HD44780_MULTIENSUPPORT is not set
 # HD44780_BACKLIGHT_SUPPORT is not set
+# HD44780_MULTIENSUPPORT is not set
+# HD44780_READBACK is not set
 # HD44780_BACKLIGHT_INV is not set
 # HR20_LCD_SUPPORT_FULL is not set
 # S1D15G10_SUPPORT is not set
@@ -371,6 +390,7 @@ HD44780_DIREKT=y
 LCD_SUPPORT=y
 # DEBUG_HD44780 is not set
 # DEBUG_LCD_MENU is not set
+# DEBUG_HD44780_I2C is not set
 
 #
 # Storage
@@ -398,6 +418,7 @@ LCD_SUPPORT=y
 # I2C_PCF8574X_SUPPORT is not set
 # I2C_PCA9555_SUPPORT is not set
 # I2C_MAX7311_SUPPORT is not set
+# I2C_MCP23017_SUPPORT is not set
 # I2C_UDP_SUPPORT is not set
 # DEBUG_I2C is not set
 # I2C_SLAVE_SUPPORT is not set
@@ -486,26 +507,6 @@ REMOTE_IRMP_PORT=10001
 # DEBUG_IRMP is not set
 # DEBUG_REMOTE_IRMP is not set
 # PSB2186_SUPPORT is not set
-# PWM_SUPPORT is not set
-# PWM_GENERAL_SUPPORT is not set
-# PWM_GENERAL_INVERT_SUPPORT is not set
-# PWM_GENERAL_FADING_SUPPORT is not set
-# CH_A_PWM_GENERAL_SUPPORT is not set
-# CH_B_PWM_GENERAL_SUPPORT is not set
-# CH_C_PWM_GENERAL_SUPPORT is not set
-# PWM_WAV_SUPPORT is not set
-# VFS_PWM_WAV_SUPPORT is not set
-# PWM_MELODY_SUPPORT is not set
-# ENTCHEN_PWM_MELODY_SUPPORT is not set
-# TETRIS_PWM_MELODY_SUPPORT is not set
-# PWM_SERVO_SUPPORT is not set
-PWM_SERVOS=1
-# PWM_SERVO_INVERT is not set
-# PWM_SERVO_DEFAULT_ENABLED is not set
-# PWM_FREQ_SUPPORT is not set
-# PWM_DTMF_SUPPORT is not set
-# DEBUG_PWM is not set
-# DEBUG_PWM_SERVO is not set
 ONEWIRE_SUPPORT=y
 # ONEWIRE_DETECT_SUPPORT is not set
 # ONEWIRE_DS2502_SUPPORT is not set
@@ -537,6 +538,9 @@ ONEWIRE_SUPPORT=y
 # ULTRASONIC_SUPPORT is not set
 # DEBUG_ULTRASONIC is not set
 # HBRIDGE_SUPPORT is not set
+# DUAL_HBRIDGE_SUPPORT is not set
+# SHARE_ENABLE_HBRIDGE_SUPPORT is not set
+# HBRIDGE_INVERTER_SUPPORT is not set
 # DEBUG_HBRIDGE is not set
 # MCUF_SUPPORT is not set
 # MCUF_SERIAL_SUPPORT is not set
@@ -581,6 +585,8 @@ NET_MAX_FRAME_LENGTH_GT_571=y
 CONF_ARTNET_PORT=6454
 CONF_ARTNET_INUNIVERSE=1
 CONF_ARTNET_OUTUNIVERSE=0
+CONF_ARTNET_OUTPUT_IP=""
+# CONF_ARTNET_SEND_POLL_REPLY is not set
 # DEBUG_ARTNET is not set
 # DALI_SUPPORT is not set
 # DALI_RAW_SUPPORT is not set
@@ -592,6 +598,7 @@ ECMD_PARSER_SUPPORT=y
 # ECMD_PAM_SUPPORT is not set
 # ECMD_SCRIPT_SUPPORT is not set
 # ECMD_LOG_VIA_SYSLOG is not set
+# ECMD_SERIAL_USART_SUPPORT is not set
 ECMD_TCP_SUPPORT=y
 ECMD_TCP_PORT=2701
 ECMD_UDP_SUPPORT=y
@@ -623,12 +630,6 @@ ECMD_SENDER_SUPPORT=y
 # DEBUG_ECMD_SCRIPT is not set
 # ELTAKOMS_SUPPORT is not set
 # EMS_SUPPORT is not set
-EMS_BUFFER_LEN=64
-EMS_PORT=7950
-# EMS_DEBUG_STATS is not set
-# EMS_PROTO_DEBUG is not set
-# EMS_IO_DEBUG is not set
-# EMS_ERROR_DEBUG is not set
 # FNORDLICHT_SUPPORT is not set
 # HTTPLOG_SUPPORT is not set
 CONF_HTTPLOG_SERVICE="volkszaehler.org"
@@ -649,6 +650,11 @@ CONF_IRC_REALNAME="Ethersex Wollmilchsau"
 # DEBUG_IRC is not set
 MDNS_SD_SUPPORT=y
 # MODBUS_SUPPORT is not set
+# MQTT_SUPPORT is not set
+MQTT_CALLBACK_SLOTS=1
+# MQTT_STATIC_CONF is not set
+# MQTT_DEBUG is not set
+# MQTT_PARSE_DEBUG is not set
 MYSQL_SUPPORT=y
 CONF_MYSQL_IP="2001:6f8:1209:f0:230:5ff:fe23:3f8"
 CONF_MYSQL_USERNAME="root"
@@ -682,6 +688,8 @@ CONF_NETSTAT_API="/~habo/stat/"
 # PROTO_INTERTECHNO_SUPPORT is not set
 # PROTO_INTERTECHNO_SL_SUPPORT is not set
 # PROTO_OASEFMMASTER_SUPPORT is not set
+# PROTO_FA20RF_SUPPORT is not set
+# PROTO_SMOKEDETECTOR_SUPPORT is not set
 # SIP_SUPPORT is not set
 CONF_SIP_PROXY_IP=""
 CONF_SIP_FROM="621"
@@ -777,8 +785,7 @@ DST_END_WEEK=5
 DST_END_DOW=0
 DST_END_HOUR=3
 CLOCK_CRYSTAL_SUPPORT=y
-# CLOCK_CPU_SUPPORT is not set
-# CLOCK_NTP_ADJUST_SUPPORT is not set
+# CLOCK_PERIODIC_SUPPORT is not set
 DCF77_SUPPORT=y
 DCF77_MODULE=DCFANA
 DCFANA=y
@@ -789,10 +796,10 @@ NTP_SUPPORT=y
 NTP_SERVER="time6.ipv6.uni-muenster.de"
 NTP_PORT=123
 NTP_QUERY_INTERVAL=1800
+DEBUG_NTP=y
 NTPD_SUPPORT=y
 WHM_SUPPORT=y
 # UPTIME_SUPPORT is not set
-# DEBUG_NTP_ADJUST is not set
 # CRON_SUPPORT is not set
 # CRON_DEFAULT_UTC is not set
 # CRON_SUPPORT_TEST is not set
@@ -820,6 +827,7 @@ DMX_FXSLOT_AMOUNT=4
 # DMX_FX_RANDOM is not set
 # DMX_FX_FIRE is not set
 # DMX_FX_WATER is not set
+# DMX_FX_RGB is not set
 UDP_ECHO_NET_SUPPORT=y
 # WOL_SUPPORT is not set
 # MOTD_SUPPORT is not set
@@ -863,6 +871,7 @@ STELLA_FADE_STEP_INIT=10
 STELLA_FADE_FUNCTION_INIT=stella_fade_func_0
 stella_fade_func_0=y
 # stella_fade_func_1 is not set
+# STELLA_USE_CIE1931 is not set
 # DEBUG_STELLA is not set
 # STARBURST_SUPPORT is not set
 # STARBURST_PCA9685 is not set
@@ -967,13 +976,6 @@ CONF_TIME2PRESS_POWER=40
 CONF_TIME2PRESS_POWERL=3
 # PROJECTOR_SANYO_Z700_SUPPORT is not set
 # FREQCOUNT_SUPPORT is not set
-FREQCOUNT_CHANNELS=1
-# FREQCOUNT_BOOT_ON is not set
-FREQCOUNT_AVERAGE=8
-# FREQCOUNT_NOSLOW_SUPPORT is not set
-# FREQCOUNT_DUTY_SUPPORT is not set
-# FREQCOUNT_MOVING_AVERAGE_SUPPORT is not set
-# FREQCOUNT_DEBUGGING is not set
 # TANKLEVEL_SUPPORT is not set
 TANKLEVEL_ADC_CHANNEL=0
 # TANKLEVEL_STARTUP is not set
@@ -994,10 +996,12 @@ USART_SUPPORT=y
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -1012,12 +1016,15 @@ avrispmkII=y
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -1027,6 +1034,8 @@ avrispmkII=y
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -1037,13 +1046,22 @@ avrispmkII=y
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -1059,6 +1077,7 @@ avrispmkII=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set

--- a/core/usart.h
+++ b/core/usart.h
@@ -146,7 +146,7 @@ usart_init(void) \
   { \
     usart(UBRR,H) = UBRRH_VALUE; \
     usart(UBRR,L) = UBRRL_VALUE; \
-    /* set mode 8N1: 8 bits, 1 stop, even parity, asynchronous usart \
+    /* set mode 8E1: 8 bits, 1 stop, even parity, asynchronous usart \
      * and set URSEL, if present, */ \
     usart(UCSR,C) =  _BV(usart(UPM,1)) | _BV(usart(UCSZ,0)) | _BV(usart(UCSZ,1)) | _BV_URSEL; \
     /*enable the RX interrupt and receiver and transmitter */\

--- a/core/usart.h
+++ b/core/usart.h
@@ -135,6 +135,26 @@ usart_init(void) \
   } \
 }
 
+  /* init the usart module (8E1) */
+#define generate_usart_init_8E1() \
+static void \
+usart_init(void) \
+{\
+  /* The ATmega644 datasheet suggests to clear the global\
+   * interrupt flags on initialization ... */\
+  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) \
+  { \
+    usart(UBRR,H) = UBRRH_VALUE; \
+    usart(UBRR,L) = UBRRL_VALUE; \
+    /* set mode 8N1: 8 bits, 1 stop, even parity, asynchronous usart \
+     * and set URSEL, if present, */ \
+    usart(UCSR,C) =  _BV(usart(UPM,1)) | _BV(usart(UCSZ,0)) | _BV(usart(UCSZ,1)) | _BV_URSEL; \
+    /*enable the RX interrupt and receiver and transmitter */\
+     usart(UCSR,B) |= _BV(usart(TXEN)) | _BV(usart(RXEN)) | _BV(usart(RXCIE)); \
+    /* Set or not set the 2x mode */ \
+    USART_2X(); \
+  } \
+}
   /* init the usart module (8E2) */
 #define generate_usart_init_8E2() \
 static void \

--- a/doc/Configure.help
+++ b/doc/Configure.help
@@ -3444,3 +3444,16 @@ DEBUG_HD44780_I2C
 
   This logs the commands send to and read from to LCD via I2C
 
+MODBUS_BAUDRATE
+  Select the baudrate of the serial port for MODBUS RTU (RS485) application
+  
+  Typical values for Modbus applications are:
+  9600
+  19200
+  38400
+
+MODBUS_USART_CONFIG_8N1
+  Select the port mode you want to use with MODBUS:
+  8E1 stands for: 8 data bits, even parity, 1 stop bit (Modbus default)
+  8N1 stands for: 8 data bits, no parity, 1 stop bit
+

--- a/pinning/hardware/netio.m4
+++ b/pinning/hardware/netio.m4
@@ -1,6 +1,6 @@
 ifdef(`conf_MODBUS', `dnl
   /* add support for RS485 */
-  pin(RS485TE_USART0, PC0, OUTPUT)
+  pin(RS485TE_USART0, PD3, OUTPUT)
 ')dnl
 
 /* port the enc28j60 is attached to */

--- a/pinning/hardware/netio.m4
+++ b/pinning/hardware/netio.m4
@@ -1,5 +1,7 @@
-/* add support for RS485 */
-pin(RS485TE_USART0, PD2, OUTPUT)
+ifdef(`conf_MODBUS', `dnl
+  /* add support for RS485 */
+  pin(RS485TE_USART0, PC0, OUTPUT)
+')dnl
 
 /* port the enc28j60 is attached to */
 pin(SPI_CS_NET, SPI_CS_HARDWARE)

--- a/pinning/hardware/netio.m4
+++ b/pinning/hardware/netio.m4
@@ -1,8 +1,3 @@
-ifdef(`conf_MODBUS', `dnl
-  /* add support for RS485 */
-  pin(RS485TE_USART0, PD3, OUTPUT)
-')dnl
-
 /* port the enc28j60 is attached to */
 pin(SPI_CS_NET, SPI_CS_HARDWARE)
 

--- a/pinning/hardware/netio.m4
+++ b/pinning/hardware/netio.m4
@@ -1,3 +1,6 @@
+/* add support for RS485 */
+pin(RS485TE_USART0, PD2, OUTPUT)
+
 /* port the enc28j60 is attached to */
 pin(SPI_CS_NET, SPI_CS_HARDWARE)
 

--- a/protocols/modbus/config.in
+++ b/protocols/modbus/config.in
@@ -1,6 +1,6 @@
 usart_count_used
 if [ "$MODBUS_SUPPORT" = y -o $USARTS -gt $USARTS_USED ]; then
-  dep_bool "Modbus Support" MODBUS_SUPPORT 
+  dep_bool_menu "Modbus Support" MODBUS_SUPPORT 
     if [ "$MODBUS_SUPPORT" = y ]; then
       choice '  Modbus usart select' "$(usart_choice MODBUS)"
       usart_process_choice MODBUS
@@ -19,6 +19,8 @@ if [ "$MODBUS_SUPPORT" = y -o $USARTS -gt $USARTS_USED ]; then
     if [ "$MODBUS_CLIENT_SUPPORT" = y ]; then
       int "  Modbus Client Broadcast" MODBUS_BROADCAST 255
     fi
+  comment "  Remember to customize RS485 direction pin in pinning/hardware"
+  endmenu
 else
   define_bool MODBUS_SUPPORT n
 	comment "MODBUS not available. No free usart. ($USARTS_USED/$USARTS)"

--- a/protocols/modbus/config.in
+++ b/protocols/modbus/config.in
@@ -4,6 +4,11 @@ if [ "$MODBUS_SUPPORT" = y -o $USARTS -gt $USARTS_USED ]; then
     if [ "$MODBUS_SUPPORT" = y ]; then
       choice '  Modbus usart select' "$(usart_choice MODBUS)"
       usart_process_choice MODBUS
+      int    "  Modbus usart baudrate" MODBUS_BAUDRATE 9600
+      choice '  Modbus usart config'   \
+            "8N1            MODBUS_USART_CONFIG_8N1          \
+             8E1            MODBUS_USART_CONFIG_8E1" \
+            '8E1' MODBUS_USART_CONFIG
     fi
     if [ "$MODBUS_SUPPORT" = y ]; then
       bool "  Modbus Client Stack" MODBUS_CLIENT_SUPPORT  n

--- a/protocols/modbus/modbus.c
+++ b/protocols/modbus/modbus.c
@@ -43,9 +43,17 @@
 struct modbus_connection_state_t modbus_client_state;
 #endif
 
+#define MODBUS_USART_CONFIG_8N1	1
+#define MODBUS_USART_CONFIG_8E1	2
 
 /* We generate our own usart init module, for our usart port */
-generate_usart_init()
+#if MODBUS_USART_CONFIG == MODBUS_USART_CONFIG_8N1
+        generate_usart_init()
+#elif MODBUS_USART_CONFIG == MODBUS_USART_CONFIG_8E1
+        generate_usart_init_8E1()
+#else
+        #error "MODBUS_USART_CONFIG not correctly defined"
+#endif
 
 volatile struct modbus_buffer modbus_data;
 

--- a/protocols/modbus/modbus.h
+++ b/protocols/modbus/modbus.h
@@ -23,9 +23,6 @@
 #ifndef _MODBUS_H
 #define _MODBUS_H
 
-/* Default baudrate */
-#define MODBUS_BAUDRATE 9600
-
 struct modbus_buffer {
   uint8_t *data;
   uint8_t sent;

--- a/scripts/add-hardware
+++ b/scripts/add-hardware
@@ -476,6 +476,12 @@ FNORD
     pin(PSB2186_ALE, PD4, OUTPUT)
 FNORD
 
+  template $MODBUS_SUPPORT << FNORD
+    /* port config for RS485 */
+    /* used by MODBUS and bidirectional DMX */
+    pin(pin(RS485TE_USART0, PD3, OUTPUT)
+FNORD
+
 fi
 
 ) > "pinning/hardware/$hw.m4"

--- a/scripts/profiles/Jackalope
+++ b/scripts/profiles/Jackalope
@@ -23,6 +23,7 @@ atmega168=y
 # atmega644 is not set
 # atmega644p is not set
 # atmega1284p is not set
+# atmega2560 is not set
 # at90can32 is not set
 # at90can64 is not set
 # at90can128 is not set
@@ -32,6 +33,7 @@ FREQ=20000000
 # antares_IO is not set
 # antares_O is not set
 # Arduino_Duemilanove is not set
+# arduino_mega2560_r3 is not set
 # beteigeuze is not set
 # conrad_probot is not set
 # ehaserl is not set
@@ -74,7 +76,7 @@ EEPROM_PAGESIZE=0x4
 SPI_TIMEOUT=y
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="ac826dc"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 DEBUG=y
 DEBUG_OUTPUT=usart
@@ -88,6 +90,23 @@ DEBUG_USE_USART=0
 DEBUG_BAUDRATE=115200
 # DEBUG_HOOK is not set
 # DEBUG_RESET_REASON is not set
+
+#
+# Periodic / Scheduler
+#
+CONF_MTICKS_PER_SEC=50
+# PERIODIC_TIMER3_SUPPORT is not set
+CONF_PERIODIC_USE_TIMER=1
+# PERIODIC_TIMER_API_SUPPORT is not set
+# PERIODIC_ADJUST_SUPPORT is not set
+# DEBUG_PERIODIC is not set
+# DEBUG_PERIODIC_ECMD_SUPPORT is not set
+# DEBUG_PERIODIC_WAVEFORMS_SUPPORT is not set
+# DEBUG_PERIODIC_OC1A_SUPPORT is not set
+# SCHEDULER_SUPPORT is not set
+# SCHEDULER_DYNAMIC_SUPPORT is not set
+CONF_SCHEDULER_NUM_DYNAMIC_TIMERS=8
+# DEBUG_SCHEDULER_SUPPORT is not set
 # STATUSLEDS is not set
 # STATUSLED_POWER_SUPPORT is not set
 # STATUSLED_BOOTED_SUPPORT is not set
@@ -262,7 +281,6 @@ CONF_OPENVPN_PORT=1194
 # DEBUG_OPENVPN is not set
 # DEBUG_ROUTER is not set
 # DEBUG_UIP is not set
-# DEBUG_NTP is not set
 # DEBUG_UNKNOWN_PACKETS is not set
 
 #
@@ -275,10 +293,11 @@ PORTIO_SIMPLE=y
 PORTIO_SIMPLE_SUPPORT=y
 # PORTIO_SUPPORT is not set
 NAMED_PIN_SUPPORT=y
-# conrad_probot is not set
-# default is not set
 _NP_CONFIG=Jackalope
 Jackalope=y
+# arduino_mega2560 is not set
+# conrad_probot is not set
+# default is not set
 # netio_k8io is not set
 # radig_web is not set
 NP_CONFIG=pinning/named_pin/Jackalope
@@ -329,6 +348,8 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD Displays
 #
 # HD44780_SUPPORT is not set
+# HD44780_BACKLIGHT_SUPPORT is not set
+# HD44780_MULTIENSUPPORT is not set
 # HD44780_BACKLIGHT_INV is not set
 # HR20_LCD_SUPPORT_FULL is not set
 # S1D15G10_SUPPORT is not set
@@ -338,6 +359,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD_SUPPORT is not set
 # DEBUG_HD44780 is not set
 # DEBUG_LCD_MENU is not set
+# DEBUG_HD44780_I2C is not set
 
 #
 # Storage
@@ -365,6 +387,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # I2C_PCF8574X_SUPPORT is not set
 # I2C_PCA9555_SUPPORT is not set
 # I2C_MAX7311_SUPPORT is not set
+# I2C_MCP23017_SUPPORT is not set
 # I2C_UDP_SUPPORT is not set
 # DEBUG_I2C is not set
 # I2C_SLAVE_SUPPORT is not set
@@ -453,26 +476,6 @@ REMOTE_IRMP_PORT=10001
 # DEBUG_IRMP is not set
 # DEBUG_REMOTE_IRMP is not set
 # PSB2186_SUPPORT is not set
-# PWM_SUPPORT is not set
-# PWM_GENERAL_SUPPORT is not set
-# PWM_GENERAL_INVERT_SUPPORT is not set
-# PWM_GENERAL_FADING_SUPPORT is not set
-# CH_A_PWM_GENERAL_SUPPORT is not set
-# CH_B_PWM_GENERAL_SUPPORT is not set
-# CH_C_PWM_GENERAL_SUPPORT is not set
-# PWM_WAV_SUPPORT is not set
-# VFS_PWM_WAV_SUPPORT is not set
-# PWM_MELODY_SUPPORT is not set
-# ENTCHEN_PWM_MELODY_SUPPORT is not set
-# TETRIS_PWM_MELODY_SUPPORT is not set
-# PWM_SERVO_SUPPORT is not set
-PWM_SERVOS=1
-# PWM_SERVO_INVERT is not set
-# PWM_SERVO_DEFAULT_ENABLED is not set
-# PWM_FREQ_SUPPORT is not set
-# PWM_DTMF_SUPPORT is not set
-# DEBUG_PWM is not set
-# DEBUG_PWM_SERVO is not set
 # ONEWIRE_SUPPORT is not set
 # ONEWIRE_DETECT_SUPPORT is not set
 # ONEWIRE_DS2502_SUPPORT is not set
@@ -504,6 +507,9 @@ PWM_SERVOS=1
 # ULTRASONIC_SUPPORT is not set
 # DEBUG_ULTRASONIC is not set
 # HBRIDGE_SUPPORT is not set
+# DUAL_HBRIDGE_SUPPORT is not set
+# SHARE_ENABLE_HBRIDGE_SUPPORT is not set
+# HBRIDGE_INVERTER_SUPPORT is not set
 # DEBUG_HBRIDGE is not set
 # MCUF_SUPPORT is not set
 # MCUF_SERIAL_SUPPORT is not set
@@ -548,6 +554,8 @@ MCUF_MODUL_DISPLAY_MODE_RANDOM=y
 CONF_ARTNET_PORT=6454
 CONF_ARTNET_INUNIVERSE=1
 CONF_ARTNET_OUTUNIVERSE=0
+CONF_ARTNET_OUTPUT_IP="192.168.0.255"
+# CONF_ARTNET_SEND_POLL_REPLY is not set
 # DEBUG_ARTNET is not set
 # DALI_SUPPORT is not set
 # DALI_RAW_SUPPORT is not set
@@ -559,6 +567,7 @@ ECMD_PARSER_SUPPORT=y
 # ECMD_PAM_SUPPORT is not set
 # ECMD_SCRIPT_SUPPORT is not set
 # ECMD_LOG_VIA_SYSLOG is not set
+# ECMD_SERIAL_USART_SUPPORT is not set
 # ECMD_TCP_SUPPORT is not set
 ECMD_UDP_SUPPORT=y
 ECMD_UDP_PORT=2701
@@ -587,12 +596,6 @@ ECMD_UDP_PORT=2701
 # DEBUG_ECMD_SCRIPT is not set
 # ELTAKOMS_SUPPORT is not set
 # EMS_SUPPORT is not set
-EMS_BUFFER_LEN=64
-EMS_PORT=7950
-# EMS_DEBUG_STATS is not set
-# EMS_PROTO_DEBUG is not set
-# EMS_IO_DEBUG is not set
-# EMS_ERROR_DEBUG is not set
 # FNORDLICHT_SUPPORT is not set
 # HTTPLOG_SUPPORT is not set
 CONF_HTTPLOG_SERVICE="volkszaehler.org"
@@ -613,6 +616,11 @@ CONF_IRC_REALNAME="Ethersex Wollmilchsau"
 # DEBUG_IRC is not set
 # MDNS_SD_SUPPORT is not set
 # MODBUS_SUPPORT is not set
+# MQTT_SUPPORT is not set
+MQTT_CALLBACK_SLOTS=1
+# MQTT_STATIC_CONF is not set
+# MQTT_DEBUG is not set
+# MQTT_PARSE_DEBUG is not set
 # MYSQL_SUPPORT is not set
 CONF_MYSQL_IP="192.168.23.254"
 CONF_MYSQL_USERNAME="root"
@@ -646,6 +654,8 @@ CONF_NETSTAT_API="/~habo/stat/"
 # PROTO_INTERTECHNO_SUPPORT is not set
 # PROTO_INTERTECHNO_SL_SUPPORT is not set
 # PROTO_OASEFMMASTER_SUPPORT is not set
+# PROTO_FA20RF_SUPPORT is not set
+# PROTO_SMOKEDETECTOR_SUPPORT is not set
 # SIP_SUPPORT is not set
 CONF_SIP_PROXY_IP="192.168.178.1"
 CONF_SIP_FROM="621"
@@ -722,15 +732,17 @@ CW_WPM=12
 # CLOCK_SUPPORT is not set
 # CLOCK_DATETIME_SUPPORT is not set
 # CLOCK_CRYSTAL_SUPPORT is not set
-# CLOCK_CPU_SUPPORT is not set
-# CLOCK_NTP_ADJUST_SUPPORT is not set
+# CLOCK_PERIODIC_SUPPORT is not set
 # DCF77_SUPPORT is not set
 # DEBUG_DCF77 is not set
 # NTP_SUPPORT is not set
+NTP_SERVER_IP="192.53.103.108"
+NTP_PORT=123
+NTP_QUERY_INTERVAL=1800
+# DEBUG_NTP is not set
 # NTPD_SUPPORT is not set
 # WHM_SUPPORT is not set
 # UPTIME_SUPPORT is not set
-# DEBUG_NTP_ADJUST is not set
 # CRON_SUPPORT is not set
 # CRON_DEFAULT_UTC is not set
 # CRON_SUPPORT_TEST is not set
@@ -754,6 +766,7 @@ DMX_FXSLOT_AMOUNT=4
 # DMX_FX_RANDOM is not set
 # DMX_FX_FIRE is not set
 # DMX_FX_WATER is not set
+# DMX_FX_RGB is not set
 # UDP_ECHO_NET_SUPPORT is not set
 # WOL_SUPPORT is not set
 # MOTD_SUPPORT is not set
@@ -797,6 +810,7 @@ STELLA_FADE_STEP_INIT=10
 STELLA_FADE_FUNCTION_INIT=stella_fade_func_0
 stella_fade_func_0=y
 # stella_fade_func_1 is not set
+# STELLA_USE_CIE1931 is not set
 # DEBUG_STELLA is not set
 # STARBURST_SUPPORT is not set
 # STARBURST_PCA9685 is not set
@@ -902,13 +916,6 @@ CONF_TIME2PRESS_POWER=40
 CONF_TIME2PRESS_POWERL=3
 # PROJECTOR_SANYO_Z700_SUPPORT is not set
 # FREQCOUNT_SUPPORT is not set
-FREQCOUNT_CHANNELS=1
-# FREQCOUNT_BOOT_ON is not set
-FREQCOUNT_AVERAGE=8
-# FREQCOUNT_NOSLOW_SUPPORT is not set
-# FREQCOUNT_DUTY_SUPPORT is not set
-# FREQCOUNT_MOVING_AVERAGE_SUPPORT is not set
-# FREQCOUNT_DEBUGGING is not set
 # TANKLEVEL_SUPPORT is not set
 TANKLEVEL_ADC_CHANNEL=0
 # TANKLEVEL_STARTUP is not set
@@ -929,10 +936,12 @@ IPV4_SUPPORT=y
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -947,12 +956,15 @@ avrispmkII=y
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -962,6 +974,8 @@ avrispmkII=y
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -972,13 +986,22 @@ avrispmkII=y
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -994,6 +1017,7 @@ avrispmkII=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set

--- a/scripts/profiles/JeeLinkv2
+++ b/scripts/profiles/JeeLinkv2
@@ -23,6 +23,7 @@ atmega328p=y
 # atmega644 is not set
 # atmega644p is not set
 # atmega1284p is not set
+# atmega2560 is not set
 # at90can32 is not set
 # at90can64 is not set
 # at90can128 is not set
@@ -32,6 +33,7 @@ FREQ=16000000
 # antares_IO is not set
 # antares_O is not set
 # Arduino_Duemilanove is not set
+# arduino_mega2560_r3 is not set
 # beteigeuze is not set
 # conrad_probot is not set
 # ehaserl is not set
@@ -74,7 +76,7 @@ EEPROM_PAGESIZE=0x4
 # SPI_TIMEOUT is not set
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="ac826dc"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 # DEBUG is not set
 # DEBUG_USE_SYSLOG is not set
@@ -82,6 +84,23 @@ GIT_VERSION="ac826dc"
 # SOFT_UART_SUPPORT is not set
 # DEBUG_HOOK is not set
 # DEBUG_RESET_REASON is not set
+
+#
+# Periodic / Scheduler
+#
+CONF_MTICKS_PER_SEC=50
+# PERIODIC_TIMER3_SUPPORT is not set
+CONF_PERIODIC_USE_TIMER=1
+# PERIODIC_TIMER_API_SUPPORT is not set
+# PERIODIC_ADJUST_SUPPORT is not set
+# DEBUG_PERIODIC is not set
+# DEBUG_PERIODIC_ECMD_SUPPORT is not set
+# DEBUG_PERIODIC_WAVEFORMS_SUPPORT is not set
+# DEBUG_PERIODIC_OC1A_SUPPORT is not set
+# SCHEDULER_SUPPORT is not set
+# SCHEDULER_DYNAMIC_SUPPORT is not set
+CONF_SCHEDULER_NUM_DYNAMIC_TIMERS=8
+# DEBUG_SCHEDULER_SUPPORT is not set
 STATUSLEDS=y
 # STATUSLED_POWER_SUPPORT is not set
 # STATUSLED_BOOTED_SUPPORT is not set
@@ -266,7 +285,6 @@ CONF_OPENVPN_PORT=1194
 # DEBUG_OPENVPN is not set
 # DEBUG_ROUTER is not set
 # DEBUG_UIP is not set
-# DEBUG_NTP is not set
 # DEBUG_UNKNOWN_PACKETS is not set
 
 #
@@ -326,6 +344,8 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD Displays
 #
 # HD44780_SUPPORT is not set
+# HD44780_BACKLIGHT_SUPPORT is not set
+# HD44780_MULTIENSUPPORT is not set
 # HD44780_BACKLIGHT_INV is not set
 # HR20_LCD_SUPPORT_FULL is not set
 # S1D15G10_SUPPORT is not set
@@ -335,6 +355,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD_SUPPORT is not set
 # DEBUG_HD44780 is not set
 # DEBUG_LCD_MENU is not set
+# DEBUG_HD44780_I2C is not set
 
 #
 # Storage
@@ -362,6 +383,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # I2C_PCF8574X_SUPPORT is not set
 # I2C_PCA9555_SUPPORT is not set
 # I2C_MAX7311_SUPPORT is not set
+# I2C_MCP23017_SUPPORT is not set
 # I2C_UDP_SUPPORT is not set
 # DEBUG_I2C is not set
 # I2C_SLAVE_SUPPORT is not set
@@ -450,26 +472,6 @@ REMOTE_IRMP_PORT=10001
 # DEBUG_IRMP is not set
 # DEBUG_REMOTE_IRMP is not set
 # PSB2186_SUPPORT is not set
-# PWM_SUPPORT is not set
-# PWM_GENERAL_SUPPORT is not set
-# PWM_GENERAL_INVERT_SUPPORT is not set
-# PWM_GENERAL_FADING_SUPPORT is not set
-# CH_A_PWM_GENERAL_SUPPORT is not set
-# CH_B_PWM_GENERAL_SUPPORT is not set
-# CH_C_PWM_GENERAL_SUPPORT is not set
-# PWM_WAV_SUPPORT is not set
-# VFS_PWM_WAV_SUPPORT is not set
-# PWM_MELODY_SUPPORT is not set
-# ENTCHEN_PWM_MELODY_SUPPORT is not set
-# TETRIS_PWM_MELODY_SUPPORT is not set
-# PWM_SERVO_SUPPORT is not set
-PWM_SERVOS=1
-# PWM_SERVO_INVERT is not set
-# PWM_SERVO_DEFAULT_ENABLED is not set
-# PWM_FREQ_SUPPORT is not set
-# PWM_DTMF_SUPPORT is not set
-# DEBUG_PWM is not set
-# DEBUG_PWM_SERVO is not set
 # ONEWIRE_SUPPORT is not set
 # ONEWIRE_DETECT_SUPPORT is not set
 # ONEWIRE_DS2502_SUPPORT is not set
@@ -501,6 +503,9 @@ PWM_SERVOS=1
 # ULTRASONIC_SUPPORT is not set
 # DEBUG_ULTRASONIC is not set
 # HBRIDGE_SUPPORT is not set
+# DUAL_HBRIDGE_SUPPORT is not set
+# SHARE_ENABLE_HBRIDGE_SUPPORT is not set
+# HBRIDGE_INVERTER_SUPPORT is not set
 # DEBUG_HBRIDGE is not set
 # MCUF_SUPPORT is not set
 # MCUF_SERIAL_SUPPORT is not set
@@ -545,6 +550,8 @@ MCUF_MODUL_DISPLAY_MODE_RANDOM=y
 CONF_ARTNET_PORT=6454
 CONF_ARTNET_INUNIVERSE=1
 CONF_ARTNET_OUTUNIVERSE=0
+CONF_ARTNET_OUTPUT_IP="192.168.0.255"
+# CONF_ARTNET_SEND_POLL_REPLY is not set
 # DEBUG_ARTNET is not set
 # DALI_SUPPORT is not set
 # DALI_RAW_SUPPORT is not set
@@ -585,12 +592,6 @@ FREE_SUPPORT=y
 # DEBUG_ECMD_SCRIPT is not set
 # ELTAKOMS_SUPPORT is not set
 # EMS_SUPPORT is not set
-EMS_BUFFER_LEN=64
-EMS_PORT=7950
-# EMS_DEBUG_STATS is not set
-# EMS_PROTO_DEBUG is not set
-# EMS_IO_DEBUG is not set
-# EMS_ERROR_DEBUG is not set
 # FNORDLICHT_SUPPORT is not set
 # HTTPLOG_SUPPORT is not set
 CONF_HTTPLOG_SERVICE="volkszaehler.org"
@@ -611,6 +612,11 @@ CONF_IRC_REALNAME="Ethersex Wollmilchsau"
 # DEBUG_IRC is not set
 # MDNS_SD_SUPPORT is not set
 # MODBUS_SUPPORT is not set
+# MQTT_SUPPORT is not set
+MQTT_CALLBACK_SLOTS=1
+# MQTT_STATIC_CONF is not set
+# MQTT_DEBUG is not set
+# MQTT_PARSE_DEBUG is not set
 # MYSQL_SUPPORT is not set
 CONF_MYSQL_IP="192.168.23.254"
 CONF_MYSQL_USERNAME="root"
@@ -644,6 +650,8 @@ CONF_NETSTAT_API="/~habo/stat/"
 # PROTO_INTERTECHNO_SUPPORT is not set
 # PROTO_INTERTECHNO_SL_SUPPORT is not set
 # PROTO_OASEFMMASTER_SUPPORT is not set
+# PROTO_FA20RF_SUPPORT is not set
+# PROTO_SMOKEDETECTOR_SUPPORT is not set
 # SIP_SUPPORT is not set
 CONF_SIP_PROXY_IP="192.168.178.1"
 CONF_SIP_FROM="621"
@@ -734,15 +742,17 @@ DST_END_WEEK=5
 DST_END_DOW=0
 DST_END_HOUR=3
 # CLOCK_CRYSTAL_SUPPORT is not set
-# CLOCK_CPU_SUPPORT is not set
-# CLOCK_NTP_ADJUST_SUPPORT is not set
+# CLOCK_PERIODIC_SUPPORT is not set
 # DCF77_SUPPORT is not set
 # DEBUG_DCF77 is not set
 # NTP_SUPPORT is not set
+NTP_SERVER_IP="192.53.103.108"
+NTP_PORT=123
+NTP_QUERY_INTERVAL=1800
+# DEBUG_NTP is not set
 # NTPD_SUPPORT is not set
 WHM_SUPPORT=y
 # UPTIME_SUPPORT is not set
-# DEBUG_NTP_ADJUST is not set
 # CRON_SUPPORT is not set
 # CRON_DEFAULT_UTC is not set
 # CRON_SUPPORT_TEST is not set
@@ -766,6 +776,7 @@ DMX_FXSLOT_AMOUNT=4
 # DMX_FX_RANDOM is not set
 # DMX_FX_FIRE is not set
 # DMX_FX_WATER is not set
+# DMX_FX_RGB is not set
 # UDP_ECHO_NET_SUPPORT is not set
 # WOL_SUPPORT is not set
 # MOTD_SUPPORT is not set
@@ -809,6 +820,7 @@ STELLA_FADE_STEP_INIT=10
 STELLA_FADE_FUNCTION_INIT=stella_fade_func_0
 stella_fade_func_0=y
 # stella_fade_func_1 is not set
+# STELLA_USE_CIE1931 is not set
 # DEBUG_STELLA is not set
 # STARBURST_SUPPORT is not set
 # STARBURST_PCA9685 is not set
@@ -914,13 +926,6 @@ CONF_TIME2PRESS_POWER=40
 CONF_TIME2PRESS_POWERL=3
 # PROJECTOR_SANYO_Z700_SUPPORT is not set
 # FREQCOUNT_SUPPORT is not set
-FREQCOUNT_CHANNELS=1
-# FREQCOUNT_BOOT_ON is not set
-FREQCOUNT_AVERAGE=8
-# FREQCOUNT_NOSLOW_SUPPORT is not set
-# FREQCOUNT_DUTY_SUPPORT is not set
-# FREQCOUNT_MOVING_AVERAGE_SUPPORT is not set
-# FREQCOUNT_DEBUGGING is not set
 # TANKLEVEL_SUPPORT is not set
 TANKLEVEL_ADC_CHANNEL=0
 # TANKLEVEL_STARTUP is not set
@@ -942,10 +947,12 @@ IPV4_SUPPORT=y
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -960,12 +967,15 @@ avrispmkII=y
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -975,6 +985,8 @@ avrispmkII=y
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -985,13 +997,22 @@ avrispmkII=y
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -1007,6 +1028,7 @@ avrispmkII=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set

--- a/scripts/profiles/USBrfm12stick
+++ b/scripts/profiles/USBrfm12stick
@@ -23,6 +23,7 @@ atmega88=y
 # atmega644 is not set
 # atmega644p is not set
 # atmega1284p is not set
+# atmega2560 is not set
 # at90can32 is not set
 # at90can64 is not set
 # at90can128 is not set
@@ -32,6 +33,7 @@ FREQ=16000000
 # antares_IO is not set
 # antares_O is not set
 # Arduino_Duemilanove is not set
+# arduino_mega2560_r3 is not set
 # beteigeuze is not set
 # conrad_probot is not set
 # ehaserl is not set
@@ -74,7 +76,7 @@ TEENSY_SUPPORT=y
 # SPI_TIMEOUT is not set
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="ac826dc"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 # DEBUG is not set
 # DEBUG_USE_SYSLOG is not set
@@ -82,6 +84,23 @@ GIT_VERSION="ac826dc"
 # SOFT_UART_SUPPORT is not set
 # DEBUG_HOOK is not set
 # DEBUG_RESET_REASON is not set
+
+#
+# Periodic / Scheduler
+#
+CONF_MTICKS_PER_SEC=50
+# PERIODIC_TIMER3_SUPPORT is not set
+CONF_PERIODIC_USE_TIMER=1
+# PERIODIC_TIMER_API_SUPPORT is not set
+# PERIODIC_ADJUST_SUPPORT is not set
+# DEBUG_PERIODIC is not set
+# DEBUG_PERIODIC_ECMD_SUPPORT is not set
+# DEBUG_PERIODIC_WAVEFORMS_SUPPORT is not set
+# DEBUG_PERIODIC_OC1A_SUPPORT is not set
+# SCHEDULER_SUPPORT is not set
+# SCHEDULER_DYNAMIC_SUPPORT is not set
+CONF_SCHEDULER_NUM_DYNAMIC_TIMERS=8
+# DEBUG_SCHEDULER_SUPPORT is not set
 STATUSLEDS=y
 # STATUSLED_POWER_SUPPORT is not set
 # STATUSLED_BOOTED_SUPPORT is not set
@@ -267,7 +286,6 @@ CONF_OPENVPN_PORT=1194
 # DEBUG_OPENVPN is not set
 # DEBUG_ROUTER is not set
 # DEBUG_UIP is not set
-# DEBUG_NTP is not set
 # DEBUG_UNKNOWN_PACKETS is not set
 
 #
@@ -277,8 +295,6 @@ PORTIO_SCHEME=CONFIG_IO_NONE
 CONFIG_IO_NONE=y
 # PORTIO_SIMPLE is not set
 # PORTIO_FULL_FEATURED is not set
-# PORTIO_SIMPLE_SUPPORT is not set
-# PORTIO_SUPPORT is not set
 # NAMED_PIN_SUPPORT is not set
 # TTY_SUPPORT is not set
 TTY_COLS=16
@@ -326,6 +342,8 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD Displays
 #
 # HD44780_SUPPORT is not set
+# HD44780_BACKLIGHT_SUPPORT is not set
+# HD44780_MULTIENSUPPORT is not set
 # HD44780_BACKLIGHT_INV is not set
 # HR20_LCD_SUPPORT is not set
 # S1D15G10_SUPPORT is not set
@@ -335,6 +353,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD_SUPPORT is not set
 # DEBUG_HD44780 is not set
 # DEBUG_LCD_MENU is not set
+# DEBUG_HD44780_I2C is not set
 
 #
 # Storage
@@ -362,6 +381,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # I2C_PCF8574X_SUPPORT is not set
 # I2C_PCA9555_SUPPORT is not set
 # I2C_MAX7311_SUPPORT is not set
+# I2C_MCP23017_SUPPORT is not set
 # I2C_UDP_SUPPORT is not set
 # DEBUG_I2C is not set
 # I2C_SLAVE_SUPPORT is not set
@@ -459,26 +479,6 @@ REMOTE_IRMP_PORT=10001
 # DEBUG_IRMP is not set
 # DEBUG_REMOTE_IRMP is not set
 # PSB2186_SUPPORT is not set
-# PWM_SUPPORT is not set
-# PWM_GENERAL_SUPPORT is not set
-# PWM_GENERAL_INVERT_SUPPORT is not set
-# PWM_GENERAL_FADING_SUPPORT is not set
-# CH_A_PWM_GENERAL_SUPPORT is not set
-# CH_B_PWM_GENERAL_SUPPORT is not set
-# CH_C_PWM_GENERAL_SUPPORT is not set
-# PWM_WAV_SUPPORT is not set
-# VFS_PWM_WAV_SUPPORT is not set
-# PWM_MELODY_SUPPORT is not set
-# ENTCHEN_PWM_MELODY_SUPPORT is not set
-# TETRIS_PWM_MELODY_SUPPORT is not set
-# PWM_SERVO_SUPPORT is not set
-PWM_SERVOS=1
-# PWM_SERVO_INVERT is not set
-# PWM_SERVO_DEFAULT_ENABLED is not set
-# PWM_FREQ_SUPPORT is not set
-# PWM_DTMF_SUPPORT is not set
-# DEBUG_PWM is not set
-# DEBUG_PWM_SERVO is not set
 # ONEWIRE_SUPPORT is not set
 # ONEWIRE_DETECT_SUPPORT is not set
 # ONEWIRE_DS2502_SUPPORT is not set
@@ -510,6 +510,9 @@ PWM_SERVOS=1
 # ULTRASONIC_SUPPORT is not set
 # DEBUG_ULTRASONIC is not set
 # HBRIDGE_SUPPORT is not set
+# DUAL_HBRIDGE_SUPPORT is not set
+# SHARE_ENABLE_HBRIDGE_SUPPORT is not set
+# HBRIDGE_INVERTER_SUPPORT is not set
 # DEBUG_HBRIDGE is not set
 # MCUF_SUPPORT is not set
 # MCUF_SERIAL_SUPPORT is not set
@@ -556,6 +559,8 @@ MCUF_MODUL_DISPLAY_MODE_RANDOM=y
 CONF_ARTNET_PORT=6454
 CONF_ARTNET_INUNIVERSE=1
 CONF_ARTNET_OUTUNIVERSE=0
+CONF_ARTNET_OUTPUT_IP="192.168.0.255"
+# CONF_ARTNET_SEND_POLL_REPLY is not set
 # DEBUG_ARTNET is not set
 # DALI_SUPPORT is not set
 # DALI_RAW_SUPPORT is not set
@@ -605,6 +610,7 @@ ECMD_TCP_PORT=2701
 # EMS_SUPPORT is not set
 EMS_BUFFER_LEN=192
 EMS_PORT=7950
+# EMS_USART_0 is not set
 # EMS_DEBUG_STATS is not set
 # EMS_PROTO_DEBUG is not set
 # EMS_IO_DEBUG is not set
@@ -636,6 +642,11 @@ CONF_IRC_REALNAME="Ethersex Wollmilchsau"
 # DEBUG_IRC is not set
 # MDNS_SD_SUPPORT is not set
 # MODBUS_SUPPORT is not set
+# MQTT_SUPPORT is not set
+MQTT_CALLBACK_SLOTS=1
+# MQTT_STATIC_CONF is not set
+# MQTT_DEBUG is not set
+# MQTT_PARSE_DEBUG is not set
 # MYSQL_SUPPORT is not set
 CONF_MYSQL_IP="192.168.23.254"
 CONF_MYSQL_USERNAME="root"
@@ -669,6 +680,8 @@ CONF_NETSTAT_API="/~habo/stat/"
 # PROTO_INTERTECHNO_SUPPORT is not set
 # PROTO_INTERTECHNO_SL_SUPPORT is not set
 # PROTO_OASEFMMASTER_SUPPORT is not set
+# PROTO_FA20RF_SUPPORT is not set
+# PROTO_SMOKEDETECTOR_SUPPORT is not set
 # SIP_SUPPORT is not set
 CONF_SIP_PROXY_IP="192.168.178.1"
 CONF_SIP_FROM="621"
@@ -732,10 +745,11 @@ BSBPORT_MESSAGE_BUFFER_LEN=10
 BSBPORT_MESSAGE_MAX_LEN=25
 BSBPORT_OWNADDRESS=7
 # BSBPORT_POLLING_SUPPORT is not set
+# BSBPORT_MQTT_SUPPORT is not set
 # DEBUG_BSBPORT_RX is not set
 # DEBUG_BSBPORT_TX is not set
-# DEBUG_BSBPORT_PARSE is not set
 # DEBUG_BSBPORT_ECMD is not set
+# DEBUG_BSBPORT_MQTT is not set
 # MSR1_SUPPORT is not set
 MSR1_USART_0=y
 MSR1_USE_USART=0
@@ -791,15 +805,17 @@ SGC_SLEEPMODE=0
 # CLOCK_DATE_SUPPORT is not set
 # CLOCK_TIME_SUPPORT is not set
 # CLOCK_CRYSTAL_SUPPORT is not set
-# CLOCK_CPU_SUPPORT is not set
-# CLOCK_NTP_ADJUST_SUPPORT is not set
+# CLOCK_PERIODIC_SUPPORT is not set
 # DCF77_SUPPORT is not set
 # DEBUG_DCF77 is not set
 # NTP_SUPPORT is not set
+NTP_SERVER_IP="192.53.103.108"
+NTP_PORT=123
+NTP_QUERY_INTERVAL=1800
+# DEBUG_NTP is not set
 # NTPD_SUPPORT is not set
 # WHM_SUPPORT is not set
 # UPTIME_SUPPORT is not set
-# DEBUG_NTP_ADJUST is not set
 # CRON_SUPPORT is not set
 # CRON_DEFAULT_UTC is not set
 # CRON_EEPROM_SUPPORT is not set
@@ -821,6 +837,7 @@ DMX_FXSLOT_AMOUNT=4
 # DMX_FX_RANDOM is not set
 # DMX_FX_FIRE is not set
 # DMX_FX_WATER is not set
+# DMX_FX_RGB is not set
 # UDP_ECHO_NET_SUPPORT is not set
 # WOL_SUPPORT is not set
 # MOTD_SUPPORT is not set
@@ -864,6 +881,7 @@ STELLA_FADE_STEP_INIT=10
 STELLA_FADE_FUNCTION_INIT=stella_fade_func_0
 stella_fade_func_0=y
 # stella_fade_func_1 is not set
+# STELLA_USE_CIE1931 is not set
 # DEBUG_STELLA is not set
 # STARBURST_SUPPORT is not set
 # STARBURST_PCA9685 is not set
@@ -971,13 +989,6 @@ CONF_TIME2PRESS_POWERL=3
 # SANYO_Z700_USART_0 is not set
 # DEBUG_SANYO_Z700 is not set
 # FREQCOUNT_SUPPORT is not set
-FREQCOUNT_CHANNELS=1
-# FREQCOUNT_BOOT_ON is not set
-FREQCOUNT_AVERAGE=8
-# FREQCOUNT_NOSLOW_SUPPORT is not set
-# FREQCOUNT_DUTY_SUPPORT is not set
-# FREQCOUNT_MOVING_AVERAGE_SUPPORT is not set
-# FREQCOUNT_DEBUGGING is not set
 # TANKLEVEL_SUPPORT is not set
 TANKLEVEL_ADC_CHANNEL=0
 # TANKLEVEL_STARTUP is not set
@@ -998,10 +1009,12 @@ IPV4_SUPPORT=y
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -1016,12 +1029,15 @@ avrispmkII=y
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -1031,6 +1047,8 @@ avrispmkII=y
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -1041,13 +1059,22 @@ avrispmkII=y
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -1063,6 +1090,7 @@ avrispmkII=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set

--- a/scripts/profiles/alpengluehn
+++ b/scripts/profiles/alpengluehn
@@ -23,6 +23,7 @@ ARCH_AVR=y
 MCU=atmega644p
 atmega644p=y
 # atmega1284p is not set
+# atmega2560 is not set
 # at90can32 is not set
 # at90can64 is not set
 # at90can128 is not set
@@ -33,6 +34,7 @@ alpengluehn=y
 # antares_IO is not set
 # antares_O is not set
 # Arduino_Duemilanove is not set
+# arduino_mega2560_r3 is not set
 # beteigeuze is not set
 # conrad_probot is not set
 # ehaserl is not set
@@ -74,7 +76,7 @@ EEPROM_PAGESIZE=0x8
 # SPI_TIMEOUT is not set
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="ac826dc"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 # DEBUG is not set
 # DEBUG_USE_SYSLOG is not set
@@ -82,6 +84,23 @@ GIT_VERSION="ac826dc"
 # SOFT_UART_SUPPORT is not set
 # DEBUG_HOOK is not set
 # DEBUG_RESET_REASON is not set
+
+#
+# Periodic / Scheduler
+#
+CONF_MTICKS_PER_SEC=50
+# PERIODIC_TIMER3_SUPPORT is not set
+CONF_PERIODIC_USE_TIMER=1
+# PERIODIC_TIMER_API_SUPPORT is not set
+# PERIODIC_ADJUST_SUPPORT is not set
+# DEBUG_PERIODIC is not set
+# DEBUG_PERIODIC_ECMD_SUPPORT is not set
+# DEBUG_PERIODIC_WAVEFORMS_SUPPORT is not set
+# DEBUG_PERIODIC_OC1A_SUPPORT is not set
+# SCHEDULER_SUPPORT is not set
+# SCHEDULER_DYNAMIC_SUPPORT is not set
+CONF_SCHEDULER_NUM_DYNAMIC_TIMERS=8
+# DEBUG_SCHEDULER_SUPPORT is not set
 # STATUSLEDS is not set
 # STATUSLED_POWER_SUPPORT is not set
 # STATUSLED_BOOTED_SUPPORT is not set
@@ -256,7 +275,6 @@ CONF_OPENVPN_PORT=1194
 # DEBUG_OPENVPN is not set
 # DEBUG_ROUTER is not set
 # DEBUG_UIP is not set
-# DEBUG_NTP is not set
 # DEBUG_UNKNOWN_PACKETS is not set
 
 #
@@ -317,6 +335,8 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD Displays
 #
 # HD44780_SUPPORT is not set
+# HD44780_BACKLIGHT_SUPPORT is not set
+# HD44780_MULTIENSUPPORT is not set
 # HD44780_BACKLIGHT_INV is not set
 # HR20_LCD_SUPPORT_FULL is not set
 # S1D15G10_SUPPORT is not set
@@ -326,6 +346,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD_SUPPORT is not set
 # DEBUG_HD44780 is not set
 # DEBUG_LCD_MENU is not set
+# DEBUG_HD44780_I2C is not set
 
 #
 # Storage
@@ -354,6 +375,7 @@ I2C_PCA9685_SUPPORT=y
 # I2C_PCF8574X_SUPPORT is not set
 # I2C_PCA9555_SUPPORT is not set
 # I2C_MAX7311_SUPPORT is not set
+# I2C_MCP23017_SUPPORT is not set
 # I2C_UDP_SUPPORT is not set
 # DEBUG_I2C is not set
 # I2C_SLAVE_SUPPORT is not set
@@ -452,26 +474,6 @@ REMOTE_IRMP_PORT=10001
 # DEBUG_IRMP is not set
 # DEBUG_REMOTE_IRMP is not set
 # PSB2186_SUPPORT is not set
-# PWM_SUPPORT is not set
-# PWM_GENERAL_SUPPORT is not set
-# PWM_GENERAL_INVERT_SUPPORT is not set
-# PWM_GENERAL_FADING_SUPPORT is not set
-# CH_A_PWM_GENERAL_SUPPORT is not set
-# CH_B_PWM_GENERAL_SUPPORT is not set
-# CH_C_PWM_GENERAL_SUPPORT is not set
-# PWM_WAV_SUPPORT is not set
-# VFS_PWM_WAV_SUPPORT is not set
-# PWM_MELODY_SUPPORT is not set
-# ENTCHEN_PWM_MELODY_SUPPORT is not set
-# TETRIS_PWM_MELODY_SUPPORT is not set
-# PWM_SERVO_SUPPORT is not set
-PWM_SERVOS=1
-# PWM_SERVO_INVERT is not set
-# PWM_SERVO_DEFAULT_ENABLED is not set
-# PWM_FREQ_SUPPORT is not set
-# PWM_DTMF_SUPPORT is not set
-# DEBUG_PWM is not set
-# DEBUG_PWM_SERVO is not set
 # ONEWIRE_SUPPORT is not set
 # ONEWIRE_DETECT_SUPPORT is not set
 # ONEWIRE_DS2502_SUPPORT is not set
@@ -503,6 +505,9 @@ PWM_SERVOS=1
 # ULTRASONIC_SUPPORT is not set
 # DEBUG_ULTRASONIC is not set
 # HBRIDGE_SUPPORT is not set
+# DUAL_HBRIDGE_SUPPORT is not set
+# SHARE_ENABLE_HBRIDGE_SUPPORT is not set
+# HBRIDGE_INVERTER_SUPPORT is not set
 # DEBUG_HBRIDGE is not set
 # MCUF_SUPPORT is not set
 # MCUF_SERIAL_SUPPORT is not set
@@ -550,6 +555,8 @@ ARTNET_SUPPORT=y
 CONF_ARTNET_PORT=6454
 CONF_ARTNET_INUNIVERSE=0
 CONF_ARTNET_OUTUNIVERSE=1
+CONF_ARTNET_OUTPUT_IP="192.168.0.255"
+# CONF_ARTNET_SEND_POLL_REPLY is not set
 # DEBUG_ARTNET is not set
 # DALI_SUPPORT is not set
 # DALI_RAW_SUPPORT is not set
@@ -599,6 +606,8 @@ FREE_SUPPORT=y
 # EMS_SUPPORT is not set
 EMS_BUFFER_LEN=255
 EMS_PORT=7950
+# EMS_USART_0 is not set
+# EMS_USART_1 is not set
 # EMS_DEBUG_STATS is not set
 # EMS_PROTO_DEBUG is not set
 # EMS_IO_DEBUG is not set
@@ -630,6 +639,11 @@ CONF_IRC_REALNAME="Ethersex Wollmilchsau"
 # DEBUG_IRC is not set
 # MDNS_SD_SUPPORT is not set
 # MODBUS_SUPPORT is not set
+# MQTT_SUPPORT is not set
+MQTT_CALLBACK_SLOTS=1
+# MQTT_STATIC_CONF is not set
+# MQTT_DEBUG is not set
+# MQTT_PARSE_DEBUG is not set
 # MYSQL_SUPPORT is not set
 CONF_MYSQL_IP="192.168.23.254"
 CONF_MYSQL_USERNAME="root"
@@ -663,6 +677,8 @@ CONF_NETSTAT_API="/~habo/stat/"
 # PROTO_INTERTECHNO_SUPPORT is not set
 # PROTO_INTERTECHNO_SL_SUPPORT is not set
 # PROTO_OASEFMMASTER_SUPPORT is not set
+# PROTO_FA20RF_SUPPORT is not set
+# PROTO_SMOKEDETECTOR_SUPPORT is not set
 # SIP_SUPPORT is not set
 CONF_SIP_PROXY_IP="192.168.178.1"
 CONF_SIP_FROM="621"
@@ -728,10 +744,11 @@ BSBPORT_MESSAGE_BUFFER_LEN=10
 BSBPORT_MESSAGE_MAX_LEN=25
 BSBPORT_OWNADDRESS=7
 # BSBPORT_POLLING_SUPPORT is not set
+# BSBPORT_MQTT_SUPPORT is not set
 # DEBUG_BSBPORT_RX is not set
 # DEBUG_BSBPORT_TX is not set
-# DEBUG_BSBPORT_PARSE is not set
 # DEBUG_BSBPORT_ECMD is not set
+# DEBUG_BSBPORT_MQTT is not set
 # MSR1_SUPPORT is not set
 MSR1_USART_0=y
 # MSR1_USART_1 is not set
@@ -790,15 +807,17 @@ SGC_SLEEPMODE=0
 # CLOCK_SUPPORT is not set
 # CLOCK_DATETIME_SUPPORT is not set
 # CLOCK_CRYSTAL_SUPPORT is not set
-# CLOCK_CPU_SUPPORT is not set
-# CLOCK_NTP_ADJUST_SUPPORT is not set
+# CLOCK_PERIODIC_SUPPORT is not set
 # DCF77_SUPPORT is not set
 # DEBUG_DCF77 is not set
 # NTP_SUPPORT is not set
+NTP_SERVER_IP="192.53.103.108"
+NTP_PORT=123
+NTP_QUERY_INTERVAL=1800
+# DEBUG_NTP is not set
 # NTPD_SUPPORT is not set
 # WHM_SUPPORT is not set
 # UPTIME_SUPPORT is not set
-# DEBUG_NTP_ADJUST is not set
 # CRON_SUPPORT is not set
 # CRON_DEFAULT_UTC is not set
 # CRON_SUPPORT_TEST is not set
@@ -822,6 +841,7 @@ DMX_FX_RAINBOW=y
 DMX_FX_RANDOM=y
 DMX_FX_FIRE=y
 DMX_FX_WATER=y
+# DMX_FX_RGB is not set
 # UDP_ECHO_NET_SUPPORT is not set
 # WOL_SUPPORT is not set
 # MOTD_SUPPORT is not set
@@ -867,6 +887,7 @@ stella_fade_func_0=y
 # stella_fade_func_1 is not set
 STELLA_UNIVERSE=1
 STELLA_UNIVERSE_OFFSET=0
+# STELLA_USE_CIE1931 is not set
 # DEBUG_STELLA is not set
 STARBURST_SUPPORT=y
 STARBURST_PCA9685=y
@@ -984,13 +1005,6 @@ CONF_TIME2PRESS_POWERL=3
 # SANYO_Z700_USART_1 is not set
 # DEBUG_SANYO_Z700 is not set
 # FREQCOUNT_SUPPORT is not set
-FREQCOUNT_CHANNELS=1
-# FREQCOUNT_BOOT_ON is not set
-FREQCOUNT_AVERAGE=8
-# FREQCOUNT_NOSLOW_SUPPORT is not set
-# FREQCOUNT_DUTY_SUPPORT is not set
-# FREQCOUNT_MOVING_AVERAGE_SUPPORT is not set
-# FREQCOUNT_DEBUGGING is not set
 # TANKLEVEL_SUPPORT is not set
 TANKLEVEL_ADC_CHANNEL=0
 # TANKLEVEL_STARTUP is not set
@@ -1011,10 +1025,12 @@ IPV4_SUPPORT=y
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -1029,12 +1045,15 @@ avrispmkII=y
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -1044,6 +1063,8 @@ avrispmkII=y
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -1054,13 +1075,22 @@ avrispmkII=y
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -1076,6 +1106,7 @@ avrispmkII=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set

--- a/scripts/profiles/antares_I
+++ b/scripts/profiles/antares_I
@@ -22,6 +22,7 @@ ARCH_AVR=y
 # atmega644 is not set
 # atmega644p is not set
 # atmega1284p is not set
+# atmega2560 is not set
 # at90can32 is not set
 # at90can64 is not set
 MCU=at90can128
@@ -33,6 +34,7 @@ antares_I=y
 # antares_IO is not set
 # antares_O is not set
 # Arduino_Duemilanove is not set
+# arduino_mega2560_r3 is not set
 # beteigeuze is not set
 # conrad_probot is not set
 # ehaserl is not set
@@ -65,7 +67,7 @@ BOOTLOADER_SIZE=8192
 BOOTLOADER_START_ADDRESS=0x1E000
 FLASH_SIZE=0x20000
 EEPROM_SIZE=0x1000
-RAM_SIZE=0x1000
+RAM_SIZE=0x1100
 FLASH_PAGESIZE=0x100
 EEPROM_PAGESIZE=0x8
 # CRC_PAD_SUPPORT is not set
@@ -74,7 +76,7 @@ EEPROM_PAGESIZE=0x8
 SPI_TIMEOUT=y
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="ac826dc"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 DEBUG=y
 # usart is not set
@@ -86,6 +88,23 @@ DEBUG_USE_SYSLOG=y
 # SOFT_UART_SUPPORT is not set
 # DEBUG_HOOK is not set
 DEBUG_RESET_REASON=y
+
+#
+# Periodic / Scheduler
+#
+CONF_MTICKS_PER_SEC=50
+# PERIODIC_TIMER3_SUPPORT is not set
+CONF_PERIODIC_USE_TIMER=1
+# PERIODIC_TIMER_API_SUPPORT is not set
+# PERIODIC_ADJUST_SUPPORT is not set
+# DEBUG_PERIODIC is not set
+# DEBUG_PERIODIC_ECMD_SUPPORT is not set
+# DEBUG_PERIODIC_WAVEFORMS_SUPPORT is not set
+# DEBUG_PERIODIC_OC1A_SUPPORT is not set
+# SCHEDULER_SUPPORT is not set
+# SCHEDULER_DYNAMIC_SUPPORT is not set
+CONF_SCHEDULER_NUM_DYNAMIC_TIMERS=8
+# DEBUG_SCHEDULER_SUPPORT is not set
 STATUSLEDS=y
 # STATUSLED_POWER_SUPPORT is not set
 # STATUSLED_BOOTED_SUPPORT is not set
@@ -260,7 +279,6 @@ CONF_OPENVPN_PORT=1194
 # DEBUG_OPENVPN is not set
 # DEBUG_ROUTER is not set
 # DEBUG_UIP is not set
-# DEBUG_NTP is not set
 # DEBUG_UNKNOWN_PACKETS is not set
 
 #
@@ -270,8 +288,6 @@ PORTIO_SCHEME=CONFIG_IO_NONE
 CONFIG_IO_NONE=y
 # PORTIO_SIMPLE is not set
 # PORTIO_FULL_FEATURED is not set
-# PORTIO_SIMPLE_SUPPORT is not set
-# PORTIO_SUPPORT is not set
 # NAMED_PIN_SUPPORT is not set
 # TTY_SUPPORT is not set
 TTY_COLS=16
@@ -321,6 +337,8 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD Displays
 #
 # HD44780_SUPPORT is not set
+# HD44780_BACKLIGHT_SUPPORT is not set
+# HD44780_MULTIENSUPPORT is not set
 # HD44780_BACKLIGHT_INV is not set
 # HR20_LCD_SUPPORT_FULL is not set
 # S1D15G10_SUPPORT is not set
@@ -330,6 +348,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD_SUPPORT is not set
 # DEBUG_HD44780 is not set
 # DEBUG_LCD_MENU is not set
+# DEBUG_HD44780_I2C is not set
 
 #
 # Storage
@@ -357,6 +376,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # I2C_PCF8574X_SUPPORT is not set
 # I2C_PCA9555_SUPPORT is not set
 # I2C_MAX7311_SUPPORT is not set
+# I2C_MCP23017_SUPPORT is not set
 # I2C_UDP_SUPPORT is not set
 # DEBUG_I2C is not set
 # I2C_SLAVE_SUPPORT is not set
@@ -456,26 +476,6 @@ DEBUG_IRMP=y
 IRSND_SUPPORT_SIRCS_PROTOCOL=y
 IRSND_SUPPORT_RC5_PROTOCOL=y
 # PSB2186_SUPPORT is not set
-# PWM_SUPPORT is not set
-# PWM_GENERAL_SUPPORT is not set
-# PWM_GENERAL_INVERT_SUPPORT is not set
-# PWM_GENERAL_FADING_SUPPORT is not set
-# CH_A_PWM_GENERAL_SUPPORT is not set
-# CH_B_PWM_GENERAL_SUPPORT is not set
-# CH_C_PWM_GENERAL_SUPPORT is not set
-# PWM_WAV_SUPPORT is not set
-# VFS_PWM_WAV_SUPPORT is not set
-# PWM_MELODY_SUPPORT is not set
-# ENTCHEN_PWM_MELODY_SUPPORT is not set
-# TETRIS_PWM_MELODY_SUPPORT is not set
-# PWM_SERVO_SUPPORT is not set
-PWM_SERVOS=1
-# PWM_SERVO_INVERT is not set
-# PWM_SERVO_DEFAULT_ENABLED is not set
-# PWM_FREQ_SUPPORT is not set
-# PWM_DTMF_SUPPORT is not set
-# DEBUG_PWM is not set
-# DEBUG_PWM_SERVO is not set
 ONEWIRE_SUPPORT=y
 ONEWIRE_DETECT_SUPPORT=y
 # ONEWIRE_DS2502_SUPPORT is not set
@@ -513,6 +513,9 @@ OW_SENSORS_COUNT=10
 # ULTRASONIC_SUPPORT is not set
 # DEBUG_ULTRASONIC is not set
 # HBRIDGE_SUPPORT is not set
+# DUAL_HBRIDGE_SUPPORT is not set
+# SHARE_ENABLE_HBRIDGE_SUPPORT is not set
+# HBRIDGE_INVERTER_SUPPORT is not set
 # DEBUG_HBRIDGE is not set
 # MCUF_SUPPORT is not set
 # MCUF_SERIAL_SUPPORT is not set
@@ -559,6 +562,8 @@ NET_MAX_FRAME_LENGTH_GT_571=y
 CONF_ARTNET_PORT=6454
 CONF_ARTNET_INUNIVERSE=1
 CONF_ARTNET_OUTUNIVERSE=0
+CONF_ARTNET_OUTPUT_IP="192.168.0.255"
+# CONF_ARTNET_SEND_POLL_REPLY is not set
 # DEBUG_ARTNET is not set
 # DALI_SUPPORT is not set
 # DALI_RAW_SUPPORT is not set
@@ -607,6 +612,8 @@ ELTAKOMS_USE_USART=1
 # EMS_SUPPORT is not set
 EMS_BUFFER_LEN=255
 EMS_PORT=7950
+# EMS_USART_0 is not set
+# EMS_USART_1 is not set
 # EMS_DEBUG_STATS is not set
 # EMS_PROTO_DEBUG is not set
 # EMS_IO_DEBUG is not set
@@ -638,6 +645,11 @@ CONF_IRC_REALNAME="Ethersex Wollmilchsau"
 # DEBUG_IRC is not set
 # MDNS_SD_SUPPORT is not set
 # MODBUS_SUPPORT is not set
+# MQTT_SUPPORT is not set
+MQTT_CALLBACK_SLOTS=1
+# MQTT_STATIC_CONF is not set
+# MQTT_DEBUG is not set
+# MQTT_PARSE_DEBUG is not set
 # MYSQL_SUPPORT is not set
 CONF_MYSQL_IP="192.168.1.7"
 CONF_MYSQL_USERNAME="root"
@@ -671,6 +683,8 @@ CONF_NETSTAT_API="/~habo/stat/"
 # PROTO_INTERTECHNO_SUPPORT is not set
 # PROTO_INTERTECHNO_SL_SUPPORT is not set
 # PROTO_OASEFMMASTER_SUPPORT is not set
+# PROTO_FA20RF_SUPPORT is not set
+# PROTO_SMOKEDETECTOR_SUPPORT is not set
 # SIP_SUPPORT is not set
 CONF_SIP_PROXY_IP="192.168.178.1"
 CONF_SIP_FROM="621"
@@ -735,10 +749,11 @@ BSBPORT_MESSAGE_BUFFER_LEN=10
 BSBPORT_MESSAGE_MAX_LEN=25
 BSBPORT_OWNADDRESS=7
 # BSBPORT_POLLING_SUPPORT is not set
+# BSBPORT_MQTT_SUPPORT is not set
 # DEBUG_BSBPORT_RX is not set
 # DEBUG_BSBPORT_TX is not set
-# DEBUG_BSBPORT_PARSE is not set
 # DEBUG_BSBPORT_ECMD is not set
+# DEBUG_BSBPORT_MQTT is not set
 # MSR1_SUPPORT is not set
 # MSR1_USART_0 is not set
 # MSR1_USART_1 is not set
@@ -808,18 +823,17 @@ DST_END_WEEK=5
 DST_END_DOW=0
 DST_END_HOUR=3
 # CLOCK_CRYSTAL_SUPPORT is not set
-CLOCK_CPU_SUPPORT=y
-# CLOCK_NTP_ADJUST_SUPPORT is not set
+# CLOCK_PERIODIC_SUPPORT is not set
 # DCF77_SUPPORT is not set
 # DEBUG_DCF77 is not set
 NTP_SUPPORT=y
 NTP_SERVER_IP="192.53.103.108"
 NTP_PORT=123
 NTP_QUERY_INTERVAL=1800
-NTPD_SUPPORT=y
+# DEBUG_NTP is not set
+# NTPD_SUPPORT is not set
 WHM_SUPPORT=y
 UPTIME_SUPPORT=y
-# DEBUG_NTP_ADJUST is not set
 # CRON_SUPPORT is not set
 # CRON_DEFAULT_UTC is not set
 # CRON_SUPPORT_TEST is not set
@@ -843,6 +857,7 @@ DMX_FXSLOT_AMOUNT=4
 # DMX_FX_RANDOM is not set
 # DMX_FX_FIRE is not set
 # DMX_FX_WATER is not set
+# DMX_FX_RGB is not set
 # UDP_ECHO_NET_SUPPORT is not set
 # WOL_SUPPORT is not set
 # MOTD_SUPPORT is not set
@@ -886,6 +901,7 @@ STELLA_FADE_STEP_INIT=10
 STELLA_FADE_FUNCTION_INIT=stella_fade_func_0
 stella_fade_func_0=y
 # stella_fade_func_1 is not set
+# STELLA_USE_CIE1931 is not set
 # DEBUG_STELLA is not set
 # STARBURST_SUPPORT is not set
 # STARBURST_PCA9685 is not set
@@ -1014,10 +1030,12 @@ IPV4_SUPPORT=y
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -1032,12 +1050,15 @@ avrispmkII=y
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -1047,6 +1068,8 @@ avrispmkII=y
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -1057,13 +1080,22 @@ avrispmkII=y
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -1079,6 +1111,7 @@ avrispmkII=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set

--- a/scripts/profiles/antares_IO
+++ b/scripts/profiles/antares_IO
@@ -22,6 +22,7 @@ ARCH_AVR=y
 # atmega644 is not set
 # atmega644p is not set
 # atmega1284p is not set
+# atmega2560 is not set
 # at90can32 is not set
 # at90can64 is not set
 MCU=at90can128
@@ -33,6 +34,7 @@ HARDWARE=antares_IO
 antares_IO=y
 # antares_O is not set
 # Arduino_Duemilanove is not set
+# arduino_mega2560_r3 is not set
 # beteigeuze is not set
 # conrad_probot is not set
 # ehaserl is not set
@@ -65,7 +67,7 @@ BOOTLOADER_SIZE=8192
 BOOTLOADER_START_ADDRESS=0x1E000
 FLASH_SIZE=0x20000
 EEPROM_SIZE=0x1000
-RAM_SIZE=0x1000
+RAM_SIZE=0x1100
 FLASH_PAGESIZE=0x100
 EEPROM_PAGESIZE=0x8
 # CRC_PAD_SUPPORT is not set
@@ -74,7 +76,7 @@ EEPROM_PAGESIZE=0x8
 SPI_TIMEOUT=y
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="ac826dc"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 # DEBUG is not set
 # DEBUG_USE_SYSLOG is not set
@@ -82,6 +84,23 @@ GIT_VERSION="ac826dc"
 # SOFT_UART_SUPPORT is not set
 # DEBUG_HOOK is not set
 # DEBUG_RESET_REASON is not set
+
+#
+# Periodic / Scheduler
+#
+CONF_MTICKS_PER_SEC=50
+# PERIODIC_TIMER3_SUPPORT is not set
+CONF_PERIODIC_USE_TIMER=1
+# PERIODIC_TIMER_API_SUPPORT is not set
+# PERIODIC_ADJUST_SUPPORT is not set
+# DEBUG_PERIODIC is not set
+# DEBUG_PERIODIC_ECMD_SUPPORT is not set
+# DEBUG_PERIODIC_WAVEFORMS_SUPPORT is not set
+# DEBUG_PERIODIC_OC1A_SUPPORT is not set
+# SCHEDULER_SUPPORT is not set
+# SCHEDULER_DYNAMIC_SUPPORT is not set
+CONF_SCHEDULER_NUM_DYNAMIC_TIMERS=8
+# DEBUG_SCHEDULER_SUPPORT is not set
 STATUSLEDS=y
 # STATUSLED_POWER_SUPPORT is not set
 # STATUSLED_BOOTED_SUPPORT is not set
@@ -258,7 +277,6 @@ CONF_OPENVPN_PORT=1194
 # DEBUG_OPENVPN is not set
 # DEBUG_ROUTER is not set
 # DEBUG_UIP is not set
-# DEBUG_NTP is not set
 # DEBUG_UNKNOWN_PACKETS is not set
 
 #
@@ -268,7 +286,6 @@ PORTIO_SCHEME=CONFIG_IO_NONE
 CONFIG_IO_NONE=y
 # PORTIO_SIMPLE is not set
 # PORTIO_FULL_FEATURED is not set
-# PORTIO_SIMPLE_SUPPORT is not set
 # NAMED_PIN_SUPPORT is not set
 # TTY_SUPPORT is not set
 TTY_COLS=16
@@ -318,6 +335,8 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD Displays
 #
 # HD44780_SUPPORT is not set
+# HD44780_BACKLIGHT_SUPPORT is not set
+# HD44780_MULTIENSUPPORT is not set
 # HD44780_BACKLIGHT_INV is not set
 # HR20_LCD_SUPPORT_FULL is not set
 # S1D15G10_SUPPORT is not set
@@ -327,6 +346,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD_SUPPORT is not set
 # DEBUG_HD44780 is not set
 # DEBUG_LCD_MENU is not set
+# DEBUG_HD44780_I2C is not set
 
 #
 # Storage
@@ -336,6 +356,7 @@ SD_READER_SUPPORT=y
 # SD_LFN_SUPPORT is not set
 # SD_READONLY is not set
 SD_WRITE_SUPPORT=y
+# SD_DATETIME_SUPPORT is not set
 SD_READ_TIMEOUT=y
 SD_PING_READ=y
 SD_PING_READ_SUPPORT=y
@@ -368,6 +389,7 @@ SD_PING_READ_SUPPORT=y
 # I2C_PCF8574X_SUPPORT is not set
 # I2C_PCA9555_SUPPORT is not set
 # I2C_MAX7311_SUPPORT is not set
+# I2C_MCP23017_SUPPORT is not set
 # I2C_UDP_SUPPORT is not set
 # DEBUG_I2C is not set
 # I2C_SLAVE_SUPPORT is not set
@@ -466,26 +488,6 @@ REMOTE_IRMP_PORT=10001
 # DEBUG_IRMP is not set
 # DEBUG_REMOTE_IRMP is not set
 # PSB2186_SUPPORT is not set
-# PWM_SUPPORT is not set
-# PWM_GENERAL_SUPPORT is not set
-# PWM_GENERAL_INVERT_SUPPORT is not set
-# PWM_GENERAL_FADING_SUPPORT is not set
-# CH_A_PWM_GENERAL_SUPPORT is not set
-# CH_B_PWM_GENERAL_SUPPORT is not set
-# CH_C_PWM_GENERAL_SUPPORT is not set
-# PWM_WAV_SUPPORT is not set
-# VFS_PWM_WAV_SUPPORT is not set
-# PWM_MELODY_SUPPORT is not set
-# ENTCHEN_PWM_MELODY_SUPPORT is not set
-# TETRIS_PWM_MELODY_SUPPORT is not set
-# PWM_SERVO_SUPPORT is not set
-PWM_SERVOS=1
-# PWM_SERVO_INVERT is not set
-# PWM_SERVO_DEFAULT_ENABLED is not set
-# PWM_FREQ_SUPPORT is not set
-# PWM_DTMF_SUPPORT is not set
-# DEBUG_PWM is not set
-# DEBUG_PWM_SERVO is not set
 ONEWIRE_SUPPORT=y
 ONEWIRE_DETECT_SUPPORT=y
 # ONEWIRE_DS2502_SUPPORT is not set
@@ -523,6 +525,9 @@ OW_SENSORS_COUNT=50
 # ULTRASONIC_SUPPORT is not set
 # DEBUG_ULTRASONIC is not set
 # HBRIDGE_SUPPORT is not set
+# DUAL_HBRIDGE_SUPPORT is not set
+# SHARE_ENABLE_HBRIDGE_SUPPORT is not set
+# HBRIDGE_INVERTER_SUPPORT is not set
 # DEBUG_HBRIDGE is not set
 # MCUF_SUPPORT is not set
 # MCUF_SERIAL_SUPPORT is not set
@@ -570,6 +575,8 @@ NET_MAX_FRAME_LENGTH_GT_571=y
 CONF_ARTNET_PORT=6454
 CONF_ARTNET_INUNIVERSE=1
 CONF_ARTNET_OUTUNIVERSE=0
+CONF_ARTNET_OUTPUT_IP="192.168.0.255"
+# CONF_ARTNET_SEND_POLL_REPLY is not set
 # DEBUG_ARTNET is not set
 # DALI_SUPPORT is not set
 # DALI_RAW_SUPPORT is not set
@@ -619,6 +626,8 @@ FREE_SUPPORT=y
 # EMS_SUPPORT is not set
 EMS_BUFFER_LEN=255
 EMS_PORT=7950
+# EMS_USART_0 is not set
+# EMS_USART_1 is not set
 # EMS_DEBUG_STATS is not set
 # EMS_PROTO_DEBUG is not set
 # EMS_IO_DEBUG is not set
@@ -650,6 +659,11 @@ CONF_IRC_REALNAME="Ethersex Wollmilchsau"
 # DEBUG_IRC is not set
 # MDNS_SD_SUPPORT is not set
 # MODBUS_SUPPORT is not set
+# MQTT_SUPPORT is not set
+MQTT_CALLBACK_SLOTS=1
+# MQTT_STATIC_CONF is not set
+# MQTT_DEBUG is not set
+# MQTT_PARSE_DEBUG is not set
 # MYSQL_SUPPORT is not set
 CONF_MYSQL_IP="192.168.1.7"
 CONF_MYSQL_USERNAME="root"
@@ -683,6 +697,8 @@ CONF_NETSTAT_API="/~habo/stat/"
 # PROTO_INTERTECHNO_SUPPORT is not set
 # PROTO_INTERTECHNO_SL_SUPPORT is not set
 # PROTO_OASEFMMASTER_SUPPORT is not set
+# PROTO_FA20RF_SUPPORT is not set
+# PROTO_SMOKEDETECTOR_SUPPORT is not set
 # SIP_SUPPORT is not set
 CONF_SIP_PROXY_IP="192.168.178.1"
 CONF_SIP_FROM="621"
@@ -748,10 +764,11 @@ BSBPORT_MESSAGE_BUFFER_LEN=10
 BSBPORT_MESSAGE_MAX_LEN=25
 BSBPORT_OWNADDRESS=7
 # BSBPORT_POLLING_SUPPORT is not set
+# BSBPORT_MQTT_SUPPORT is not set
 # DEBUG_BSBPORT_RX is not set
 # DEBUG_BSBPORT_TX is not set
-# DEBUG_BSBPORT_PARSE is not set
 # DEBUG_BSBPORT_ECMD is not set
+# DEBUG_BSBPORT_MQTT is not set
 # MSR1_SUPPORT is not set
 MSR1_USART_0=y
 # MSR1_USART_1 is not set
@@ -824,18 +841,17 @@ DST_END_WEEK=5
 DST_END_DOW=0
 DST_END_HOUR=3
 # CLOCK_CRYSTAL_SUPPORT is not set
-CLOCK_CPU_SUPPORT=y
-# CLOCK_NTP_ADJUST_SUPPORT is not set
+# CLOCK_PERIODIC_SUPPORT is not set
 # DCF77_SUPPORT is not set
 # DEBUG_DCF77 is not set
 NTP_SUPPORT=y
 NTP_SERVER_IP="192.53.103.108"
 NTP_PORT=123
 NTP_QUERY_INTERVAL=1800
-NTPD_SUPPORT=y
+# DEBUG_NTP is not set
+# NTPD_SUPPORT is not set
 WHM_SUPPORT=y
 UPTIME_SUPPORT=y
-# DEBUG_NTP_ADJUST is not set
 # CRON_SUPPORT is not set
 # CRON_DEFAULT_UTC is not set
 # CRON_SUPPORT_TEST is not set
@@ -859,6 +875,7 @@ DMX_FXSLOT_AMOUNT=4
 # DMX_FX_RANDOM is not set
 # DMX_FX_FIRE is not set
 # DMX_FX_WATER is not set
+# DMX_FX_RGB is not set
 # UDP_ECHO_NET_SUPPORT is not set
 # WOL_SUPPORT is not set
 # MOTD_SUPPORT is not set
@@ -902,6 +919,7 @@ STELLA_FADE_STEP_INIT=10
 STELLA_FADE_FUNCTION_INIT=stella_fade_func_0
 stella_fade_func_0=y
 # stella_fade_func_1 is not set
+# STELLA_USE_CIE1931 is not set
 # DEBUG_STELLA is not set
 # STARBURST_SUPPORT is not set
 # STARBURST_PCA9685 is not set
@@ -1030,10 +1048,12 @@ IPV4_SUPPORT=y
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -1048,12 +1068,15 @@ avrispmkII=y
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -1063,6 +1086,8 @@ avrispmkII=y
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -1073,13 +1098,22 @@ avrispmkII=y
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -1095,6 +1129,7 @@ avrispmkII=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set

--- a/scripts/profiles/antares_O
+++ b/scripts/profiles/antares_O
@@ -22,6 +22,7 @@ ARCH_AVR=y
 # atmega644 is not set
 # atmega644p is not set
 # atmega1284p is not set
+# atmega2560 is not set
 # at90can32 is not set
 # at90can64 is not set
 MCU=at90can128
@@ -33,6 +34,7 @@ FREQ=16000000
 HARDWARE=antares_O
 antares_O=y
 # Arduino_Duemilanove is not set
+# arduino_mega2560_r3 is not set
 # beteigeuze is not set
 # conrad_probot is not set
 # ehaserl is not set
@@ -65,7 +67,7 @@ BOOTLOADER_SIZE=8192
 BOOTLOADER_START_ADDRESS=0x1E000
 FLASH_SIZE=0x20000
 EEPROM_SIZE=0x1000
-RAM_SIZE=0x1000
+RAM_SIZE=0x1100
 FLASH_PAGESIZE=0x100
 EEPROM_PAGESIZE=0x8
 # CRC_PAD_SUPPORT is not set
@@ -74,7 +76,7 @@ EEPROM_PAGESIZE=0x8
 SPI_TIMEOUT=y
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="ac826dc"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 DEBUG=y
 # usart is not set
@@ -86,6 +88,23 @@ DEBUG_USE_SYSLOG=y
 # SOFT_UART_SUPPORT is not set
 # DEBUG_HOOK is not set
 DEBUG_RESET_REASON=y
+
+#
+# Periodic / Scheduler
+#
+CONF_MTICKS_PER_SEC=50
+# PERIODIC_TIMER3_SUPPORT is not set
+CONF_PERIODIC_USE_TIMER=1
+# PERIODIC_TIMER_API_SUPPORT is not set
+# PERIODIC_ADJUST_SUPPORT is not set
+# DEBUG_PERIODIC is not set
+# DEBUG_PERIODIC_ECMD_SUPPORT is not set
+# DEBUG_PERIODIC_WAVEFORMS_SUPPORT is not set
+# DEBUG_PERIODIC_OC1A_SUPPORT is not set
+# SCHEDULER_SUPPORT is not set
+# SCHEDULER_DYNAMIC_SUPPORT is not set
+CONF_SCHEDULER_NUM_DYNAMIC_TIMERS=8
+# DEBUG_SCHEDULER_SUPPORT is not set
 # STATUSLEDS is not set
 # STATUSLED_POWER_SUPPORT is not set
 # STATUSLED_BOOTED_SUPPORT is not set
@@ -260,7 +279,6 @@ CONF_OPENVPN_PORT=1194
 # DEBUG_OPENVPN is not set
 # DEBUG_ROUTER is not set
 # DEBUG_UIP is not set
-# DEBUG_NTP is not set
 # DEBUG_UNKNOWN_PACKETS is not set
 
 #
@@ -270,7 +288,6 @@ PORTIO_SCHEME=CONFIG_IO_NONE
 CONFIG_IO_NONE=y
 # PORTIO_SIMPLE is not set
 # PORTIO_FULL_FEATURED is not set
-# PORTIO_SIMPLE_SUPPORT is not set
 # NAMED_PIN_SUPPORT is not set
 # TTY_SUPPORT is not set
 TTY_COLS=16
@@ -320,6 +337,8 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD Displays
 #
 # HD44780_SUPPORT is not set
+# HD44780_BACKLIGHT_SUPPORT is not set
+# HD44780_MULTIENSUPPORT is not set
 # HD44780_BACKLIGHT_INV is not set
 # HR20_LCD_SUPPORT_FULL is not set
 # S1D15G10_SUPPORT is not set
@@ -329,6 +348,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD_SUPPORT is not set
 # DEBUG_HD44780 is not set
 # DEBUG_LCD_MENU is not set
+# DEBUG_HD44780_I2C is not set
 
 #
 # Storage
@@ -356,6 +376,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # I2C_PCF8574X_SUPPORT is not set
 # I2C_PCA9555_SUPPORT is not set
 # I2C_MAX7311_SUPPORT is not set
+# I2C_MCP23017_SUPPORT is not set
 # I2C_UDP_SUPPORT is not set
 # DEBUG_I2C is not set
 # I2C_SLAVE_SUPPORT is not set
@@ -454,26 +475,6 @@ REMOTE_IRMP_PORT=10001
 # DEBUG_IRMP is not set
 # DEBUG_REMOTE_IRMP is not set
 # PSB2186_SUPPORT is not set
-# PWM_SUPPORT is not set
-# PWM_GENERAL_SUPPORT is not set
-# PWM_GENERAL_INVERT_SUPPORT is not set
-# PWM_GENERAL_FADING_SUPPORT is not set
-# CH_A_PWM_GENERAL_SUPPORT is not set
-# CH_B_PWM_GENERAL_SUPPORT is not set
-# CH_C_PWM_GENERAL_SUPPORT is not set
-# PWM_WAV_SUPPORT is not set
-# VFS_PWM_WAV_SUPPORT is not set
-# PWM_MELODY_SUPPORT is not set
-# ENTCHEN_PWM_MELODY_SUPPORT is not set
-# TETRIS_PWM_MELODY_SUPPORT is not set
-# PWM_SERVO_SUPPORT is not set
-PWM_SERVOS=1
-# PWM_SERVO_INVERT is not set
-# PWM_SERVO_DEFAULT_ENABLED is not set
-# PWM_FREQ_SUPPORT is not set
-# PWM_DTMF_SUPPORT is not set
-# DEBUG_PWM is not set
-# DEBUG_PWM_SERVO is not set
 ONEWIRE_SUPPORT=y
 ONEWIRE_DETECT_SUPPORT=y
 # ONEWIRE_DS2502_SUPPORT is not set
@@ -511,6 +512,9 @@ OW_SENSORS_COUNT=10
 # ULTRASONIC_SUPPORT is not set
 # DEBUG_ULTRASONIC is not set
 # HBRIDGE_SUPPORT is not set
+# DUAL_HBRIDGE_SUPPORT is not set
+# SHARE_ENABLE_HBRIDGE_SUPPORT is not set
+# HBRIDGE_INVERTER_SUPPORT is not set
 # DEBUG_HBRIDGE is not set
 # MCUF_SUPPORT is not set
 # MCUF_SERIAL_SUPPORT is not set
@@ -558,6 +562,8 @@ NET_MAX_FRAME_LENGTH_GT_571=y
 CONF_ARTNET_PORT=6454
 CONF_ARTNET_INUNIVERSE=1
 CONF_ARTNET_OUTUNIVERSE=0
+CONF_ARTNET_OUTPUT_IP="192.168.0.255"
+# CONF_ARTNET_SEND_POLL_REPLY is not set
 # DEBUG_ARTNET is not set
 # DALI_SUPPORT is not set
 # DALI_RAW_SUPPORT is not set
@@ -607,6 +613,8 @@ ECMD_TCP_PORT=2701
 # EMS_SUPPORT is not set
 EMS_BUFFER_LEN=255
 EMS_PORT=7950
+# EMS_USART_0 is not set
+# EMS_USART_1 is not set
 # EMS_DEBUG_STATS is not set
 # EMS_PROTO_DEBUG is not set
 # EMS_IO_DEBUG is not set
@@ -638,6 +646,11 @@ CONF_IRC_REALNAME="Ethersex Wollmilchsau"
 # DEBUG_IRC is not set
 # MDNS_SD_SUPPORT is not set
 # MODBUS_SUPPORT is not set
+# MQTT_SUPPORT is not set
+MQTT_CALLBACK_SLOTS=1
+# MQTT_STATIC_CONF is not set
+# MQTT_DEBUG is not set
+# MQTT_PARSE_DEBUG is not set
 # MYSQL_SUPPORT is not set
 CONF_MYSQL_IP="192.168.1.7"
 CONF_MYSQL_USERNAME="root"
@@ -671,6 +684,8 @@ CONF_NETSTAT_API="/~habo/stat/"
 # PROTO_INTERTECHNO_SUPPORT is not set
 # PROTO_INTERTECHNO_SL_SUPPORT is not set
 # PROTO_OASEFMMASTER_SUPPORT is not set
+# PROTO_FA20RF_SUPPORT is not set
+# PROTO_SMOKEDETECTOR_SUPPORT is not set
 # SIP_SUPPORT is not set
 CONF_SIP_PROXY_IP="192.168.178.1"
 CONF_SIP_FROM="621"
@@ -736,10 +751,11 @@ BSBPORT_MESSAGE_BUFFER_LEN=10
 BSBPORT_MESSAGE_MAX_LEN=25
 BSBPORT_OWNADDRESS=7
 # BSBPORT_POLLING_SUPPORT is not set
+# BSBPORT_MQTT_SUPPORT is not set
 # DEBUG_BSBPORT_RX is not set
 # DEBUG_BSBPORT_TX is not set
-# DEBUG_BSBPORT_PARSE is not set
 # DEBUG_BSBPORT_ECMD is not set
+# DEBUG_BSBPORT_MQTT is not set
 # MSR1_SUPPORT is not set
 MSR1_USART_0=y
 # MSR1_USART_1 is not set
@@ -812,18 +828,17 @@ DST_END_WEEK=5
 DST_END_DOW=0
 DST_END_HOUR=3
 # CLOCK_CRYSTAL_SUPPORT is not set
-CLOCK_CPU_SUPPORT=y
-# CLOCK_NTP_ADJUST_SUPPORT is not set
+# CLOCK_PERIODIC_SUPPORT is not set
 # DCF77_SUPPORT is not set
 # DEBUG_DCF77 is not set
 NTP_SUPPORT=y
 NTP_SERVER_IP="192.53.103.108"
 NTP_PORT=123
 NTP_QUERY_INTERVAL=1800
-NTPD_SUPPORT=y
+# DEBUG_NTP is not set
+# NTPD_SUPPORT is not set
 WHM_SUPPORT=y
 UPTIME_SUPPORT=y
-# DEBUG_NTP_ADJUST is not set
 # CRON_SUPPORT is not set
 # CRON_DEFAULT_UTC is not set
 # CRON_SUPPORT_TEST is not set
@@ -847,6 +862,7 @@ DMX_FX_RAINBOW=y
 DMX_FX_RANDOM=y
 DMX_FX_FIRE=y
 DMX_FX_WATER=y
+# DMX_FX_RGB is not set
 # UDP_ECHO_NET_SUPPORT is not set
 # WOL_SUPPORT is not set
 # MOTD_SUPPORT is not set
@@ -892,6 +908,7 @@ stella_fade_func_0=y
 # stella_fade_func_1 is not set
 STELLA_UNIVERSE=1
 STELLA_UNIVERSE_OFFSET=0
+# STELLA_USE_CIE1931 is not set
 # DEBUG_STELLA is not set
 # STARBURST_SUPPORT is not set
 # STARBURST_PCA9685 is not set
@@ -1020,10 +1037,12 @@ IPV4_SUPPORT=y
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -1038,12 +1057,15 @@ avrispmkII=y
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -1053,6 +1075,8 @@ avrispmkII=y
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -1063,13 +1087,22 @@ avrispmkII=y
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -1085,6 +1118,7 @@ avrispmkII=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set

--- a/scripts/profiles/arduino_duemilanove
+++ b/scripts/profiles/arduino_duemilanove
@@ -23,6 +23,7 @@ atmega168=y
 # atmega644 is not set
 # atmega644p is not set
 # atmega1284p is not set
+# atmega2560 is not set
 # at90can32 is not set
 # at90can64 is not set
 # at90can128 is not set
@@ -33,6 +34,7 @@ FREQ=16000000
 # antares_O is not set
 HARDWARE=Arduino_Duemilanove
 Arduino_Duemilanove=y
+# arduino_mega2560_r3 is not set
 # beteigeuze is not set
 # conrad_probot is not set
 # ehaserl is not set
@@ -74,7 +76,7 @@ EEPROM_PAGESIZE=0x4
 # SPI_TIMEOUT is not set
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="ac826dc"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 DEBUG=y
 DEBUG_OUTPUT=usart
@@ -88,6 +90,23 @@ DEBUG_USE_USART=0
 DEBUG_BAUDRATE=19200
 # DEBUG_HOOK is not set
 # DEBUG_RESET_REASON is not set
+
+#
+# Periodic / Scheduler
+#
+CONF_MTICKS_PER_SEC=50
+# PERIODIC_TIMER3_SUPPORT is not set
+CONF_PERIODIC_USE_TIMER=1
+# PERIODIC_TIMER_API_SUPPORT is not set
+# PERIODIC_ADJUST_SUPPORT is not set
+# DEBUG_PERIODIC is not set
+# DEBUG_PERIODIC_ECMD_SUPPORT is not set
+# DEBUG_PERIODIC_WAVEFORMS_SUPPORT is not set
+# DEBUG_PERIODIC_OC1A_SUPPORT is not set
+# SCHEDULER_SUPPORT is not set
+# SCHEDULER_DYNAMIC_SUPPORT is not set
+CONF_SCHEDULER_NUM_DYNAMIC_TIMERS=8
+# DEBUG_SCHEDULER_SUPPORT is not set
 STATUSLEDS=y
 # STATUSLED_POWER_SUPPORT is not set
 STATUSLED_BOOTED_SUPPORT=y
@@ -262,7 +281,6 @@ CONF_OPENVPN_PORT=1194
 # DEBUG_OPENVPN is not set
 # DEBUG_ROUTER is not set
 # DEBUG_UIP is not set
-# DEBUG_NTP is not set
 # DEBUG_UNKNOWN_PACKETS is not set
 
 #
@@ -322,6 +340,8 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD Displays
 #
 # HD44780_SUPPORT is not set
+# HD44780_BACKLIGHT_SUPPORT is not set
+# HD44780_MULTIENSUPPORT is not set
 # HD44780_BACKLIGHT_INV is not set
 # HR20_LCD_SUPPORT_FULL is not set
 # S1D15G10_SUPPORT is not set
@@ -331,6 +351,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD_SUPPORT is not set
 # DEBUG_HD44780 is not set
 # DEBUG_LCD_MENU is not set
+# DEBUG_HD44780_I2C is not set
 
 #
 # Storage
@@ -358,6 +379,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # I2C_PCF8574X_SUPPORT is not set
 # I2C_PCA9555_SUPPORT is not set
 # I2C_MAX7311_SUPPORT is not set
+# I2C_MCP23017_SUPPORT is not set
 # I2C_UDP_SUPPORT is not set
 # DEBUG_I2C is not set
 # I2C_SLAVE_SUPPORT is not set
@@ -446,26 +468,6 @@ REMOTE_IRMP_PORT=10001
 # DEBUG_IRMP is not set
 # DEBUG_REMOTE_IRMP is not set
 # PSB2186_SUPPORT is not set
-# PWM_SUPPORT is not set
-# PWM_GENERAL_SUPPORT is not set
-# PWM_GENERAL_INVERT_SUPPORT is not set
-# PWM_GENERAL_FADING_SUPPORT is not set
-# CH_A_PWM_GENERAL_SUPPORT is not set
-# CH_B_PWM_GENERAL_SUPPORT is not set
-# CH_C_PWM_GENERAL_SUPPORT is not set
-# PWM_WAV_SUPPORT is not set
-# VFS_PWM_WAV_SUPPORT is not set
-# PWM_MELODY_SUPPORT is not set
-# ENTCHEN_PWM_MELODY_SUPPORT is not set
-# TETRIS_PWM_MELODY_SUPPORT is not set
-# PWM_SERVO_SUPPORT is not set
-PWM_SERVOS=1
-# PWM_SERVO_INVERT is not set
-# PWM_SERVO_DEFAULT_ENABLED is not set
-# PWM_FREQ_SUPPORT is not set
-# PWM_DTMF_SUPPORT is not set
-# DEBUG_PWM is not set
-# DEBUG_PWM_SERVO is not set
 # ONEWIRE_SUPPORT is not set
 # ONEWIRE_DETECT_SUPPORT is not set
 # ONEWIRE_DS2502_SUPPORT is not set
@@ -497,6 +499,9 @@ PWM_SERVOS=1
 # ULTRASONIC_SUPPORT is not set
 # DEBUG_ULTRASONIC is not set
 # HBRIDGE_SUPPORT is not set
+# DUAL_HBRIDGE_SUPPORT is not set
+# SHARE_ENABLE_HBRIDGE_SUPPORT is not set
+# HBRIDGE_INVERTER_SUPPORT is not set
 # DEBUG_HBRIDGE is not set
 # MCUF_SUPPORT is not set
 # MCUF_SERIAL_SUPPORT is not set
@@ -541,6 +546,8 @@ MCUF_MODUL_DISPLAY_MODE_RANDOM=y
 CONF_ARTNET_PORT=6454
 CONF_ARTNET_INUNIVERSE=1
 CONF_ARTNET_OUTUNIVERSE=0
+CONF_ARTNET_OUTPUT_IP="192.168.0.255"
+# CONF_ARTNET_SEND_POLL_REPLY is not set
 # DEBUG_ARTNET is not set
 # DALI_SUPPORT is not set
 # DALI_RAW_SUPPORT is not set
@@ -552,6 +559,7 @@ ECMD_PARSER_SUPPORT=y
 # ECMD_PAM_SUPPORT is not set
 # ECMD_SCRIPT_SUPPORT is not set
 # ECMD_LOG_VIA_SYSLOG is not set
+# ECMD_SERIAL_USART_SUPPORT is not set
 # ECMD_TCP_SUPPORT is not set
 # ECMD_UDP_SUPPORT is not set
 # ECMD_SERIAL_I2C_SUPPORT is not set
@@ -579,12 +587,6 @@ ECMD_PARSER_SUPPORT=y
 # DEBUG_ECMD_SCRIPT is not set
 # ELTAKOMS_SUPPORT is not set
 # EMS_SUPPORT is not set
-EMS_BUFFER_LEN=64
-EMS_PORT=7950
-# EMS_DEBUG_STATS is not set
-# EMS_PROTO_DEBUG is not set
-# EMS_IO_DEBUG is not set
-# EMS_ERROR_DEBUG is not set
 # FNORDLICHT_SUPPORT is not set
 # HTTPLOG_SUPPORT is not set
 CONF_HTTPLOG_SERVICE="volkszaehler.org"
@@ -605,6 +607,11 @@ CONF_IRC_REALNAME="Ethersex Wollmilchsau"
 # DEBUG_IRC is not set
 # MDNS_SD_SUPPORT is not set
 # MODBUS_SUPPORT is not set
+# MQTT_SUPPORT is not set
+MQTT_CALLBACK_SLOTS=1
+# MQTT_STATIC_CONF is not set
+# MQTT_DEBUG is not set
+# MQTT_PARSE_DEBUG is not set
 # MYSQL_SUPPORT is not set
 CONF_MYSQL_IP="192.168.23.254"
 CONF_MYSQL_USERNAME="root"
@@ -638,6 +645,8 @@ CONF_NETSTAT_API="/~habo/stat/"
 # PROTO_INTERTECHNO_SUPPORT is not set
 # PROTO_INTERTECHNO_SL_SUPPORT is not set
 # PROTO_OASEFMMASTER_SUPPORT is not set
+# PROTO_FA20RF_SUPPORT is not set
+# PROTO_SMOKEDETECTOR_SUPPORT is not set
 # SIP_SUPPORT is not set
 CONF_SIP_PROXY_IP="192.168.178.1"
 CONF_SIP_FROM="621"
@@ -728,15 +737,17 @@ DST_END_WEEK=5
 DST_END_DOW=0
 DST_END_HOUR=3
 # CLOCK_CRYSTAL_SUPPORT is not set
-# CLOCK_CPU_SUPPORT is not set
-# CLOCK_NTP_ADJUST_SUPPORT is not set
+# CLOCK_PERIODIC_SUPPORT is not set
 # DCF77_SUPPORT is not set
 # DEBUG_DCF77 is not set
 # NTP_SUPPORT is not set
+NTP_SERVER_IP="192.53.103.108"
+NTP_PORT=123
+NTP_QUERY_INTERVAL=1800
+# DEBUG_NTP is not set
 # NTPD_SUPPORT is not set
 WHM_SUPPORT=y
 # UPTIME_SUPPORT is not set
-# DEBUG_NTP_ADJUST is not set
 # CRON_SUPPORT is not set
 # CRON_DEFAULT_UTC is not set
 # CRON_SUPPORT_TEST is not set
@@ -761,6 +772,7 @@ DMX_FXSLOT_AMOUNT=4
 # DMX_FX_RANDOM is not set
 # DMX_FX_FIRE is not set
 # DMX_FX_WATER is not set
+# DMX_FX_RGB is not set
 # UDP_ECHO_NET_SUPPORT is not set
 # WOL_SUPPORT is not set
 # MOTD_SUPPORT is not set
@@ -804,6 +816,7 @@ STELLA_FADE_STEP_INIT=10
 STELLA_FADE_FUNCTION_INIT=stella_fade_func_0
 stella_fade_func_0=y
 # stella_fade_func_1 is not set
+# STELLA_USE_CIE1931 is not set
 # DEBUG_STELLA is not set
 # STARBURST_SUPPORT is not set
 # STARBURST_PCA9685 is not set
@@ -909,13 +922,6 @@ CONF_TIME2PRESS_POWER=40
 CONF_TIME2PRESS_POWERL=3
 # PROJECTOR_SANYO_Z700_SUPPORT is not set
 # FREQCOUNT_SUPPORT is not set
-FREQCOUNT_CHANNELS=1
-# FREQCOUNT_BOOT_ON is not set
-FREQCOUNT_AVERAGE=8
-# FREQCOUNT_NOSLOW_SUPPORT is not set
-# FREQCOUNT_DUTY_SUPPORT is not set
-# FREQCOUNT_MOVING_AVERAGE_SUPPORT is not set
-# FREQCOUNT_DEBUGGING is not set
 # TANKLEVEL_SUPPORT is not set
 TANKLEVEL_ADC_CHANNEL=0
 # TANKLEVEL_STARTUP is not set
@@ -935,10 +941,12 @@ TANKLEVEL_HOLD_TIME=20
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -953,12 +961,15 @@ avrispmkII=y
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -968,6 +979,8 @@ avrispmkII=y
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -978,13 +991,22 @@ avrispmkII=y
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -1000,6 +1022,7 @@ avrispmkII=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set

--- a/scripts/profiles/arduino_mega2560_r3
+++ b/scripts/profiles/arduino_mega2560_r3
@@ -67,7 +67,7 @@ BOOTLOADER_SIZE=0
 BOOTLOADER_START_ADDRESS=0x40000
 FLASH_SIZE=0x40000
 EEPROM_SIZE=0x1000
-RAM_SIZE=0x2000
+RAM_SIZE=0x2200
 FLASH_PAGESIZE=0x100
 EEPROM_PAGESIZE=0x8
 # CRC_PAD_SUPPORT is not set
@@ -76,7 +76,7 @@ EEPROM_PAGESIZE=0x8
 # SPI_TIMEOUT is not set
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="5e0df6b"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 # DEBUG is not set
 # DEBUG_USE_SYSLOG is not set
@@ -1058,10 +1058,12 @@ TANKLEVEL_HOLD_TIME=20
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -1075,12 +1077,15 @@ TANKLEVEL_HOLD_TIME=20
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -1090,6 +1095,8 @@ TANKLEVEL_HOLD_TIME=20
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -1100,13 +1107,22 @@ TANKLEVEL_HOLD_TIME=20
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -1123,6 +1139,7 @@ stk500=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set

--- a/scripts/profiles/beteigeuze
+++ b/scripts/profiles/beteigeuze
@@ -22,6 +22,7 @@ ARCH_AVR=y
 # atmega644 is not set
 # atmega644p is not set
 # atmega1284p is not set
+# atmega2560 is not set
 # at90can32 is not set
 # at90can64 is not set
 MCU=at90can128
@@ -32,6 +33,7 @@ FREQ=16000000
 # antares_IO is not set
 # antares_O is not set
 # Arduino_Duemilanove is not set
+# arduino_mega2560_r3 is not set
 HARDWARE=beteigeuze
 beteigeuze=y
 # conrad_probot is not set
@@ -65,7 +67,7 @@ BOOTLOADER_SIZE=8192
 BOOTLOADER_START_ADDRESS=0x1E000
 FLASH_SIZE=0x20000
 EEPROM_SIZE=0x1000
-RAM_SIZE=0x1000
+RAM_SIZE=0x1100
 FLASH_PAGESIZE=0x100
 EEPROM_PAGESIZE=0x8
 # CRC_PAD_SUPPORT is not set
@@ -74,7 +76,7 @@ EEPROM_PAGESIZE=0x8
 SPI_TIMEOUT=y
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="ac826dc"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 DEBUG=y
 DEBUG_OUTPUT=usart
@@ -89,6 +91,23 @@ DEBUG_USE_USART=0
 DEBUG_BAUDRATE=115200
 # DEBUG_HOOK is not set
 DEBUG_RESET_REASON=y
+
+#
+# Periodic / Scheduler
+#
+CONF_MTICKS_PER_SEC=50
+# PERIODIC_TIMER3_SUPPORT is not set
+CONF_PERIODIC_USE_TIMER=1
+# PERIODIC_TIMER_API_SUPPORT is not set
+# PERIODIC_ADJUST_SUPPORT is not set
+# DEBUG_PERIODIC is not set
+# DEBUG_PERIODIC_ECMD_SUPPORT is not set
+# DEBUG_PERIODIC_WAVEFORMS_SUPPORT is not set
+# DEBUG_PERIODIC_OC1A_SUPPORT is not set
+# SCHEDULER_SUPPORT is not set
+# SCHEDULER_DYNAMIC_SUPPORT is not set
+CONF_SCHEDULER_NUM_DYNAMIC_TIMERS=8
+# DEBUG_SCHEDULER_SUPPORT is not set
 STATUSLEDS=y
 # STATUSLED_POWER_SUPPORT is not set
 # STATUSLED_BOOTED_SUPPORT is not set
@@ -263,7 +282,6 @@ CONF_OPENVPN_PORT=1194
 # DEBUG_OPENVPN is not set
 # DEBUG_ROUTER is not set
 # DEBUG_UIP is not set
-# DEBUG_NTP is not set
 # DEBUG_UNKNOWN_PACKETS is not set
 
 #
@@ -273,8 +291,6 @@ PORTIO_SCHEME=CONFIG_IO_NONE
 CONFIG_IO_NONE=y
 # PORTIO_SIMPLE is not set
 # PORTIO_FULL_FEATURED is not set
-# PORTIO_SIMPLE_SUPPORT is not set
-# PORTIO_SUPPORT is not set
 # NAMED_PIN_SUPPORT is not set
 # TTY_SUPPORT is not set
 TTY_COLS=16
@@ -324,6 +340,8 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD Displays
 #
 # HD44780_SUPPORT is not set
+# HD44780_BACKLIGHT_SUPPORT is not set
+# HD44780_MULTIENSUPPORT is not set
 # HD44780_BACKLIGHT_INV is not set
 # HR20_LCD_SUPPORT_FULL is not set
 # S1D15G10_SUPPORT is not set
@@ -333,6 +351,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD_SUPPORT is not set
 # DEBUG_HD44780 is not set
 # DEBUG_LCD_MENU is not set
+# DEBUG_HD44780_I2C is not set
 
 #
 # Storage
@@ -360,6 +379,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # I2C_PCF8574X_SUPPORT is not set
 # I2C_PCA9555_SUPPORT is not set
 # I2C_MAX7311_SUPPORT is not set
+# I2C_MCP23017_SUPPORT is not set
 # I2C_UDP_SUPPORT is not set
 # DEBUG_I2C is not set
 # I2C_SLAVE_SUPPORT is not set
@@ -450,26 +470,6 @@ DEBUG_IRMP=y
 IRSND_SUPPORT_SIRCS_PROTOCOL=y
 IRSND_SUPPORT_RC5_PROTOCOL=y
 # PSB2186_SUPPORT is not set
-# PWM_SUPPORT is not set
-# PWM_GENERAL_SUPPORT is not set
-# PWM_GENERAL_INVERT_SUPPORT is not set
-# PWM_GENERAL_FADING_SUPPORT is not set
-# CH_A_PWM_GENERAL_SUPPORT is not set
-# CH_B_PWM_GENERAL_SUPPORT is not set
-# CH_C_PWM_GENERAL_SUPPORT is not set
-# PWM_WAV_SUPPORT is not set
-# VFS_PWM_WAV_SUPPORT is not set
-# PWM_MELODY_SUPPORT is not set
-# ENTCHEN_PWM_MELODY_SUPPORT is not set
-# TETRIS_PWM_MELODY_SUPPORT is not set
-# PWM_SERVO_SUPPORT is not set
-PWM_SERVOS=1
-# PWM_SERVO_INVERT is not set
-# PWM_SERVO_DEFAULT_ENABLED is not set
-# PWM_FREQ_SUPPORT is not set
-# PWM_DTMF_SUPPORT is not set
-# DEBUG_PWM is not set
-# DEBUG_PWM_SERVO is not set
 ONEWIRE_SUPPORT=y
 ONEWIRE_DETECT_SUPPORT=y
 # ONEWIRE_DS2502_SUPPORT is not set
@@ -507,6 +507,9 @@ OW_SENSORS_COUNT=10
 # ULTRASONIC_SUPPORT is not set
 # DEBUG_ULTRASONIC is not set
 # HBRIDGE_SUPPORT is not set
+# DUAL_HBRIDGE_SUPPORT is not set
+# SHARE_ENABLE_HBRIDGE_SUPPORT is not set
+# HBRIDGE_INVERTER_SUPPORT is not set
 # DEBUG_HBRIDGE is not set
 # MCUF_SUPPORT is not set
 # MCUF_SERIAL_SUPPORT is not set
@@ -551,6 +554,8 @@ NET_MAX_FRAME_LENGTH_GT_571=y
 CONF_ARTNET_PORT=6454
 CONF_ARTNET_INUNIVERSE=1
 CONF_ARTNET_OUTUNIVERSE=0
+CONF_ARTNET_OUTPUT_IP="192.168.0.255"
+# CONF_ARTNET_SEND_POLL_REPLY is not set
 # DEBUG_ARTNET is not set
 # DALI_SUPPORT is not set
 # DALI_RAW_SUPPORT is not set
@@ -562,6 +567,7 @@ ECMD_PARSER_SUPPORT=y
 # ECMD_PAM_SUPPORT is not set
 # ECMD_SCRIPT_SUPPORT is not set
 # ECMD_LOG_VIA_SYSLOG is not set
+# ECMD_SERIAL_USART_SUPPORT is not set
 ECMD_TCP_SUPPORT=y
 ECMD_TCP_PORT=2701
 # ECMD_UDP_SUPPORT is not set
@@ -594,12 +600,6 @@ ELTAKOMS_USART_1=y
 ELTAKOMS_USE_USART=1
 DEBUG_ELTAKOMS=y
 # EMS_SUPPORT is not set
-EMS_BUFFER_LEN=255
-EMS_PORT=7950
-# EMS_DEBUG_STATS is not set
-# EMS_PROTO_DEBUG is not set
-# EMS_IO_DEBUG is not set
-# EMS_ERROR_DEBUG is not set
 # FNORDLICHT_SUPPORT is not set
 # HTTPLOG_SUPPORT is not set
 CONF_HTTPLOG_SERVICE="volkszaehler.org"
@@ -620,6 +620,11 @@ CONF_IRC_REALNAME="Ethersex Wollmilchsau"
 # DEBUG_IRC is not set
 # MDNS_SD_SUPPORT is not set
 # MODBUS_SUPPORT is not set
+# MQTT_SUPPORT is not set
+MQTT_CALLBACK_SLOTS=1
+# MQTT_STATIC_CONF is not set
+# MQTT_DEBUG is not set
+# MQTT_PARSE_DEBUG is not set
 # MYSQL_SUPPORT is not set
 CONF_MYSQL_IP="192.168.1.7"
 CONF_MYSQL_USERNAME="root"
@@ -653,6 +658,8 @@ CONF_NETSTAT_API="/~habo/stat/"
 # PROTO_INTERTECHNO_SUPPORT is not set
 # PROTO_INTERTECHNO_SL_SUPPORT is not set
 # PROTO_OASEFMMASTER_SUPPORT is not set
+# PROTO_FA20RF_SUPPORT is not set
+# PROTO_SMOKEDETECTOR_SUPPORT is not set
 # SIP_SUPPORT is not set
 CONF_SIP_PROXY_IP="192.168.178.1"
 CONF_SIP_FROM="621"
@@ -743,18 +750,17 @@ DST_END_WEEK=5
 DST_END_DOW=0
 DST_END_HOUR=3
 # CLOCK_CRYSTAL_SUPPORT is not set
-CLOCK_CPU_SUPPORT=y
-# CLOCK_NTP_ADJUST_SUPPORT is not set
+# CLOCK_PERIODIC_SUPPORT is not set
 # DCF77_SUPPORT is not set
 # DEBUG_DCF77 is not set
 NTP_SUPPORT=y
 NTP_SERVER="de.pool.ntp.org"
 NTP_PORT=123
 NTP_QUERY_INTERVAL=1800
-NTPD_SUPPORT=y
+# DEBUG_NTP is not set
+# NTPD_SUPPORT is not set
 WHM_SUPPORT=y
 UPTIME_SUPPORT=y
-# DEBUG_NTP_ADJUST is not set
 # CRON_SUPPORT is not set
 # CRON_DEFAULT_UTC is not set
 # CRON_SUPPORT_TEST is not set
@@ -778,6 +784,7 @@ DMX_FXSLOT_AMOUNT=4
 # DMX_FX_RANDOM is not set
 # DMX_FX_FIRE is not set
 # DMX_FX_WATER is not set
+# DMX_FX_RGB is not set
 # UDP_ECHO_NET_SUPPORT is not set
 # WOL_SUPPORT is not set
 # MOTD_SUPPORT is not set
@@ -821,6 +828,7 @@ STELLA_FADE_STEP_INIT=10
 STELLA_FADE_FUNCTION_INIT=stella_fade_func_0
 stella_fade_func_0=y
 # stella_fade_func_1 is not set
+# STELLA_USE_CIE1931 is not set
 # DEBUG_STELLA is not set
 # STARBURST_SUPPORT is not set
 # STARBURST_PCA9685 is not set
@@ -945,10 +953,12 @@ IPV4_SUPPORT=y
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -963,12 +973,15 @@ avrispmkII=y
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -978,6 +991,8 @@ avrispmkII=y
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -988,13 +1003,22 @@ avrispmkII=y
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -1010,6 +1034,7 @@ avrispmkII=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set

--- a/scripts/profiles/bootloader
+++ b/scripts/profiles/bootloader
@@ -23,6 +23,7 @@ MCU=atmega644
 atmega644=y
 # atmega644p is not set
 # atmega1284p is not set
+# atmega2560 is not set
 # at90can32 is not set
 # at90can64 is not set
 # at90can128 is not set
@@ -32,6 +33,7 @@ FREQ=20000000
 # antares_IO is not set
 # antares_O is not set
 # Arduino_Duemilanove is not set
+# arduino_mega2560_r3 is not set
 # beteigeuze is not set
 # conrad_probot is not set
 # ehaserl is not set
@@ -74,7 +76,7 @@ TEENSY_SUPPORT=y
 # SPI_TIMEOUT is not set
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="ac826dc"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 # DEBUG is not set
 # DEBUG_USE_SYSLOG is not set
@@ -82,6 +84,23 @@ GIT_VERSION="ac826dc"
 # SOFT_UART_SUPPORT is not set
 # DEBUG_HOOK is not set
 # DEBUG_RESET_REASON is not set
+
+#
+# Periodic / Scheduler
+#
+CONF_MTICKS_PER_SEC=50
+# PERIODIC_TIMER3_SUPPORT is not set
+CONF_PERIODIC_USE_TIMER=1
+# PERIODIC_TIMER_API_SUPPORT is not set
+# PERIODIC_ADJUST_SUPPORT is not set
+# DEBUG_PERIODIC is not set
+# DEBUG_PERIODIC_ECMD_SUPPORT is not set
+# DEBUG_PERIODIC_WAVEFORMS_SUPPORT is not set
+# DEBUG_PERIODIC_OC1A_SUPPORT is not set
+# SCHEDULER_SUPPORT is not set
+# SCHEDULER_DYNAMIC_SUPPORT is not set
+CONF_SCHEDULER_NUM_DYNAMIC_TIMERS=8
+# DEBUG_SCHEDULER_SUPPORT is not set
 # STATUSLEDS is not set
 # STATUSLED_POWER_SUPPORT is not set
 # STATUSLED_BOOTED_SUPPORT is not set
@@ -249,7 +268,6 @@ CONF_OPENVPN_PORT=1194
 # DEBUG_OPENVPN is not set
 # DEBUG_ROUTER is not set
 # DEBUG_UIP is not set
-# DEBUG_NTP is not set
 # DEBUG_UNKNOWN_PACKETS is not set
 
 #
@@ -259,8 +277,6 @@ PORTIO_SCHEME=CONFIG_IO_NONE
 CONFIG_IO_NONE=y
 # PORTIO_SIMPLE is not set
 # PORTIO_FULL_FEATURED is not set
-# PORTIO_SIMPLE_SUPPORT is not set
-# PORTIO_SUPPORT is not set
 # NAMED_PIN_SUPPORT is not set
 # TTY_SUPPORT is not set
 TTY_COLS=16
@@ -308,6 +324,8 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD Displays
 #
 # HD44780_SUPPORT is not set
+# HD44780_BACKLIGHT_SUPPORT is not set
+# HD44780_MULTIENSUPPORT is not set
 # HD44780_BACKLIGHT_INV is not set
 # HR20_LCD_SUPPORT is not set
 # S1D15G10_SUPPORT is not set
@@ -317,6 +335,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD_SUPPORT is not set
 # DEBUG_HD44780 is not set
 # DEBUG_LCD_MENU is not set
+# DEBUG_HD44780_I2C is not set
 
 #
 # Storage
@@ -344,6 +363,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # I2C_PCF8574X_SUPPORT is not set
 # I2C_PCA9555_SUPPORT is not set
 # I2C_MAX7311_SUPPORT is not set
+# I2C_MCP23017_SUPPORT is not set
 # I2C_UDP_SUPPORT is not set
 # DEBUG_I2C is not set
 # I2C_SLAVE_SUPPORT is not set
@@ -441,26 +461,6 @@ REMOTE_IRMP_PORT=10001
 # DEBUG_IRMP is not set
 # DEBUG_REMOTE_IRMP is not set
 # PSB2186_SUPPORT is not set
-# PWM_SUPPORT is not set
-# PWM_GENERAL_SUPPORT is not set
-# PWM_GENERAL_INVERT_SUPPORT is not set
-# PWM_GENERAL_FADING_SUPPORT is not set
-# CH_A_PWM_GENERAL_SUPPORT is not set
-# CH_B_PWM_GENERAL_SUPPORT is not set
-# CH_C_PWM_GENERAL_SUPPORT is not set
-# PWM_WAV_SUPPORT is not set
-# VFS_PWM_WAV_SUPPORT is not set
-# PWM_MELODY_SUPPORT is not set
-# ENTCHEN_PWM_MELODY_SUPPORT is not set
-# TETRIS_PWM_MELODY_SUPPORT is not set
-# PWM_SERVO_SUPPORT is not set
-PWM_SERVOS=1
-# PWM_SERVO_INVERT is not set
-# PWM_SERVO_DEFAULT_ENABLED is not set
-# PWM_FREQ_SUPPORT is not set
-# PWM_DTMF_SUPPORT is not set
-# DEBUG_PWM is not set
-# DEBUG_PWM_SERVO is not set
 # ONEWIRE_SUPPORT is not set
 # ONEWIRE_DETECT_SUPPORT is not set
 # ONEWIRE_DS2502_SUPPORT is not set
@@ -492,6 +492,9 @@ PWM_SERVOS=1
 # ULTRASONIC_SUPPORT is not set
 # DEBUG_ULTRASONIC is not set
 # HBRIDGE_SUPPORT is not set
+# DUAL_HBRIDGE_SUPPORT is not set
+# SHARE_ENABLE_HBRIDGE_SUPPORT is not set
+# HBRIDGE_INVERTER_SUPPORT is not set
 # DEBUG_HBRIDGE is not set
 # MCUF_SUPPORT is not set
 # MCUF_SERIAL_SUPPORT is not set
@@ -538,6 +541,8 @@ NET_MAX_FRAME_LENGTH_GT_571=y
 CONF_ARTNET_PORT=6454
 CONF_ARTNET_INUNIVERSE=1
 CONF_ARTNET_OUTUNIVERSE=0
+CONF_ARTNET_OUTPUT_IP="192.168.0.255"
+# CONF_ARTNET_SEND_POLL_REPLY is not set
 # DEBUG_ARTNET is not set
 # DALI_SUPPORT is not set
 # DALI_RAW_SUPPORT is not set
@@ -586,6 +591,7 @@ DMX_USE_USART=0
 # EMS_SUPPORT is not set
 EMS_BUFFER_LEN=255
 EMS_PORT=7950
+# EMS_USART_0 is not set
 # EMS_DEBUG_STATS is not set
 # EMS_PROTO_DEBUG is not set
 # EMS_IO_DEBUG is not set
@@ -616,6 +622,11 @@ CONF_IRC_REALNAME="Ethersex Wollmilchsau"
 # DEBUG_IRC is not set
 # MDNS_SD_SUPPORT is not set
 # MODBUS_SUPPORT is not set
+# MQTT_SUPPORT is not set
+MQTT_CALLBACK_SLOTS=1
+# MQTT_STATIC_CONF is not set
+# MQTT_DEBUG is not set
+# MQTT_PARSE_DEBUG is not set
 # MYSQL_SUPPORT is not set
 CONF_MYSQL_IP="192.168.23.254"
 CONF_MYSQL_USERNAME="root"
@@ -649,6 +660,8 @@ CONF_NETSTAT_API="/~habo/stat/"
 # PROTO_INTERTECHNO_SUPPORT is not set
 # PROTO_INTERTECHNO_SL_SUPPORT is not set
 # PROTO_OASEFMMASTER_SUPPORT is not set
+# PROTO_FA20RF_SUPPORT is not set
+# PROTO_SMOKEDETECTOR_SUPPORT is not set
 # SIP_SUPPORT is not set
 CONF_SIP_PROXY_IP="192.168.178.1"
 CONF_SIP_FROM="621"
@@ -712,10 +725,11 @@ BSBPORT_MESSAGE_BUFFER_LEN=10
 BSBPORT_MESSAGE_MAX_LEN=25
 BSBPORT_OWNADDRESS=7
 # BSBPORT_POLLING_SUPPORT is not set
+# BSBPORT_MQTT_SUPPORT is not set
 # DEBUG_BSBPORT_RX is not set
 # DEBUG_BSBPORT_TX is not set
-# DEBUG_BSBPORT_PARSE is not set
 # DEBUG_BSBPORT_ECMD is not set
+# DEBUG_BSBPORT_MQTT is not set
 # MSR1_SUPPORT is not set
 MSR1_USART_0=y
 MSR1_USE_USART=0
@@ -770,15 +784,17 @@ SGC_SLEEPMODE=0
 # CLOCK_DATE_SUPPORT is not set
 # CLOCK_TIME_SUPPORT is not set
 # CLOCK_CRYSTAL_SUPPORT is not set
-# CLOCK_CPU_SUPPORT is not set
-# CLOCK_NTP_ADJUST_SUPPORT is not set
+# CLOCK_PERIODIC_SUPPORT is not set
 # DCF77_SUPPORT is not set
 # DEBUG_DCF77 is not set
 # NTP_SUPPORT is not set
+NTP_SERVER_IP="192.53.103.108"
+NTP_PORT=123
+NTP_QUERY_INTERVAL=1800
+# DEBUG_NTP is not set
 # NTPD_SUPPORT is not set
 # WHM_SUPPORT is not set
 # UPTIME_SUPPORT is not set
-# DEBUG_NTP_ADJUST is not set
 # CRON_SUPPORT is not set
 # CRON_DEFAULT_UTC is not set
 # CRON_EEPROM_SUPPORT is not set
@@ -800,6 +816,7 @@ DMX_FXSLOT_AMOUNT=4
 # DMX_FX_RANDOM is not set
 # DMX_FX_FIRE is not set
 # DMX_FX_WATER is not set
+# DMX_FX_RGB is not set
 # UDP_ECHO_NET_SUPPORT is not set
 # WOL_SUPPORT is not set
 # MOTD_SUPPORT is not set
@@ -843,6 +860,7 @@ STELLA_FADE_STEP_INIT=10
 STELLA_FADE_FUNCTION_INIT=stella_fade_func_0
 stella_fade_func_0=y
 # stella_fade_func_1 is not set
+# STELLA_USE_CIE1931 is not set
 # DEBUG_STELLA is not set
 # STARBURST_SUPPORT is not set
 # STARBURST_PCA9685 is not set
@@ -950,13 +968,6 @@ CONF_TIME2PRESS_POWERL=3
 # SANYO_Z700_USART_0 is not set
 # DEBUG_SANYO_Z700 is not set
 # FREQCOUNT_SUPPORT is not set
-FREQCOUNT_CHANNELS=1
-# FREQCOUNT_BOOT_ON is not set
-FREQCOUNT_AVERAGE=8
-# FREQCOUNT_NOSLOW_SUPPORT is not set
-# FREQCOUNT_DUTY_SUPPORT is not set
-# FREQCOUNT_MOVING_AVERAGE_SUPPORT is not set
-# FREQCOUNT_DEBUGGING is not set
 # TANKLEVEL_SUPPORT is not set
 TANKLEVEL_ADC_CHANNEL=0
 # TANKLEVEL_STARTUP is not set
@@ -977,10 +988,12 @@ IPV4_SUPPORT=y
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -995,12 +1008,15 @@ avrispmkII=y
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -1010,6 +1026,8 @@ avrispmkII=y
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -1020,13 +1038,22 @@ avrispmkII=y
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -1042,6 +1069,7 @@ avrispmkII=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set

--- a/scripts/profiles/defconfig
+++ b/scripts/profiles/defconfig
@@ -23,6 +23,7 @@ MCU=atmega644
 atmega644=y
 # atmega644p is not set
 # atmega1284p is not set
+# atmega2560 is not set
 # at90can32 is not set
 # at90can64 is not set
 # at90can128 is not set
@@ -32,6 +33,7 @@ FREQ=20000000
 # antares_IO is not set
 # antares_O is not set
 # Arduino_Duemilanove is not set
+# arduino_mega2560_r3 is not set
 # beteigeuze is not set
 # conrad_probot is not set
 # ehaserl is not set
@@ -74,7 +76,7 @@ EEPROM_PAGESIZE=0x8
 # SPI_TIMEOUT is not set
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="ac826dc"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 # DEBUG is not set
 # DEBUG_USE_SYSLOG is not set
@@ -82,6 +84,23 @@ GIT_VERSION="ac826dc"
 # SOFT_UART_SUPPORT is not set
 # DEBUG_HOOK is not set
 # DEBUG_RESET_REASON is not set
+
+#
+# Periodic / Scheduler
+#
+CONF_MTICKS_PER_SEC=50
+# PERIODIC_TIMER3_SUPPORT is not set
+CONF_PERIODIC_USE_TIMER=1
+# PERIODIC_TIMER_API_SUPPORT is not set
+# PERIODIC_ADJUST_SUPPORT is not set
+# DEBUG_PERIODIC is not set
+# DEBUG_PERIODIC_ECMD_SUPPORT is not set
+# DEBUG_PERIODIC_WAVEFORMS_SUPPORT is not set
+# DEBUG_PERIODIC_OC1A_SUPPORT is not set
+# SCHEDULER_SUPPORT is not set
+# SCHEDULER_DYNAMIC_SUPPORT is not set
+CONF_SCHEDULER_NUM_DYNAMIC_TIMERS=8
+# DEBUG_SCHEDULER_SUPPORT is not set
 # STATUSLEDS is not set
 # STATUSLED_POWER_SUPPORT is not set
 # STATUSLED_BOOTED_SUPPORT is not set
@@ -256,7 +275,6 @@ CONF_OPENVPN_PORT=1194
 # DEBUG_OPENVPN is not set
 # DEBUG_ROUTER is not set
 # DEBUG_UIP is not set
-# DEBUG_NTP is not set
 # DEBUG_UNKNOWN_PACKETS is not set
 
 #
@@ -316,6 +334,8 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD Displays
 #
 # HD44780_SUPPORT is not set
+# HD44780_BACKLIGHT_SUPPORT is not set
+# HD44780_MULTIENSUPPORT is not set
 # HD44780_BACKLIGHT_INV is not set
 # HR20_LCD_SUPPORT_FULL is not set
 # S1D15G10_SUPPORT is not set
@@ -325,6 +345,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD_SUPPORT is not set
 # DEBUG_HD44780 is not set
 # DEBUG_LCD_MENU is not set
+# DEBUG_HD44780_I2C is not set
 
 #
 # Storage
@@ -352,6 +373,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # I2C_PCF8574X_SUPPORT is not set
 # I2C_PCA9555_SUPPORT is not set
 # I2C_MAX7311_SUPPORT is not set
+# I2C_MCP23017_SUPPORT is not set
 # I2C_UDP_SUPPORT is not set
 # DEBUG_I2C is not set
 # I2C_SLAVE_SUPPORT is not set
@@ -449,26 +471,6 @@ REMOTE_IRMP_PORT=10001
 # DEBUG_IRMP is not set
 # DEBUG_REMOTE_IRMP is not set
 # PSB2186_SUPPORT is not set
-# PWM_SUPPORT is not set
-# PWM_GENERAL_SUPPORT is not set
-# PWM_GENERAL_INVERT_SUPPORT is not set
-# PWM_GENERAL_FADING_SUPPORT is not set
-# CH_A_PWM_GENERAL_SUPPORT is not set
-# CH_B_PWM_GENERAL_SUPPORT is not set
-# CH_C_PWM_GENERAL_SUPPORT is not set
-# PWM_WAV_SUPPORT is not set
-# VFS_PWM_WAV_SUPPORT is not set
-# PWM_MELODY_SUPPORT is not set
-# ENTCHEN_PWM_MELODY_SUPPORT is not set
-# TETRIS_PWM_MELODY_SUPPORT is not set
-# PWM_SERVO_SUPPORT is not set
-PWM_SERVOS=1
-# PWM_SERVO_INVERT is not set
-# PWM_SERVO_DEFAULT_ENABLED is not set
-# PWM_FREQ_SUPPORT is not set
-# PWM_DTMF_SUPPORT is not set
-# DEBUG_PWM is not set
-# DEBUG_PWM_SERVO is not set
 # ONEWIRE_SUPPORT is not set
 # ONEWIRE_DETECT_SUPPORT is not set
 # ONEWIRE_DS2502_SUPPORT is not set
@@ -500,6 +502,9 @@ PWM_SERVOS=1
 # ULTRASONIC_SUPPORT is not set
 # DEBUG_ULTRASONIC is not set
 # HBRIDGE_SUPPORT is not set
+# DUAL_HBRIDGE_SUPPORT is not set
+# SHARE_ENABLE_HBRIDGE_SUPPORT is not set
+# HBRIDGE_INVERTER_SUPPORT is not set
 # DEBUG_HBRIDGE is not set
 # MCUF_SUPPORT is not set
 # MCUF_SERIAL_SUPPORT is not set
@@ -546,6 +551,8 @@ NET_MAX_FRAME_LENGTH_GT_571=y
 CONF_ARTNET_PORT=6454
 CONF_ARTNET_INUNIVERSE=1
 CONF_ARTNET_OUTUNIVERSE=0
+CONF_ARTNET_OUTPUT_IP="192.168.0.255"
+# CONF_ARTNET_SEND_POLL_REPLY is not set
 # DEBUG_ARTNET is not set
 # DALI_SUPPORT is not set
 # DALI_RAW_SUPPORT is not set
@@ -593,6 +600,7 @@ ECMD_TCP_PORT=2701
 # EMS_SUPPORT is not set
 EMS_BUFFER_LEN=64
 EMS_PORT=7950
+# EMS_USART_0 is not set
 # EMS_DEBUG_STATS is not set
 # EMS_PROTO_DEBUG is not set
 # EMS_IO_DEBUG is not set
@@ -623,6 +631,11 @@ CONF_IRC_REALNAME="Ethersex Wollmilchsau"
 # DEBUG_IRC is not set
 # MDNS_SD_SUPPORT is not set
 # MODBUS_SUPPORT is not set
+# MQTT_SUPPORT is not set
+MQTT_CALLBACK_SLOTS=1
+# MQTT_STATIC_CONF is not set
+# MQTT_DEBUG is not set
+# MQTT_PARSE_DEBUG is not set
 # MYSQL_SUPPORT is not set
 CONF_MYSQL_IP="192.168.23.254"
 CONF_MYSQL_USERNAME="root"
@@ -656,6 +669,8 @@ CONF_NETSTAT_API="/~habo/stat/"
 # PROTO_INTERTECHNO_SUPPORT is not set
 # PROTO_INTERTECHNO_SL_SUPPORT is not set
 # PROTO_OASEFMMASTER_SUPPORT is not set
+# PROTO_FA20RF_SUPPORT is not set
+# PROTO_SMOKEDETECTOR_SUPPORT is not set
 # SIP_SUPPORT is not set
 CONF_SIP_PROXY_IP="192.168.178.1"
 CONF_SIP_FROM="621"
@@ -719,10 +734,11 @@ BSBPORT_MESSAGE_BUFFER_LEN=10
 BSBPORT_MESSAGE_MAX_LEN=25
 BSBPORT_OWNADDRESS=7
 # BSBPORT_POLLING_SUPPORT is not set
+# BSBPORT_MQTT_SUPPORT is not set
 # DEBUG_BSBPORT_RX is not set
 # DEBUG_BSBPORT_TX is not set
-# DEBUG_BSBPORT_PARSE is not set
 # DEBUG_BSBPORT_ECMD is not set
+# DEBUG_BSBPORT_MQTT is not set
 # MSR1_SUPPORT is not set
 MSR1_USART_0=y
 MSR1_USE_USART=0
@@ -790,18 +806,17 @@ DST_END_WEEK=5
 DST_END_DOW=0
 DST_END_HOUR=3
 # CLOCK_CRYSTAL_SUPPORT is not set
-# CLOCK_CPU_SUPPORT is not set
-# CLOCK_NTP_ADJUST_SUPPORT is not set
+# CLOCK_PERIODIC_SUPPORT is not set
 # DCF77_SUPPORT is not set
 # DEBUG_DCF77 is not set
 NTP_SUPPORT=y
 NTP_SERVER_IP="213.133.123.125"
 NTP_PORT=123
 NTP_QUERY_INTERVAL=1800
+# DEBUG_NTP is not set
 # NTPD_SUPPORT is not set
 # WHM_SUPPORT is not set
 # UPTIME_SUPPORT is not set
-# DEBUG_NTP_ADJUST is not set
 # CRON_SUPPORT is not set
 # CRON_DEFAULT_UTC is not set
 # CRON_SUPPORT_TEST is not set
@@ -825,6 +840,7 @@ DMX_FXSLOT_AMOUNT=4
 # DMX_FX_RANDOM is not set
 # DMX_FX_FIRE is not set
 # DMX_FX_WATER is not set
+# DMX_FX_RGB is not set
 # UDP_ECHO_NET_SUPPORT is not set
 # WOL_SUPPORT is not set
 # MOTD_SUPPORT is not set
@@ -868,6 +884,7 @@ STELLA_FADE_STEP_INIT=10
 STELLA_FADE_FUNCTION_INIT=stella_fade_func_0
 stella_fade_func_0=y
 # stella_fade_func_1 is not set
+# STELLA_USE_CIE1931 is not set
 # DEBUG_STELLA is not set
 # STARBURST_SUPPORT is not set
 # STARBURST_PCA9685 is not set
@@ -975,13 +992,6 @@ CONF_TIME2PRESS_POWERL=3
 # SANYO_Z700_USART_0 is not set
 # DEBUG_SANYO_Z700 is not set
 # FREQCOUNT_SUPPORT is not set
-FREQCOUNT_CHANNELS=1
-# FREQCOUNT_BOOT_ON is not set
-FREQCOUNT_AVERAGE=8
-# FREQCOUNT_NOSLOW_SUPPORT is not set
-# FREQCOUNT_DUTY_SUPPORT is not set
-# FREQCOUNT_MOVING_AVERAGE_SUPPORT is not set
-# FREQCOUNT_DEBUGGING is not set
 # TANKLEVEL_SUPPORT is not set
 TANKLEVEL_ADC_CHANNEL=0
 # TANKLEVEL_STARTUP is not set
@@ -1002,10 +1012,12 @@ IPV4_SUPPORT=y
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -1020,12 +1032,15 @@ avrispmkII=y
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -1035,6 +1050,8 @@ avrispmkII=y
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -1045,13 +1062,22 @@ avrispmkII=y
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -1067,6 +1093,7 @@ avrispmkII=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set

--- a/scripts/profiles/ehaserl
+++ b/scripts/profiles/ehaserl
@@ -23,6 +23,7 @@ atmega88=y
 # atmega644 is not set
 # atmega644p is not set
 # atmega1284p is not set
+# atmega2560 is not set
 # at90can32 is not set
 # at90can64 is not set
 # at90can128 is not set
@@ -32,6 +33,7 @@ FREQ=12000000
 # antares_IO is not set
 # antares_O is not set
 # Arduino_Duemilanove is not set
+# arduino_mega2560_r3 is not set
 # beteigeuze is not set
 # conrad_probot is not set
 HARDWARE=ehaserl
@@ -74,7 +76,7 @@ TEENSY_SUPPORT=y
 # SPI_TIMEOUT is not set
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="ac826dc"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 # DEBUG is not set
 # DEBUG_USE_SYSLOG is not set
@@ -82,6 +84,23 @@ GIT_VERSION="ac826dc"
 # SOFT_UART_SUPPORT is not set
 # DEBUG_HOOK is not set
 # DEBUG_RESET_REASON is not set
+
+#
+# Periodic / Scheduler
+#
+CONF_MTICKS_PER_SEC=50
+# PERIODIC_TIMER3_SUPPORT is not set
+CONF_PERIODIC_USE_TIMER=1
+# PERIODIC_TIMER_API_SUPPORT is not set
+# PERIODIC_ADJUST_SUPPORT is not set
+# DEBUG_PERIODIC is not set
+# DEBUG_PERIODIC_ECMD_SUPPORT is not set
+# DEBUG_PERIODIC_WAVEFORMS_SUPPORT is not set
+# DEBUG_PERIODIC_OC1A_SUPPORT is not set
+# SCHEDULER_SUPPORT is not set
+# SCHEDULER_DYNAMIC_SUPPORT is not set
+CONF_SCHEDULER_NUM_DYNAMIC_TIMERS=8
+# DEBUG_SCHEDULER_SUPPORT is not set
 # STATUSLEDS is not set
 # STATUSLED_POWER_SUPPORT is not set
 # STATUSLED_BOOTED_SUPPORT is not set
@@ -266,7 +285,6 @@ CONF_OPENVPN_PORT=1194
 # DEBUG_OPENVPN is not set
 # DEBUG_ROUTER is not set
 # DEBUG_UIP is not set
-# DEBUG_NTP is not set
 # DEBUG_UNKNOWN_PACKETS is not set
 
 #
@@ -325,6 +343,8 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD Displays
 #
 # HD44780_SUPPORT is not set
+# HD44780_BACKLIGHT_SUPPORT is not set
+# HD44780_MULTIENSUPPORT is not set
 # HD44780_BACKLIGHT_INV is not set
 # HR20_LCD_SUPPORT is not set
 # S1D15G10_SUPPORT is not set
@@ -334,6 +354,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD_SUPPORT is not set
 # DEBUG_HD44780 is not set
 # DEBUG_LCD_MENU is not set
+# DEBUG_HD44780_I2C is not set
 
 #
 # Storage
@@ -361,6 +382,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # I2C_PCF8574X_SUPPORT is not set
 # I2C_PCA9555_SUPPORT is not set
 # I2C_MAX7311_SUPPORT is not set
+# I2C_MCP23017_SUPPORT is not set
 # I2C_UDP_SUPPORT is not set
 # DEBUG_I2C is not set
 # I2C_SLAVE_SUPPORT is not set
@@ -458,26 +480,6 @@ REMOTE_IRMP_PORT=10001
 # DEBUG_IRMP is not set
 # DEBUG_REMOTE_IRMP is not set
 # PSB2186_SUPPORT is not set
-# PWM_SUPPORT is not set
-# PWM_GENERAL_SUPPORT is not set
-# PWM_GENERAL_INVERT_SUPPORT is not set
-# PWM_GENERAL_FADING_SUPPORT is not set
-# CH_A_PWM_GENERAL_SUPPORT is not set
-# CH_B_PWM_GENERAL_SUPPORT is not set
-# CH_C_PWM_GENERAL_SUPPORT is not set
-# PWM_WAV_SUPPORT is not set
-# VFS_PWM_WAV_SUPPORT is not set
-# PWM_MELODY_SUPPORT is not set
-# ENTCHEN_PWM_MELODY_SUPPORT is not set
-# TETRIS_PWM_MELODY_SUPPORT is not set
-# PWM_SERVO_SUPPORT is not set
-PWM_SERVOS=1
-# PWM_SERVO_INVERT is not set
-# PWM_SERVO_DEFAULT_ENABLED is not set
-# PWM_FREQ_SUPPORT is not set
-# PWM_DTMF_SUPPORT is not set
-# DEBUG_PWM is not set
-# DEBUG_PWM_SERVO is not set
 # ONEWIRE_SUPPORT is not set
 # ONEWIRE_DETECT_SUPPORT is not set
 # ONEWIRE_DS2502_SUPPORT is not set
@@ -509,6 +511,9 @@ PWM_SERVOS=1
 # ULTRASONIC_SUPPORT is not set
 # DEBUG_ULTRASONIC is not set
 # HBRIDGE_SUPPORT is not set
+# DUAL_HBRIDGE_SUPPORT is not set
+# SHARE_ENABLE_HBRIDGE_SUPPORT is not set
+# HBRIDGE_INVERTER_SUPPORT is not set
 # DEBUG_HBRIDGE is not set
 # MCUF_SUPPORT is not set
 # MCUF_SERIAL_SUPPORT is not set
@@ -555,6 +560,8 @@ MCUF_MODUL_DISPLAY_MODE_RANDOM=y
 CONF_ARTNET_PORT=6454
 CONF_ARTNET_INUNIVERSE=1
 CONF_ARTNET_OUTUNIVERSE=0
+CONF_ARTNET_OUTPUT_IP="192.168.0.255"
+# CONF_ARTNET_SEND_POLL_REPLY is not set
 # DEBUG_ARTNET is not set
 # DALI_SUPPORT is not set
 # DALI_RAW_SUPPORT is not set
@@ -604,6 +611,7 @@ ECMD_UDP_PORT=2701
 # EMS_SUPPORT is not set
 EMS_BUFFER_LEN=64
 EMS_PORT=7950
+# EMS_USART_0 is not set
 # EMS_DEBUG_STATS is not set
 # EMS_PROTO_DEBUG is not set
 # EMS_IO_DEBUG is not set
@@ -634,6 +642,11 @@ CONF_IRC_REALNAME="Ethersex Wollmilchsau"
 # DEBUG_IRC is not set
 # MDNS_SD_SUPPORT is not set
 # MODBUS_SUPPORT is not set
+# MQTT_SUPPORT is not set
+MQTT_CALLBACK_SLOTS=1
+# MQTT_STATIC_CONF is not set
+# MQTT_DEBUG is not set
+# MQTT_PARSE_DEBUG is not set
 # MYSQL_SUPPORT is not set
 CONF_MYSQL_IP="192.168.23.254"
 CONF_MYSQL_USERNAME="root"
@@ -667,6 +680,8 @@ CONF_NETSTAT_API="/~habo/stat/"
 # PROTO_INTERTECHNO_SUPPORT is not set
 # PROTO_INTERTECHNO_SL_SUPPORT is not set
 # PROTO_OASEFMMASTER_SUPPORT is not set
+# PROTO_FA20RF_SUPPORT is not set
+# PROTO_SMOKEDETECTOR_SUPPORT is not set
 # SIP_SUPPORT is not set
 CONF_SIP_PROXY_IP="192.168.178.1"
 CONF_SIP_FROM="621"
@@ -730,10 +745,11 @@ BSBPORT_MESSAGE_BUFFER_LEN=10
 BSBPORT_MESSAGE_MAX_LEN=25
 BSBPORT_OWNADDRESS=7
 # BSBPORT_POLLING_SUPPORT is not set
+# BSBPORT_MQTT_SUPPORT is not set
 # DEBUG_BSBPORT_RX is not set
 # DEBUG_BSBPORT_TX is not set
-# DEBUG_BSBPORT_PARSE is not set
 # DEBUG_BSBPORT_ECMD is not set
+# DEBUG_BSBPORT_MQTT is not set
 # MSR1_SUPPORT is not set
 MSR1_USART_0=y
 MSR1_USE_USART=0
@@ -789,15 +805,17 @@ SGC_SLEEPMODE=0
 # CLOCK_DATE_SUPPORT is not set
 # CLOCK_TIME_SUPPORT is not set
 # CLOCK_CRYSTAL_SUPPORT is not set
-# CLOCK_CPU_SUPPORT is not set
-# CLOCK_NTP_ADJUST_SUPPORT is not set
+# CLOCK_PERIODIC_SUPPORT is not set
 # DCF77_SUPPORT is not set
 # DEBUG_DCF77 is not set
 # NTP_SUPPORT is not set
+NTP_SERVER_IP="192.53.103.108"
+NTP_PORT=123
+NTP_QUERY_INTERVAL=1800
+# DEBUG_NTP is not set
 # NTPD_SUPPORT is not set
 # WHM_SUPPORT is not set
 # UPTIME_SUPPORT is not set
-# DEBUG_NTP_ADJUST is not set
 # CRON_SUPPORT is not set
 # CRON_DEFAULT_UTC is not set
 # CRON_EEPROM_SUPPORT is not set
@@ -819,6 +837,7 @@ DMX_FXSLOT_AMOUNT=4
 # DMX_FX_RANDOM is not set
 # DMX_FX_FIRE is not set
 # DMX_FX_WATER is not set
+# DMX_FX_RGB is not set
 # UDP_ECHO_NET_SUPPORT is not set
 # WOL_SUPPORT is not set
 # MOTD_SUPPORT is not set
@@ -862,6 +881,7 @@ STELLA_FADE_STEP_INIT=10
 STELLA_FADE_FUNCTION_INIT=stella_fade_func_0
 stella_fade_func_0=y
 # stella_fade_func_1 is not set
+# STELLA_USE_CIE1931 is not set
 # DEBUG_STELLA is not set
 # STARBURST_SUPPORT is not set
 # STARBURST_PCA9685 is not set
@@ -969,13 +989,6 @@ CONF_TIME2PRESS_POWERL=3
 # SANYO_Z700_USART_0 is not set
 # DEBUG_SANYO_Z700 is not set
 # FREQCOUNT_SUPPORT is not set
-FREQCOUNT_CHANNELS=1
-# FREQCOUNT_BOOT_ON is not set
-FREQCOUNT_AVERAGE=8
-# FREQCOUNT_NOSLOW_SUPPORT is not set
-# FREQCOUNT_DUTY_SUPPORT is not set
-# FREQCOUNT_MOVING_AVERAGE_SUPPORT is not set
-# FREQCOUNT_DEBUGGING is not set
 # TANKLEVEL_SUPPORT is not set
 TANKLEVEL_ADC_CHANNEL=0
 # TANKLEVEL_STARTUP is not set
@@ -996,10 +1009,12 @@ IPV4_SUPPORT=y
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -1014,12 +1029,15 @@ avrispmkII=y
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -1029,6 +1047,8 @@ avrispmkII=y
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -1039,13 +1059,22 @@ avrispmkII=y
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -1061,6 +1090,7 @@ avrispmkII=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set

--- a/scripts/profiles/ethersex
+++ b/scripts/profiles/ethersex
@@ -23,6 +23,7 @@ MCU=atmega644
 atmega644=y
 # atmega644p is not set
 # atmega1284p is not set
+# atmega2560 is not set
 # at90can32 is not set
 # at90can64 is not set
 # at90can128 is not set
@@ -32,6 +33,7 @@ FREQ=20000000
 # antares_IO is not set
 # antares_O is not set
 # Arduino_Duemilanove is not set
+# arduino_mega2560_r3 is not set
 # beteigeuze is not set
 # conrad_probot is not set
 # ehaserl is not set
@@ -74,7 +76,7 @@ EEPROM_PAGESIZE=0x8
 # SPI_TIMEOUT is not set
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="ac826dc"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 # DEBUG is not set
 # DEBUG_USE_SYSLOG is not set
@@ -82,6 +84,23 @@ GIT_VERSION="ac826dc"
 # SOFT_UART_SUPPORT is not set
 # DEBUG_HOOK is not set
 # DEBUG_RESET_REASON is not set
+
+#
+# Periodic / Scheduler
+#
+CONF_MTICKS_PER_SEC=50
+# PERIODIC_TIMER3_SUPPORT is not set
+CONF_PERIODIC_USE_TIMER=1
+# PERIODIC_TIMER_API_SUPPORT is not set
+# PERIODIC_ADJUST_SUPPORT is not set
+# DEBUG_PERIODIC is not set
+# DEBUG_PERIODIC_ECMD_SUPPORT is not set
+# DEBUG_PERIODIC_WAVEFORMS_SUPPORT is not set
+# DEBUG_PERIODIC_OC1A_SUPPORT is not set
+# SCHEDULER_SUPPORT is not set
+# SCHEDULER_DYNAMIC_SUPPORT is not set
+CONF_SCHEDULER_NUM_DYNAMIC_TIMERS=8
+# DEBUG_SCHEDULER_SUPPORT is not set
 # STATUSLEDS is not set
 # STATUSLED_POWER_SUPPORT is not set
 # STATUSLED_BOOTED_SUPPORT is not set
@@ -252,7 +271,6 @@ CONF_OPENVPN_PORT=1194
 # DEBUG_OPENVPN is not set
 # DEBUG_ROUTER is not set
 # DEBUG_UIP is not set
-# DEBUG_NTP is not set
 # DEBUG_UNKNOWN_PACKETS is not set
 
 #
@@ -312,6 +330,8 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD Displays
 #
 # HD44780_SUPPORT is not set
+# HD44780_BACKLIGHT_SUPPORT is not set
+# HD44780_MULTIENSUPPORT is not set
 # HD44780_BACKLIGHT_INV is not set
 # HR20_LCD_SUPPORT_FULL is not set
 # S1D15G10_SUPPORT is not set
@@ -321,6 +341,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD_SUPPORT is not set
 # DEBUG_HD44780 is not set
 # DEBUG_LCD_MENU is not set
+# DEBUG_HD44780_I2C is not set
 
 #
 # Storage
@@ -348,6 +369,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # I2C_PCF8574X_SUPPORT is not set
 # I2C_PCA9555_SUPPORT is not set
 # I2C_MAX7311_SUPPORT is not set
+# I2C_MCP23017_SUPPORT is not set
 # I2C_UDP_SUPPORT is not set
 # DEBUG_I2C is not set
 # I2C_SLAVE_SUPPORT is not set
@@ -445,26 +467,6 @@ REMOTE_IRMP_PORT=10001
 # DEBUG_IRMP is not set
 # DEBUG_REMOTE_IRMP is not set
 # PSB2186_SUPPORT is not set
-# PWM_SUPPORT is not set
-# PWM_GENERAL_SUPPORT is not set
-# PWM_GENERAL_INVERT_SUPPORT is not set
-# PWM_GENERAL_FADING_SUPPORT is not set
-# CH_A_PWM_GENERAL_SUPPORT is not set
-# CH_B_PWM_GENERAL_SUPPORT is not set
-# CH_C_PWM_GENERAL_SUPPORT is not set
-# PWM_WAV_SUPPORT is not set
-# VFS_PWM_WAV_SUPPORT is not set
-# PWM_MELODY_SUPPORT is not set
-# ENTCHEN_PWM_MELODY_SUPPORT is not set
-# TETRIS_PWM_MELODY_SUPPORT is not set
-# PWM_SERVO_SUPPORT is not set
-PWM_SERVOS=1
-# PWM_SERVO_INVERT is not set
-# PWM_SERVO_DEFAULT_ENABLED is not set
-# PWM_FREQ_SUPPORT is not set
-# PWM_DTMF_SUPPORT is not set
-# DEBUG_PWM is not set
-# DEBUG_PWM_SERVO is not set
 # ONEWIRE_SUPPORT is not set
 # ONEWIRE_DETECT_SUPPORT is not set
 # ONEWIRE_DS2502_SUPPORT is not set
@@ -496,6 +498,9 @@ PWM_SERVOS=1
 # ULTRASONIC_SUPPORT is not set
 # DEBUG_ULTRASONIC is not set
 # HBRIDGE_SUPPORT is not set
+# DUAL_HBRIDGE_SUPPORT is not set
+# SHARE_ENABLE_HBRIDGE_SUPPORT is not set
+# HBRIDGE_INVERTER_SUPPORT is not set
 # DEBUG_HBRIDGE is not set
 # MCUF_SUPPORT is not set
 # MCUF_SERIAL_SUPPORT is not set
@@ -542,6 +547,8 @@ NET_MAX_FRAME_LENGTH_GT_571=y
 CONF_ARTNET_PORT=6454
 CONF_ARTNET_INUNIVERSE=1
 CONF_ARTNET_OUTUNIVERSE=0
+CONF_ARTNET_OUTPUT_IP=""
+# CONF_ARTNET_SEND_POLL_REPLY is not set
 # DEBUG_ARTNET is not set
 # DALI_SUPPORT is not set
 # DALI_RAW_SUPPORT is not set
@@ -589,6 +596,7 @@ ECMD_TCP_PORT=2701
 # EMS_SUPPORT is not set
 EMS_BUFFER_LEN=64
 EMS_PORT=7950
+# EMS_USART_0 is not set
 # EMS_DEBUG_STATS is not set
 # EMS_PROTO_DEBUG is not set
 # EMS_IO_DEBUG is not set
@@ -619,6 +627,11 @@ CONF_IRC_REALNAME="Ethersex Wollmilchsau"
 # DEBUG_IRC is not set
 # MDNS_SD_SUPPORT is not set
 # MODBUS_SUPPORT is not set
+# MQTT_SUPPORT is not set
+MQTT_CALLBACK_SLOTS=1
+# MQTT_STATIC_CONF is not set
+# MQTT_DEBUG is not set
+# MQTT_PARSE_DEBUG is not set
 # MYSQL_SUPPORT is not set
 CONF_MYSQL_IP="2001:6f8:1209:f0:230:5ff:fe23:3f8"
 CONF_MYSQL_USERNAME="root"
@@ -652,6 +665,8 @@ CONF_NETSTAT_API="/~habo/stat/"
 # PROTO_INTERTECHNO_SUPPORT is not set
 # PROTO_INTERTECHNO_SL_SUPPORT is not set
 # PROTO_OASEFMMASTER_SUPPORT is not set
+# PROTO_FA20RF_SUPPORT is not set
+# PROTO_SMOKEDETECTOR_SUPPORT is not set
 # SIP_SUPPORT is not set
 CONF_SIP_PROXY_IP=""
 CONF_SIP_FROM="621"
@@ -715,10 +730,11 @@ BSBPORT_MESSAGE_BUFFER_LEN=10
 BSBPORT_MESSAGE_MAX_LEN=25
 BSBPORT_OWNADDRESS=7
 # BSBPORT_POLLING_SUPPORT is not set
+# BSBPORT_MQTT_SUPPORT is not set
 # DEBUG_BSBPORT_RX is not set
 # DEBUG_BSBPORT_TX is not set
-# DEBUG_BSBPORT_PARSE is not set
 # DEBUG_BSBPORT_ECMD is not set
+# DEBUG_BSBPORT_MQTT is not set
 # MSR1_SUPPORT is not set
 MSR1_USART_0=y
 MSR1_USE_USART=0
@@ -772,15 +788,17 @@ SGC_SLEEPMODE=0
 # CLOCK_SUPPORT is not set
 # CLOCK_DATETIME_SUPPORT is not set
 # CLOCK_CRYSTAL_SUPPORT is not set
-# CLOCK_CPU_SUPPORT is not set
-# CLOCK_NTP_ADJUST_SUPPORT is not set
+# CLOCK_PERIODIC_SUPPORT is not set
 # DCF77_SUPPORT is not set
 # DEBUG_DCF77 is not set
 # NTP_SUPPORT is not set
+NTP_SERVER_IP="2001:638:902:1:0:0:0:10"
+NTP_PORT=123
+NTP_QUERY_INTERVAL=1800
+# DEBUG_NTP is not set
 # NTPD_SUPPORT is not set
 # WHM_SUPPORT is not set
 # UPTIME_SUPPORT is not set
-# DEBUG_NTP_ADJUST is not set
 # CRON_SUPPORT is not set
 # CRON_DEFAULT_UTC is not set
 # CRON_SUPPORT_TEST is not set
@@ -804,6 +822,7 @@ DMX_FXSLOT_AMOUNT=4
 # DMX_FX_RANDOM is not set
 # DMX_FX_FIRE is not set
 # DMX_FX_WATER is not set
+# DMX_FX_RGB is not set
 # UDP_ECHO_NET_SUPPORT is not set
 # WOL_SUPPORT is not set
 # MOTD_SUPPORT is not set
@@ -847,6 +866,7 @@ STELLA_FADE_STEP_INIT=10
 STELLA_FADE_FUNCTION_INIT=stella_fade_func_0
 stella_fade_func_0=y
 # stella_fade_func_1 is not set
+# STELLA_USE_CIE1931 is not set
 # DEBUG_STELLA is not set
 # STARBURST_SUPPORT is not set
 # STARBURST_PCA9685 is not set
@@ -954,13 +974,6 @@ CONF_TIME2PRESS_POWERL=3
 # SANYO_Z700_USART_0 is not set
 # DEBUG_SANYO_Z700 is not set
 # FREQCOUNT_SUPPORT is not set
-FREQCOUNT_CHANNELS=1
-# FREQCOUNT_BOOT_ON is not set
-FREQCOUNT_AVERAGE=8
-# FREQCOUNT_NOSLOW_SUPPORT is not set
-# FREQCOUNT_DUTY_SUPPORT is not set
-# FREQCOUNT_MOVING_AVERAGE_SUPPORT is not set
-# FREQCOUNT_DEBUGGING is not set
 # TANKLEVEL_SUPPORT is not set
 TANKLEVEL_ADC_CHANNEL=0
 # TANKLEVEL_STARTUP is not set
@@ -980,10 +993,12 @@ TANKLEVEL_HOLD_TIME=20
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -998,12 +1013,15 @@ avrispmkII=y
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -1013,6 +1031,8 @@ avrispmkII=y
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -1023,13 +1043,22 @@ avrispmkII=y
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -1045,6 +1074,7 @@ avrispmkII=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set

--- a/scripts/profiles/fimser
+++ b/scripts/profiles/fimser
@@ -23,6 +23,7 @@ atmega328p=y
 # atmega644 is not set
 # atmega644p is not set
 # atmega1284p is not set
+# atmega2560 is not set
 # at90can32 is not set
 # at90can64 is not set
 # at90can128 is not set
@@ -32,6 +33,7 @@ FREQ=1000000
 # antares_IO is not set
 # antares_O is not set
 # Arduino_Duemilanove is not set
+# arduino_mega2560_r3 is not set
 # beteigeuze is not set
 # conrad_probot is not set
 # ehaserl is not set
@@ -74,7 +76,7 @@ EEPROM_PAGESIZE=0x4
 # SPI_TIMEOUT is not set
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="ac826dc"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 # DEBUG is not set
 # DEBUG_USE_SYSLOG is not set
@@ -82,6 +84,23 @@ GIT_VERSION="ac826dc"
 # SOFT_UART_SUPPORT is not set
 # DEBUG_HOOK is not set
 # DEBUG_RESET_REASON is not set
+
+#
+# Periodic / Scheduler
+#
+CONF_MTICKS_PER_SEC=50
+# PERIODIC_TIMER3_SUPPORT is not set
+CONF_PERIODIC_USE_TIMER=1
+# PERIODIC_TIMER_API_SUPPORT is not set
+# PERIODIC_ADJUST_SUPPORT is not set
+# DEBUG_PERIODIC is not set
+# DEBUG_PERIODIC_ECMD_SUPPORT is not set
+# DEBUG_PERIODIC_WAVEFORMS_SUPPORT is not set
+# DEBUG_PERIODIC_OC1A_SUPPORT is not set
+# SCHEDULER_SUPPORT is not set
+# SCHEDULER_DYNAMIC_SUPPORT is not set
+CONF_SCHEDULER_NUM_DYNAMIC_TIMERS=8
+# DEBUG_SCHEDULER_SUPPORT is not set
 # STATUSLEDS is not set
 # STATUSLED_POWER_SUPPORT is not set
 # STATUSLED_BOOTED_SUPPORT is not set
@@ -257,7 +276,6 @@ CONF_OPENVPN_PORT=1194
 # DEBUG_OPENVPN is not set
 # DEBUG_ROUTER is not set
 # DEBUG_UIP is not set
-# DEBUG_NTP is not set
 # DEBUG_UNKNOWN_PACKETS is not set
 
 #
@@ -317,6 +335,8 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD Displays
 #
 # HD44780_SUPPORT is not set
+# HD44780_BACKLIGHT_SUPPORT is not set
+# HD44780_MULTIENSUPPORT is not set
 # HD44780_BACKLIGHT_INV is not set
 # HR20_LCD_SUPPORT_FULL is not set
 # S1D15G10_SUPPORT is not set
@@ -326,6 +346,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD_SUPPORT is not set
 # DEBUG_HD44780 is not set
 # DEBUG_LCD_MENU is not set
+# DEBUG_HD44780_I2C is not set
 
 #
 # Storage
@@ -353,6 +374,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # I2C_PCF8574X_SUPPORT is not set
 # I2C_PCA9555_SUPPORT is not set
 # I2C_MAX7311_SUPPORT is not set
+# I2C_MCP23017_SUPPORT is not set
 # I2C_UDP_SUPPORT is not set
 # DEBUG_I2C is not set
 # I2C_SLAVE_SUPPORT is not set
@@ -450,26 +472,6 @@ REMOTE_IRMP_PORT=10001
 # DEBUG_IRMP is not set
 # DEBUG_REMOTE_IRMP is not set
 # PSB2186_SUPPORT is not set
-# PWM_SUPPORT is not set
-# PWM_GENERAL_SUPPORT is not set
-# PWM_GENERAL_INVERT_SUPPORT is not set
-# PWM_GENERAL_FADING_SUPPORT is not set
-# CH_A_PWM_GENERAL_SUPPORT is not set
-# CH_B_PWM_GENERAL_SUPPORT is not set
-# CH_C_PWM_GENERAL_SUPPORT is not set
-# PWM_WAV_SUPPORT is not set
-# VFS_PWM_WAV_SUPPORT is not set
-# PWM_MELODY_SUPPORT is not set
-# ENTCHEN_PWM_MELODY_SUPPORT is not set
-# TETRIS_PWM_MELODY_SUPPORT is not set
-# PWM_SERVO_SUPPORT is not set
-PWM_SERVOS=1
-# PWM_SERVO_INVERT is not set
-# PWM_SERVO_DEFAULT_ENABLED is not set
-# PWM_FREQ_SUPPORT is not set
-# PWM_DTMF_SUPPORT is not set
-# DEBUG_PWM is not set
-# DEBUG_PWM_SERVO is not set
 # ONEWIRE_SUPPORT is not set
 # ONEWIRE_DETECT_SUPPORT is not set
 # ONEWIRE_DS2502_SUPPORT is not set
@@ -501,6 +503,9 @@ PWM_SERVOS=1
 # ULTRASONIC_SUPPORT is not set
 # DEBUG_ULTRASONIC is not set
 # HBRIDGE_SUPPORT is not set
+# DUAL_HBRIDGE_SUPPORT is not set
+# SHARE_ENABLE_HBRIDGE_SUPPORT is not set
+# HBRIDGE_INVERTER_SUPPORT is not set
 # DEBUG_HBRIDGE is not set
 # MCUF_SUPPORT is not set
 # MCUF_SERIAL_SUPPORT is not set
@@ -547,6 +552,8 @@ MCUF_MODUL_DISPLAY_MODE_RANDOM=y
 CONF_ARTNET_PORT=6454
 CONF_ARTNET_INUNIVERSE=1
 CONF_ARTNET_OUTUNIVERSE=0
+CONF_ARTNET_OUTPUT_IP="192.168.0.255"
+# CONF_ARTNET_SEND_POLL_REPLY is not set
 # DEBUG_ARTNET is not set
 # DALI_SUPPORT is not set
 # DALI_RAW_SUPPORT is not set
@@ -594,6 +601,7 @@ ECMD_TCP_PORT=2701
 # EMS_SUPPORT is not set
 EMS_BUFFER_LEN=64
 EMS_PORT=7950
+# EMS_USART_0 is not set
 # EMS_DEBUG_STATS is not set
 # EMS_PROTO_DEBUG is not set
 # EMS_IO_DEBUG is not set
@@ -624,6 +632,11 @@ CONF_IRC_REALNAME="Ethersex Wollmilchsau"
 # DEBUG_IRC is not set
 # MDNS_SD_SUPPORT is not set
 # MODBUS_SUPPORT is not set
+# MQTT_SUPPORT is not set
+MQTT_CALLBACK_SLOTS=1
+# MQTT_STATIC_CONF is not set
+# MQTT_DEBUG is not set
+# MQTT_PARSE_DEBUG is not set
 # MYSQL_SUPPORT is not set
 CONF_MYSQL_IP="192.168.23.254"
 CONF_MYSQL_USERNAME="root"
@@ -657,6 +670,8 @@ CONF_NETSTAT_API="/~habo/stat/"
 # PROTO_INTERTECHNO_SUPPORT is not set
 # PROTO_INTERTECHNO_SL_SUPPORT is not set
 # PROTO_OASEFMMASTER_SUPPORT is not set
+# PROTO_FA20RF_SUPPORT is not set
+# PROTO_SMOKEDETECTOR_SUPPORT is not set
 # SIP_SUPPORT is not set
 CONF_SIP_PROXY_IP="192.168.178.1"
 CONF_SIP_FROM="621"
@@ -720,10 +735,11 @@ BSBPORT_MESSAGE_BUFFER_LEN=10
 BSBPORT_MESSAGE_MAX_LEN=25
 BSBPORT_OWNADDRESS=7
 # BSBPORT_POLLING_SUPPORT is not set
+# BSBPORT_MQTT_SUPPORT is not set
 # DEBUG_BSBPORT_RX is not set
 # DEBUG_BSBPORT_TX is not set
-# DEBUG_BSBPORT_PARSE is not set
 # DEBUG_BSBPORT_ECMD is not set
+# DEBUG_BSBPORT_MQTT is not set
 # MSR1_SUPPORT is not set
 MSR1_USART_0=y
 MSR1_USE_USART=0
@@ -791,15 +807,17 @@ DST_END_WEEK=5
 DST_END_DOW=0
 DST_END_HOUR=3
 # CLOCK_CRYSTAL_SUPPORT is not set
-# CLOCK_CPU_SUPPORT is not set
-# CLOCK_NTP_ADJUST_SUPPORT is not set
+# CLOCK_PERIODIC_SUPPORT is not set
 # DCF77_SUPPORT is not set
 # DEBUG_DCF77 is not set
 # NTP_SUPPORT is not set
+NTP_SERVER_IP="192.53.103.108"
+NTP_PORT=123
+NTP_QUERY_INTERVAL=1800
+# DEBUG_NTP is not set
 # NTPD_SUPPORT is not set
 # WHM_SUPPORT is not set
 # UPTIME_SUPPORT is not set
-# DEBUG_NTP_ADJUST is not set
 # CRON_SUPPORT is not set
 # CRON_DEFAULT_UTC is not set
 # CRON_SUPPORT_TEST is not set
@@ -823,6 +841,7 @@ DMX_FXSLOT_AMOUNT=4
 # DMX_FX_RANDOM is not set
 # DMX_FX_FIRE is not set
 # DMX_FX_WATER is not set
+# DMX_FX_RGB is not set
 # UDP_ECHO_NET_SUPPORT is not set
 # WOL_SUPPORT is not set
 # MOTD_SUPPORT is not set
@@ -866,6 +885,7 @@ STELLA_FADE_STEP_INIT=10
 STELLA_FADE_FUNCTION_INIT=stella_fade_func_0
 stella_fade_func_0=y
 # stella_fade_func_1 is not set
+# STELLA_USE_CIE1931 is not set
 # DEBUG_STELLA is not set
 # STARBURST_SUPPORT is not set
 # STARBURST_PCA9685 is not set
@@ -973,13 +993,6 @@ CONF_TIME2PRESS_POWERL=3
 # SANYO_Z700_USART_0 is not set
 # DEBUG_SANYO_Z700 is not set
 # FREQCOUNT_SUPPORT is not set
-FREQCOUNT_CHANNELS=1
-# FREQCOUNT_BOOT_ON is not set
-FREQCOUNT_AVERAGE=8
-# FREQCOUNT_NOSLOW_SUPPORT is not set
-# FREQCOUNT_DUTY_SUPPORT is not set
-# FREQCOUNT_MOVING_AVERAGE_SUPPORT is not set
-# FREQCOUNT_DEBUGGING is not set
 # TANKLEVEL_SUPPORT is not set
 TANKLEVEL_ADC_CHANNEL=0
 # TANKLEVEL_STARTUP is not set
@@ -1000,10 +1013,12 @@ IPV4_SUPPORT=y
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -1018,12 +1033,15 @@ avrispmkII=y
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -1033,6 +1051,8 @@ avrispmkII=y
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -1043,13 +1063,22 @@ avrispmkII=y
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -1065,6 +1094,7 @@ avrispmkII=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set

--- a/scripts/profiles/fnordlicht_servo
+++ b/scripts/profiles/fnordlicht_servo
@@ -23,6 +23,7 @@ atmega168=y
 # atmega644 is not set
 # atmega644p is not set
 # atmega1284p is not set
+# atmega2560 is not set
 # at90can32 is not set
 # at90can64 is not set
 # at90can128 is not set
@@ -32,6 +33,7 @@ FREQ=8000000
 # antares_IO is not set
 # antares_O is not set
 # Arduino_Duemilanove is not set
+# arduino_mega2560_r3 is not set
 # beteigeuze is not set
 # conrad_probot is not set
 # ehaserl is not set
@@ -74,7 +76,7 @@ EEPROM_PAGESIZE=0x4
 # SPI_TIMEOUT is not set
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="ac826dc"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 # DEBUG is not set
 # DEBUG_USE_SYSLOG is not set
@@ -82,6 +84,23 @@ GIT_VERSION="ac826dc"
 # SOFT_UART_SUPPORT is not set
 # DEBUG_HOOK is not set
 # DEBUG_RESET_REASON is not set
+
+#
+# Periodic / Scheduler
+#
+CONF_MTICKS_PER_SEC=50
+# PERIODIC_TIMER3_SUPPORT is not set
+CONF_PERIODIC_USE_TIMER=1
+# PERIODIC_TIMER_API_SUPPORT is not set
+# PERIODIC_ADJUST_SUPPORT is not set
+# DEBUG_PERIODIC is not set
+# DEBUG_PERIODIC_ECMD_SUPPORT is not set
+# DEBUG_PERIODIC_WAVEFORMS_SUPPORT is not set
+# DEBUG_PERIODIC_OC1A_SUPPORT is not set
+# SCHEDULER_SUPPORT is not set
+# SCHEDULER_DYNAMIC_SUPPORT is not set
+CONF_SCHEDULER_NUM_DYNAMIC_TIMERS=8
+# DEBUG_SCHEDULER_SUPPORT is not set
 # STATUSLEDS is not set
 # STATUSLED_POWER_SUPPORT is not set
 # STATUSLED_BOOTED_SUPPORT is not set
@@ -257,7 +276,6 @@ CONF_OPENVPN_PORT=1194
 # DEBUG_OPENVPN is not set
 # DEBUG_ROUTER is not set
 # DEBUG_UIP is not set
-# DEBUG_NTP is not set
 # DEBUG_UNKNOWN_PACKETS is not set
 
 #
@@ -317,6 +335,8 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD Displays
 #
 # HD44780_SUPPORT is not set
+# HD44780_BACKLIGHT_SUPPORT is not set
+# HD44780_MULTIENSUPPORT is not set
 # HD44780_BACKLIGHT_INV is not set
 # HR20_LCD_SUPPORT_FULL is not set
 # S1D15G10_SUPPORT is not set
@@ -326,6 +346,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD_SUPPORT is not set
 # DEBUG_HD44780 is not set
 # DEBUG_LCD_MENU is not set
+# DEBUG_HD44780_I2C is not set
 
 #
 # Storage
@@ -353,6 +374,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # I2C_PCF8574X_SUPPORT is not set
 # I2C_PCA9555_SUPPORT is not set
 # I2C_MAX7311_SUPPORT is not set
+# I2C_MCP23017_SUPPORT is not set
 # I2C_UDP_SUPPORT is not set
 # DEBUG_I2C is not set
 # I2C_SLAVE_SUPPORT is not set
@@ -450,26 +472,6 @@ REMOTE_IRMP_PORT=10001
 # DEBUG_IRMP is not set
 # DEBUG_REMOTE_IRMP is not set
 # PSB2186_SUPPORT is not set
-PWM_SUPPORT=y
-# PWM_GENERAL_SUPPORT is not set
-# PWM_GENERAL_INVERT_SUPPORT is not set
-# PWM_GENERAL_FADING_SUPPORT is not set
-# CH_A_PWM_GENERAL_SUPPORT is not set
-# CH_B_PWM_GENERAL_SUPPORT is not set
-# CH_C_PWM_GENERAL_SUPPORT is not set
-# PWM_WAV_SUPPORT is not set
-# VFS_PWM_WAV_SUPPORT is not set
-# PWM_MELODY_SUPPORT is not set
-# ENTCHEN_PWM_MELODY_SUPPORT is not set
-# TETRIS_PWM_MELODY_SUPPORT is not set
-PWM_SERVO_SUPPORT=y
-PWM_SERVOS=6
-# PWM_SERVO_INVERT is not set
-# PWM_SERVO_DEFAULT_ENABLED is not set
-# PWM_FREQ_SUPPORT is not set
-# PWM_DTMF_SUPPORT is not set
-# DEBUG_PWM is not set
-# DEBUG_PWM_SERVO is not set
 # ONEWIRE_SUPPORT is not set
 # ONEWIRE_DETECT_SUPPORT is not set
 # ONEWIRE_DS2502_SUPPORT is not set
@@ -501,6 +503,9 @@ PWM_SERVOS=6
 # ULTRASONIC_SUPPORT is not set
 # DEBUG_ULTRASONIC is not set
 # HBRIDGE_SUPPORT is not set
+# DUAL_HBRIDGE_SUPPORT is not set
+# SHARE_ENABLE_HBRIDGE_SUPPORT is not set
+# HBRIDGE_INVERTER_SUPPORT is not set
 # DEBUG_HBRIDGE is not set
 # MCUF_SUPPORT is not set
 # MCUF_SERIAL_SUPPORT is not set
@@ -547,6 +552,8 @@ MCUF_MODUL_DISPLAY_MODE_RANDOM=y
 CONF_ARTNET_PORT=6454
 CONF_ARTNET_INUNIVERSE=1
 CONF_ARTNET_OUTUNIVERSE=0
+CONF_ARTNET_OUTPUT_IP="192.168.0.255"
+# CONF_ARTNET_SEND_POLL_REPLY is not set
 # DEBUG_ARTNET is not set
 # DALI_SUPPORT is not set
 # DALI_RAW_SUPPORT is not set
@@ -593,6 +600,7 @@ DMX_USE_USART=0
 # EMS_SUPPORT is not set
 EMS_BUFFER_LEN=192
 EMS_PORT=7950
+# EMS_USART_0 is not set
 # EMS_DEBUG_STATS is not set
 # EMS_PROTO_DEBUG is not set
 # EMS_IO_DEBUG is not set
@@ -624,6 +632,11 @@ CONF_IRC_REALNAME="Ethersex Wollmilchsau"
 # DEBUG_IRC is not set
 # MDNS_SD_SUPPORT is not set
 # MODBUS_SUPPORT is not set
+# MQTT_SUPPORT is not set
+MQTT_CALLBACK_SLOTS=1
+# MQTT_STATIC_CONF is not set
+# MQTT_DEBUG is not set
+# MQTT_PARSE_DEBUG is not set
 # MYSQL_SUPPORT is not set
 CONF_MYSQL_IP="192.168.23.254"
 CONF_MYSQL_USERNAME="root"
@@ -657,6 +670,8 @@ CONF_NETSTAT_API="/~habo/stat/"
 # PROTO_INTERTECHNO_SUPPORT is not set
 # PROTO_INTERTECHNO_SL_SUPPORT is not set
 # PROTO_OASEFMMASTER_SUPPORT is not set
+# PROTO_FA20RF_SUPPORT is not set
+# PROTO_SMOKEDETECTOR_SUPPORT is not set
 # SIP_SUPPORT is not set
 CONF_SIP_PROXY_IP="192.168.178.1"
 CONF_SIP_FROM="621"
@@ -720,10 +735,11 @@ BSBPORT_MESSAGE_BUFFER_LEN=10
 BSBPORT_MESSAGE_MAX_LEN=25
 BSBPORT_OWNADDRESS=7
 # BSBPORT_POLLING_SUPPORT is not set
+# BSBPORT_MQTT_SUPPORT is not set
 # DEBUG_BSBPORT_RX is not set
 # DEBUG_BSBPORT_TX is not set
-# DEBUG_BSBPORT_PARSE is not set
 # DEBUG_BSBPORT_ECMD is not set
+# DEBUG_BSBPORT_MQTT is not set
 # MSR1_SUPPORT is not set
 MSR1_USART_0=y
 MSR1_USE_USART=0
@@ -778,15 +794,17 @@ SGC_SLEEPMODE=0
 # CLOCK_SUPPORT is not set
 # CLOCK_DATETIME_SUPPORT is not set
 # CLOCK_CRYSTAL_SUPPORT is not set
-# CLOCK_CPU_SUPPORT is not set
-# CLOCK_NTP_ADJUST_SUPPORT is not set
+# CLOCK_PERIODIC_SUPPORT is not set
 # DCF77_SUPPORT is not set
 # DEBUG_DCF77 is not set
 # NTP_SUPPORT is not set
+NTP_SERVER_IP="192.53.103.108"
+NTP_PORT=123
+NTP_QUERY_INTERVAL=1800
+# DEBUG_NTP is not set
 # NTPD_SUPPORT is not set
 # WHM_SUPPORT is not set
 # UPTIME_SUPPORT is not set
-# DEBUG_NTP_ADJUST is not set
 # CRON_SUPPORT is not set
 # CRON_DEFAULT_UTC is not set
 # CRON_SUPPORT_TEST is not set
@@ -810,6 +828,7 @@ DMX_FXSLOT_AMOUNT=4
 # DMX_FX_RANDOM is not set
 # DMX_FX_FIRE is not set
 # DMX_FX_WATER is not set
+# DMX_FX_RGB is not set
 # UDP_ECHO_NET_SUPPORT is not set
 # WOL_SUPPORT is not set
 # MOTD_SUPPORT is not set
@@ -853,6 +872,7 @@ STELLA_FADE_STEP_INIT=10
 STELLA_FADE_FUNCTION_INIT=stella_fade_func_0
 stella_fade_func_0=y
 # stella_fade_func_1 is not set
+# STELLA_USE_CIE1931 is not set
 # DEBUG_STELLA is not set
 # STARBURST_SUPPORT is not set
 # STARBURST_PCA9685 is not set
@@ -960,13 +980,6 @@ CONF_TIME2PRESS_POWERL=3
 # SANYO_Z700_USART_0 is not set
 # DEBUG_SANYO_Z700 is not set
 # FREQCOUNT_SUPPORT is not set
-FREQCOUNT_CHANNELS=1
-# FREQCOUNT_BOOT_ON is not set
-FREQCOUNT_AVERAGE=8
-# FREQCOUNT_NOSLOW_SUPPORT is not set
-# FREQCOUNT_DUTY_SUPPORT is not set
-# FREQCOUNT_MOVING_AVERAGE_SUPPORT is not set
-# FREQCOUNT_DEBUGGING is not set
 # TANKLEVEL_SUPPORT is not set
 TANKLEVEL_ADC_CHANNEL=0
 # TANKLEVEL_STARTUP is not set
@@ -986,10 +999,12 @@ TANKLEVEL_HOLD_TIME=20
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -1004,12 +1019,15 @@ avrispmkII=y
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -1019,6 +1037,8 @@ avrispmkII=y
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -1029,13 +1049,22 @@ avrispmkII=y
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -1051,6 +1080,7 @@ avrispmkII=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set

--- a/scripts/profiles/hr20
+++ b/scripts/profiles/hr20
@@ -23,6 +23,7 @@ atmega169=y
 # atmega644 is not set
 # atmega644p is not set
 # atmega1284p is not set
+# atmega2560 is not set
 # at90can32 is not set
 # at90can64 is not set
 # at90can128 is not set
@@ -32,6 +33,7 @@ FREQ=1000000
 # antares_IO is not set
 # antares_O is not set
 # Arduino_Duemilanove is not set
+# arduino_mega2560_r3 is not set
 # beteigeuze is not set
 # conrad_probot is not set
 # ehaserl is not set
@@ -65,7 +67,7 @@ BOOTLOADER_SIZE=0
 BOOTLOADER_START_ADDRESS=0x4000
 FLASH_SIZE=0x4000
 EEPROM_SIZE=0x200
-RAM_SIZE=0x400
+RAM_SIZE=0x500
 FLASH_PAGESIZE=0x80
 EEPROM_PAGESIZE=0x4
 # CRC_PAD_SUPPORT is not set
@@ -74,7 +76,7 @@ TEENSY_SUPPORT=y
 # SPI_TIMEOUT is not set
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="ac826dc"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 # DEBUG is not set
 # DEBUG_USE_SYSLOG is not set
@@ -82,6 +84,23 @@ GIT_VERSION="ac826dc"
 # SOFT_UART_SUPPORT is not set
 # DEBUG_HOOK is not set
 # DEBUG_RESET_REASON is not set
+
+#
+# Periodic / Scheduler
+#
+CONF_MTICKS_PER_SEC=50
+# PERIODIC_TIMER3_SUPPORT is not set
+CONF_PERIODIC_USE_TIMER=1
+# PERIODIC_TIMER_API_SUPPORT is not set
+# PERIODIC_ADJUST_SUPPORT is not set
+# DEBUG_PERIODIC is not set
+# DEBUG_PERIODIC_ECMD_SUPPORT is not set
+# DEBUG_PERIODIC_WAVEFORMS_SUPPORT is not set
+# DEBUG_PERIODIC_OC1A_SUPPORT is not set
+# SCHEDULER_SUPPORT is not set
+# SCHEDULER_DYNAMIC_SUPPORT is not set
+CONF_SCHEDULER_NUM_DYNAMIC_TIMERS=8
+# DEBUG_SCHEDULER_SUPPORT is not set
 # STATUSLEDS is not set
 # STATUSLED_POWER_SUPPORT is not set
 # STATUSLED_BOOTED_SUPPORT is not set
@@ -226,6 +245,7 @@ CONF_RFM12_IP4_NETMASK="255.255.255.0"
 # DEBUG_USB_HID_KEYBOARD is not set
 # DEBUG_USB_HID_MOUSE is not set
 ZBUS_SUPPORT=y
+# ZBUS_USART_0 is not set
 CONF_ZBUS_BAUDRATE=9600
 CONF_ZBUS_IP="10.40.1.31"
 CONF_ZBUS_IP4_NETMASK="255.255.255.0"
@@ -266,7 +286,6 @@ CONF_OPENVPN_PORT=1194
 # DEBUG_OPENVPN is not set
 # DEBUG_ROUTER is not set
 # DEBUG_UIP is not set
-# DEBUG_NTP is not set
 # DEBUG_UNKNOWN_PACKETS is not set
 
 #
@@ -276,8 +295,6 @@ PORTIO_SCHEME=CONFIG_IO_NONE
 CONFIG_IO_NONE=y
 # PORTIO_SIMPLE is not set
 # PORTIO_FULL_FEATURED is not set
-# PORTIO_SIMPLE_SUPPORT is not set
-# PORTIO_SUPPORT is not set
 # NAMED_PIN_SUPPORT is not set
 # TTY_SUPPORT is not set
 TTY_COLS=16
@@ -297,6 +314,7 @@ HC595_REGISTERS=5
 # HC165_INVERSE_OUTPUT is not set
 HC165_REGISTERS=1
 # SMS_SUPPORT is not set
+# SMS_USART_0 is not set
 # DEBUG_SMS is not set
 
 #
@@ -323,6 +341,8 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD Displays
 #
 # HD44780_SUPPORT is not set
+# HD44780_BACKLIGHT_SUPPORT is not set
+# HD44780_MULTIENSUPPORT is not set
 # HD44780_BACKLIGHT_INV is not set
 HR20_LCD_SUPPORT=y
 # S1D15G10_SUPPORT is not set
@@ -332,6 +352,7 @@ HR20_LCD_SUPPORT=y
 # LCD_SUPPORT is not set
 # DEBUG_HD44780 is not set
 # DEBUG_LCD_MENU is not set
+# DEBUG_HD44780_I2C is not set
 
 #
 # Storage
@@ -359,6 +380,7 @@ HR20_LCD_SUPPORT=y
 # I2C_PCF8574X_SUPPORT is not set
 # I2C_PCA9555_SUPPORT is not set
 # I2C_MAX7311_SUPPORT is not set
+# I2C_MCP23017_SUPPORT is not set
 # I2C_UDP_SUPPORT is not set
 # DEBUG_I2C is not set
 # I2C_SLAVE_SUPPORT is not set
@@ -447,26 +469,6 @@ REMOTE_IRMP_PORT=10001
 # DEBUG_IRMP is not set
 # DEBUG_REMOTE_IRMP is not set
 # PSB2186_SUPPORT is not set
-# PWM_SUPPORT is not set
-# PWM_GENERAL_SUPPORT is not set
-# PWM_GENERAL_INVERT_SUPPORT is not set
-# PWM_GENERAL_FADING_SUPPORT is not set
-# CH_A_PWM_GENERAL_SUPPORT is not set
-# CH_B_PWM_GENERAL_SUPPORT is not set
-# CH_C_PWM_GENERAL_SUPPORT is not set
-# PWM_WAV_SUPPORT is not set
-# VFS_PWM_WAV_SUPPORT is not set
-# PWM_MELODY_SUPPORT is not set
-# ENTCHEN_PWM_MELODY_SUPPORT is not set
-# TETRIS_PWM_MELODY_SUPPORT is not set
-# PWM_SERVO_SUPPORT is not set
-PWM_SERVOS=1
-# PWM_SERVO_INVERT is not set
-# PWM_SERVO_DEFAULT_ENABLED is not set
-# PWM_FREQ_SUPPORT is not set
-# PWM_DTMF_SUPPORT is not set
-# DEBUG_PWM is not set
-# DEBUG_PWM_SERVO is not set
 # ONEWIRE_SUPPORT is not set
 # ONEWIRE_DETECT_SUPPORT is not set
 # ONEWIRE_DS2502_SUPPORT is not set
@@ -498,6 +500,9 @@ PWM_SERVOS=1
 # ULTRASONIC_SUPPORT is not set
 # DEBUG_ULTRASONIC is not set
 # HBRIDGE_SUPPORT is not set
+# DUAL_HBRIDGE_SUPPORT is not set
+# SHARE_ENABLE_HBRIDGE_SUPPORT is not set
+# HBRIDGE_INVERTER_SUPPORT is not set
 # DEBUG_HBRIDGE is not set
 # MCUF_SUPPORT is not set
 # MCUF_SERIAL_SUPPORT is not set
@@ -542,6 +547,8 @@ MCUF_MODUL_DISPLAY_MODE_RANDOM=y
 CONF_ARTNET_PORT=6454
 CONF_ARTNET_INUNIVERSE=1
 CONF_ARTNET_OUTUNIVERSE=0
+CONF_ARTNET_OUTPUT_IP="192.168.0.255"
+# CONF_ARTNET_SEND_POLL_REPLY is not set
 # DEBUG_ARTNET is not set
 # DALI_SUPPORT is not set
 # DALI_RAW_SUPPORT is not set
@@ -585,12 +592,6 @@ DISABLE_IPCONF_SUPPORT=y
 # DEBUG_ECMD_SCRIPT is not set
 # ELTAKOMS_SUPPORT is not set
 # EMS_SUPPORT is not set
-EMS_BUFFER_LEN=64
-EMS_PORT=7950
-# EMS_DEBUG_STATS is not set
-# EMS_PROTO_DEBUG is not set
-# EMS_IO_DEBUG is not set
-# EMS_ERROR_DEBUG is not set
 # FNORDLICHT_SUPPORT is not set
 # HTTPLOG_SUPPORT is not set
 CONF_HTTPLOG_SERVICE="volkszaehler.org"
@@ -611,6 +612,11 @@ CONF_IRC_REALNAME="Ethersex Wollmilchsau"
 # DEBUG_IRC is not set
 # MDNS_SD_SUPPORT is not set
 # MODBUS_SUPPORT is not set
+# MQTT_SUPPORT is not set
+MQTT_CALLBACK_SLOTS=1
+# MQTT_STATIC_CONF is not set
+# MQTT_DEBUG is not set
+# MQTT_PARSE_DEBUG is not set
 # MYSQL_SUPPORT is not set
 CONF_MYSQL_IP="192.168.23.254"
 CONF_MYSQL_USERNAME="root"
@@ -644,6 +650,8 @@ CONF_NETSTAT_API="/~habo/stat/"
 # PROTO_INTERTECHNO_SUPPORT is not set
 # PROTO_INTERTECHNO_SL_SUPPORT is not set
 # PROTO_OASEFMMASTER_SUPPORT is not set
+# PROTO_FA20RF_SUPPORT is not set
+# PROTO_SMOKEDETECTOR_SUPPORT is not set
 # SIP_SUPPORT is not set
 CONF_SIP_PROXY_IP="192.168.178.1"
 CONF_SIP_FROM="621"
@@ -735,15 +743,17 @@ DST_END_WEEK=5
 DST_END_DOW=0
 DST_END_HOUR=3
 # CLOCK_CRYSTAL_SUPPORT is not set
-# CLOCK_CPU_SUPPORT is not set
-# CLOCK_NTP_ADJUST_SUPPORT is not set
+# CLOCK_PERIODIC_SUPPORT is not set
 # DCF77_SUPPORT is not set
 # DEBUG_DCF77 is not set
 # NTP_SUPPORT is not set
+NTP_SERVER_IP="192.53.103.108"
+NTP_PORT=123
+NTP_QUERY_INTERVAL=1800
+# DEBUG_NTP is not set
 # NTPD_SUPPORT is not set
 # WHM_SUPPORT is not set
 # UPTIME_SUPPORT is not set
-# DEBUG_NTP_ADJUST is not set
 # CRON_SUPPORT is not set
 # CRON_DEFAULT_UTC is not set
 # CRON_EEPROM_SUPPORT is not set
@@ -765,6 +775,7 @@ DMX_FXSLOT_AMOUNT=4
 # DMX_FX_RANDOM is not set
 # DMX_FX_FIRE is not set
 # DMX_FX_WATER is not set
+# DMX_FX_RGB is not set
 # UDP_ECHO_NET_SUPPORT is not set
 # WOL_SUPPORT is not set
 # MOTD_SUPPORT is not set
@@ -808,6 +819,7 @@ STELLA_FADE_STEP_INIT=10
 STELLA_FADE_FUNCTION_INIT=stella_fade_func_0
 stella_fade_func_0=y
 # stella_fade_func_1 is not set
+# STELLA_USE_CIE1931 is not set
 # DEBUG_STELLA is not set
 # STARBURST_SUPPORT is not set
 # STARBURST_PCA9685 is not set
@@ -913,13 +925,6 @@ CONF_TIME2PRESS_POWER=40
 CONF_TIME2PRESS_POWERL=3
 # PROJECTOR_SANYO_Z700_SUPPORT is not set
 # FREQCOUNT_SUPPORT is not set
-FREQCOUNT_CHANNELS=1
-# FREQCOUNT_BOOT_ON is not set
-FREQCOUNT_AVERAGE=8
-# FREQCOUNT_NOSLOW_SUPPORT is not set
-# FREQCOUNT_DUTY_SUPPORT is not set
-# FREQCOUNT_MOVING_AVERAGE_SUPPORT is not set
-# FREQCOUNT_DEBUGGING is not set
 # TANKLEVEL_SUPPORT is not set
 TANKLEVEL_ADC_CHANNEL=0
 # TANKLEVEL_STARTUP is not set
@@ -941,10 +946,12 @@ IPV4_SUPPORT=y
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -959,12 +966,15 @@ avrispmkII=y
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -974,6 +984,8 @@ avrispmkII=y
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -984,13 +996,22 @@ avrispmkII=y
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -1006,6 +1027,7 @@ avrispmkII=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set

--- a/scripts/profiles/lome6
+++ b/scripts/profiles/lome6
@@ -23,6 +23,7 @@ ARCH_AVR=y
 # atmega644p is not set
 MCU=atmega1284p
 atmega1284p=y
+# atmega2560 is not set
 # at90can32 is not set
 # at90can64 is not set
 # at90can128 is not set
@@ -32,6 +33,7 @@ FREQ=16000000
 # antares_IO is not set
 # antares_O is not set
 # Arduino_Duemilanove is not set
+# arduino_mega2560_r3 is not set
 # beteigeuze is not set
 # conrad_probot is not set
 # ehaserl is not set
@@ -74,7 +76,7 @@ EEPROM_PAGESIZE=0x8
 # SPI_TIMEOUT is not set
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="ac826dc"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 # DEBUG is not set
 # DEBUG_USE_SYSLOG is not set
@@ -82,6 +84,23 @@ GIT_VERSION="ac826dc"
 # SOFT_UART_SUPPORT is not set
 # DEBUG_HOOK is not set
 # DEBUG_RESET_REASON is not set
+
+#
+# Periodic / Scheduler
+#
+CONF_MTICKS_PER_SEC=50
+# PERIODIC_TIMER3_SUPPORT is not set
+CONF_PERIODIC_USE_TIMER=1
+# PERIODIC_TIMER_API_SUPPORT is not set
+# PERIODIC_ADJUST_SUPPORT is not set
+# DEBUG_PERIODIC is not set
+# DEBUG_PERIODIC_ECMD_SUPPORT is not set
+# DEBUG_PERIODIC_WAVEFORMS_SUPPORT is not set
+# DEBUG_PERIODIC_OC1A_SUPPORT is not set
+# SCHEDULER_SUPPORT is not set
+# SCHEDULER_DYNAMIC_SUPPORT is not set
+CONF_SCHEDULER_NUM_DYNAMIC_TIMERS=32
+# DEBUG_SCHEDULER_SUPPORT is not set
 STATUSLEDS=y
 # STATUSLED_POWER_SUPPORT is not set
 # STATUSLED_BOOTED_SUPPORT is not set
@@ -267,7 +286,6 @@ CONF_OPENVPN_PORT=1194
 # DEBUG_OPENVPN is not set
 # DEBUG_ROUTER is not set
 # DEBUG_UIP is not set
-# DEBUG_NTP is not set
 # DEBUG_UNKNOWN_PACKETS is not set
 
 #
@@ -341,9 +359,9 @@ HD44780_DIREKT=y
 # HD44780_I2CSUPPORT is not set
 # HD44780_SERLCD is not set
 # HD44780_2WIRE is not set
-HD44780_READBACK=y
-# HD44780_MULTIENSUPPORT is not set
 # HD44780_BACKLIGHT_SUPPORT is not set
+# HD44780_MULTIENSUPPORT is not set
+HD44780_READBACK=y
 # HD44780_BACKLIGHT_INV is not set
 # HR20_LCD_SUPPORT_FULL is not set
 # S1D15G10_SUPPORT is not set
@@ -353,6 +371,7 @@ HD44780_READBACK=y
 LCD_SUPPORT=y
 # DEBUG_HD44780 is not set
 # DEBUG_LCD_MENU is not set
+# DEBUG_HD44780_I2C is not set
 
 #
 # Storage
@@ -380,6 +399,7 @@ LCD_SUPPORT=y
 # I2C_PCF8574X_SUPPORT is not set
 # I2C_PCA9555_SUPPORT is not set
 # I2C_MAX7311_SUPPORT is not set
+# I2C_MCP23017_SUPPORT is not set
 # I2C_UDP_SUPPORT is not set
 # DEBUG_I2C is not set
 # I2C_SLAVE_SUPPORT is not set
@@ -477,26 +497,6 @@ REMOTE_IRMP_PORT=10001
 # DEBUG_IRMP is not set
 # DEBUG_REMOTE_IRMP is not set
 # PSB2186_SUPPORT is not set
-# PWM_SUPPORT is not set
-# PWM_GENERAL_SUPPORT is not set
-# PWM_GENERAL_INVERT_SUPPORT is not set
-# PWM_GENERAL_FADING_SUPPORT is not set
-# CH_A_PWM_GENERAL_SUPPORT is not set
-# CH_B_PWM_GENERAL_SUPPORT is not set
-# CH_C_PWM_GENERAL_SUPPORT is not set
-# PWM_WAV_SUPPORT is not set
-# VFS_PWM_WAV_SUPPORT is not set
-# PWM_MELODY_SUPPORT is not set
-# ENTCHEN_PWM_MELODY_SUPPORT is not set
-# TETRIS_PWM_MELODY_SUPPORT is not set
-# PWM_SERVO_SUPPORT is not set
-PWM_SERVOS=1
-# PWM_SERVO_INVERT is not set
-# PWM_SERVO_DEFAULT_ENABLED is not set
-# PWM_FREQ_SUPPORT is not set
-# PWM_DTMF_SUPPORT is not set
-# DEBUG_PWM is not set
-# DEBUG_PWM_SERVO is not set
 ONEWIRE_SUPPORT=y
 # ONEWIRE_DETECT_SUPPORT is not set
 # ONEWIRE_DS2502_SUPPORT is not set
@@ -528,6 +528,9 @@ ONEWIRE_SUPPORT=y
 # ULTRASONIC_SUPPORT is not set
 # DEBUG_ULTRASONIC is not set
 # HBRIDGE_SUPPORT is not set
+# DUAL_HBRIDGE_SUPPORT is not set
+# SHARE_ENABLE_HBRIDGE_SUPPORT is not set
+# HBRIDGE_INVERTER_SUPPORT is not set
 # DEBUG_HBRIDGE is not set
 # MCUF_SUPPORT is not set
 # MCUF_SERIAL_SUPPORT is not set
@@ -574,6 +577,8 @@ NET_MAX_FRAME_LENGTH_GT_571=y
 CONF_ARTNET_PORT=6454
 CONF_ARTNET_INUNIVERSE=1
 CONF_ARTNET_OUTUNIVERSE=0
+CONF_ARTNET_OUTPUT_IP="192.168.0.255"
+# CONF_ARTNET_SEND_POLL_REPLY is not set
 # DEBUG_ARTNET is not set
 # DALI_SUPPORT is not set
 # DALI_RAW_SUPPORT is not set
@@ -622,6 +627,8 @@ FREE_SUPPORT=y
 # EMS_SUPPORT is not set
 EMS_BUFFER_LEN=255
 EMS_PORT=7950
+# EMS_USART_0 is not set
+# EMS_USART_1 is not set
 # EMS_DEBUG_STATS is not set
 # EMS_PROTO_DEBUG is not set
 # EMS_IO_DEBUG is not set
@@ -653,6 +660,11 @@ CONF_IRC_REALNAME="Ethersex Wollmilchsau"
 # DEBUG_IRC is not set
 # MDNS_SD_SUPPORT is not set
 # MODBUS_SUPPORT is not set
+# MQTT_SUPPORT is not set
+MQTT_CALLBACK_SLOTS=1
+# MQTT_STATIC_CONF is not set
+# MQTT_DEBUG is not set
+# MQTT_PARSE_DEBUG is not set
 # MYSQL_SUPPORT is not set
 CONF_MYSQL_IP="192.168.23.254"
 CONF_MYSQL_USERNAME="root"
@@ -686,6 +698,8 @@ CONF_NETSTAT_API="/~habo/stat/"
 # PROTO_INTERTECHNO_SUPPORT is not set
 # PROTO_INTERTECHNO_SL_SUPPORT is not set
 # PROTO_OASEFMMASTER_SUPPORT is not set
+# PROTO_FA20RF_SUPPORT is not set
+# PROTO_SMOKEDETECTOR_SUPPORT is not set
 # SIP_SUPPORT is not set
 CONF_SIP_PROXY_IP="192.168.178.1"
 CONF_SIP_FROM="621"
@@ -751,10 +765,11 @@ BSBPORT_MESSAGE_BUFFER_LEN=10
 BSBPORT_MESSAGE_MAX_LEN=25
 BSBPORT_OWNADDRESS=7
 # BSBPORT_POLLING_SUPPORT is not set
+# BSBPORT_MQTT_SUPPORT is not set
 # DEBUG_BSBPORT_RX is not set
 # DEBUG_BSBPORT_TX is not set
-# DEBUG_BSBPORT_PARSE is not set
 # DEBUG_BSBPORT_ECMD is not set
+# DEBUG_BSBPORT_MQTT is not set
 # MSR1_SUPPORT is not set
 # MSR1_USART_0 is not set
 # MSR1_USART_1 is not set
@@ -824,18 +839,17 @@ DST_END_WEEK=5
 DST_END_DOW=0
 DST_END_HOUR=3
 # CLOCK_CRYSTAL_SUPPORT is not set
-# CLOCK_CPU_SUPPORT is not set
-# CLOCK_NTP_ADJUST_SUPPORT is not set
+# CLOCK_PERIODIC_SUPPORT is not set
 # DCF77_SUPPORT is not set
 # DEBUG_DCF77 is not set
 NTP_SUPPORT=y
 NTP_SERVER_IP="131.234.137.23"
 NTP_PORT=123
 NTP_QUERY_INTERVAL=1800
+# DEBUG_NTP is not set
 # NTPD_SUPPORT is not set
 WHM_SUPPORT=y
 # UPTIME_SUPPORT is not set
-# DEBUG_NTP_ADJUST is not set
 # CRON_SUPPORT is not set
 # CRON_DEFAULT_UTC is not set
 # CRON_SUPPORT_TEST is not set
@@ -859,6 +873,7 @@ DMX_FXSLOT_AMOUNT=4
 # DMX_FX_RANDOM is not set
 # DMX_FX_FIRE is not set
 # DMX_FX_WATER is not set
+# DMX_FX_RGB is not set
 # UDP_ECHO_NET_SUPPORT is not set
 # WOL_SUPPORT is not set
 # MOTD_SUPPORT is not set
@@ -902,6 +917,7 @@ STELLA_FADE_STEP_INIT=10
 STELLA_FADE_FUNCTION_INIT=stella_fade_func_0
 stella_fade_func_0=y
 # stella_fade_func_1 is not set
+# STELLA_USE_CIE1931 is not set
 # DEBUG_STELLA is not set
 # STARBURST_SUPPORT is not set
 # STARBURST_PCA9685 is not set
@@ -1012,13 +1028,6 @@ CONF_TIME2PRESS_POWERL=3
 # SANYO_Z700_USART_1 is not set
 # DEBUG_SANYO_Z700 is not set
 # FREQCOUNT_SUPPORT is not set
-FREQCOUNT_CHANNELS=1
-# FREQCOUNT_BOOT_ON is not set
-FREQCOUNT_AVERAGE=8
-# FREQCOUNT_NOSLOW_SUPPORT is not set
-# FREQCOUNT_DUTY_SUPPORT is not set
-# FREQCOUNT_MOVING_AVERAGE_SUPPORT is not set
-# FREQCOUNT_DEBUGGING is not set
 # TANKLEVEL_SUPPORT is not set
 TANKLEVEL_ADC_CHANNEL=0
 # TANKLEVEL_STARTUP is not set
@@ -1040,10 +1049,12 @@ IPV4_SUPPORT=y
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -1058,12 +1069,15 @@ avrispmkII=y
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -1073,6 +1087,8 @@ avrispmkII=y
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -1083,13 +1099,22 @@ avrispmkII=y
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -1105,6 +1130,7 @@ avrispmkII=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set

--- a/scripts/profiles/netio
+++ b/scripts/profiles/netio
@@ -23,6 +23,7 @@ atmega32=y
 # atmega644 is not set
 # atmega644p is not set
 # atmega1284p is not set
+# atmega2560 is not set
 # at90can32 is not set
 # at90can64 is not set
 # at90can128 is not set
@@ -32,6 +33,7 @@ FREQ=16000000
 # antares_IO is not set
 # antares_O is not set
 # Arduino_Duemilanove is not set
+# arduino_mega2560_r3 is not set
 # beteigeuze is not set
 # conrad_probot is not set
 # ehaserl is not set
@@ -74,7 +76,7 @@ EEPROM_PAGESIZE=0x4
 # SPI_TIMEOUT is not set
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="ac826dc"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 # DEBUG is not set
 # DEBUG_USE_SYSLOG is not set
@@ -82,6 +84,23 @@ GIT_VERSION="ac826dc"
 # SOFT_UART_SUPPORT is not set
 # DEBUG_HOOK is not set
 # DEBUG_RESET_REASON is not set
+
+#
+# Periodic / Scheduler
+#
+CONF_MTICKS_PER_SEC=50
+# PERIODIC_TIMER3_SUPPORT is not set
+CONF_PERIODIC_USE_TIMER=1
+# PERIODIC_TIMER_API_SUPPORT is not set
+# PERIODIC_ADJUST_SUPPORT is not set
+# DEBUG_PERIODIC is not set
+# DEBUG_PERIODIC_ECMD_SUPPORT is not set
+# DEBUG_PERIODIC_WAVEFORMS_SUPPORT is not set
+# DEBUG_PERIODIC_OC1A_SUPPORT is not set
+# SCHEDULER_SUPPORT is not set
+# SCHEDULER_DYNAMIC_SUPPORT is not set
+CONF_SCHEDULER_NUM_DYNAMIC_TIMERS=8
+# DEBUG_SCHEDULER_SUPPORT is not set
 # STATUSLEDS is not set
 # STATUSLED_POWER_SUPPORT is not set
 # STATUSLED_BOOTED_SUPPORT is not set
@@ -222,6 +241,7 @@ CONF_RFM12_IP4_NETMASK="255.255.255.0"
 # USB_NET_SUPPORT is not set
 # DEBUG_USB_HID_KEYBOARD is not set
 # DEBUG_USB_HID_MOUSE is not set
+# ZBUS_SUPPORT is not set
 # ZBUS_RAW_SUPPORT is not set
 # ROUTER_SUPPORT is not set
 UIP_SUPPORT=y
@@ -256,7 +276,6 @@ CONF_OPENVPN_PORT=1194
 # DEBUG_OPENVPN is not set
 # DEBUG_ROUTER is not set
 # DEBUG_UIP is not set
-# DEBUG_NTP is not set
 # DEBUG_UNKNOWN_PACKETS is not set
 
 #
@@ -287,6 +306,7 @@ HC595_REGISTERS=5
 # HC165_INVERSE_OUTPUT is not set
 HC165_REGISTERS=1
 # SMS_SUPPORT is not set
+# SMS_USART_0 is not set
 # DEBUG_SMS is not set
 
 #
@@ -314,6 +334,8 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD Displays
 #
 # HD44780_SUPPORT is not set
+# HD44780_BACKLIGHT_SUPPORT is not set
+# HD44780_MULTIENSUPPORT is not set
 # HD44780_BACKLIGHT_INV is not set
 # HR20_LCD_SUPPORT_FULL is not set
 # S1D15G10_SUPPORT is not set
@@ -323,6 +345,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD_SUPPORT is not set
 # DEBUG_HD44780 is not set
 # DEBUG_LCD_MENU is not set
+# DEBUG_HD44780_I2C is not set
 
 #
 # Storage
@@ -350,12 +373,21 @@ CONF_LTC1257_NUM_DEVICES=4
 # I2C_PCF8574X_SUPPORT is not set
 # I2C_PCA9555_SUPPORT is not set
 # I2C_MAX7311_SUPPORT is not set
+# I2C_MCP23017_SUPPORT is not set
 # I2C_UDP_SUPPORT is not set
 # DEBUG_I2C is not set
 # I2C_SLAVE_SUPPORT is not set
 # DEBUG_I2C_SLAVE is not set
 # CAMERA_SUPPORT is not set
 # DC3840_SUPPORT is not set
+# CONFIG_DC3840_RES80 is not set
+# CONFIG_DC3840_RES160 is not set
+# CONFIG_DC3840_RES320 is not set
+# CONFIG_DC3840_RES640 is not set
+# DC3840_HIGH_COMPRESSION is not set
+# DC3840_BLACK_WHITE is not set
+# DC3840_USART_0 is not set
+# DC3840_UDP_DEBUG is not set
 
 #
 # Radio
@@ -438,26 +470,6 @@ REMOTE_IRMP_PORT=10001
 # DEBUG_IRMP is not set
 # DEBUG_REMOTE_IRMP is not set
 # PSB2186_SUPPORT is not set
-# PWM_SUPPORT is not set
-# PWM_GENERAL_SUPPORT is not set
-# PWM_GENERAL_INVERT_SUPPORT is not set
-# PWM_GENERAL_FADING_SUPPORT is not set
-# CH_A_PWM_GENERAL_SUPPORT is not set
-# CH_B_PWM_GENERAL_SUPPORT is not set
-# CH_C_PWM_GENERAL_SUPPORT is not set
-# PWM_WAV_SUPPORT is not set
-# VFS_PWM_WAV_SUPPORT is not set
-# PWM_MELODY_SUPPORT is not set
-# ENTCHEN_PWM_MELODY_SUPPORT is not set
-# TETRIS_PWM_MELODY_SUPPORT is not set
-# PWM_SERVO_SUPPORT is not set
-PWM_SERVOS=1
-# PWM_SERVO_INVERT is not set
-# PWM_SERVO_DEFAULT_ENABLED is not set
-# PWM_FREQ_SUPPORT is not set
-# PWM_DTMF_SUPPORT is not set
-# DEBUG_PWM is not set
-# DEBUG_PWM_SERVO is not set
 ONEWIRE_SUPPORT=y
 ONEWIRE_DETECT_SUPPORT=y
 # ONEWIRE_DS2502_SUPPORT is not set
@@ -489,9 +501,13 @@ ONEWIRE_DETECT_ECMD_SUPPORT=y
 # ULTRASONIC_SUPPORT is not set
 # DEBUG_ULTRASONIC is not set
 # HBRIDGE_SUPPORT is not set
+# DUAL_HBRIDGE_SUPPORT is not set
+# SHARE_ENABLE_HBRIDGE_SUPPORT is not set
+# HBRIDGE_INVERTER_SUPPORT is not set
 # DEBUG_HBRIDGE is not set
 # MCUF_SUPPORT is not set
 # MCUF_SERIAL_SUPPORT is not set
+# MCUF_USART_0 is not set
 # MCUF_OUTPUT_SUPPORT is not set
 # BLP_SUPPORT is not set
 # LEDRG_SUPPORT is not set
@@ -533,17 +549,22 @@ MCUF_MODUL_DISPLAY_MODE_RANDOM=y
 CONF_ARTNET_PORT=6454
 CONF_ARTNET_INUNIVERSE=1
 CONF_ARTNET_OUTUNIVERSE=0
+CONF_ARTNET_OUTPUT_IP="192.168.0.255"
+# CONF_ARTNET_SEND_POLL_REPLY is not set
 # DEBUG_ARTNET is not set
 # DALI_SUPPORT is not set
 # DALI_RAW_SUPPORT is not set
 # DALI_RECEIVE_SUPPORT is not set
 # DMX_SUPPORT is not set
+DMX_OUTPUT_UNIVERSE=1
+# DMX_USART_0 is not set
 ECMD_PARSER_SUPPORT=y
 # ECMD_REMOVE_BACKSPACE_SUPPORT is not set
 # ALIASCMD_SUPPORT is not set
 # ECMD_PAM_SUPPORT is not set
 # ECMD_SCRIPT_SUPPORT is not set
 # ECMD_LOG_VIA_SYSLOG is not set
+# ECMD_SERIAL_USART_SUPPORT is not set
 ECMD_TCP_SUPPORT=y
 ECMD_TCP_PORT=2701
 # ECMD_UDP_SUPPORT is not set
@@ -571,14 +592,23 @@ ECMD_TCP_PORT=2701
 # DEBUG_ECMD_RC5 is not set
 # DEBUG_ECMD_SCRIPT is not set
 # ELTAKOMS_SUPPORT is not set
+# ELTAKOMS_USART_0 is not set
+# DEBUG_ELTAKOMS is not set
 # EMS_SUPPORT is not set
 EMS_BUFFER_LEN=64
 EMS_PORT=7950
+# EMS_USART_0 is not set
 # EMS_DEBUG_STATS is not set
 # EMS_PROTO_DEBUG is not set
 # EMS_IO_DEBUG is not set
 # EMS_ERROR_DEBUG is not set
+# FNORDLICHT_BASIC_SUPPORT is not set
+FNORDLICHT_BAUDRATE=19200
+# FNORDLICHT_USART_0 is not set
 # FNORDLICHT_SUPPORT is not set
+CONF_FNORDLICHTER=1
+# FNORDLICHT_SERVO_SUPPORT is not set
+# DEBUG_FNORDLICHT is not set
 # HTTPLOG_SUPPORT is not set
 CONF_HTTPLOG_SERVICE="volkszaehler.org"
 CONF_HTTPLOG_PATH="/httplog/httplog.php"
@@ -598,6 +628,11 @@ CONF_IRC_REALNAME="Ethersex Wollmilchsau"
 # DEBUG_IRC is not set
 # MDNS_SD_SUPPORT is not set
 # MODBUS_SUPPORT is not set
+# MQTT_SUPPORT is not set
+MQTT_CALLBACK_SLOTS=1
+# MQTT_STATIC_CONF is not set
+# MQTT_DEBUG is not set
+# MQTT_PARSE_DEBUG is not set
 # MYSQL_SUPPORT is not set
 CONF_MYSQL_IP="192.168.23.254"
 CONF_MYSQL_USERNAME="root"
@@ -631,6 +666,8 @@ CONF_NETSTAT_API="/~habo/stat/"
 # PROTO_INTERTECHNO_SUPPORT is not set
 # PROTO_INTERTECHNO_SL_SUPPORT is not set
 # PROTO_OASEFMMASTER_SUPPORT is not set
+# PROTO_FA20RF_SUPPORT is not set
+# PROTO_SMOKEDETECTOR_SUPPORT is not set
 # SIP_SUPPORT is not set
 CONF_SIP_PROXY_IP="192.168.178.1"
 CONF_SIP_FROM="621"
@@ -674,11 +711,46 @@ CONF_USTREAM_IP="205.188.234.7"
 CONF_USTREAM_PORT=80
 # DEBUG_USTREAM is not set
 # YPORT_SUPPORT is not set
+# YPORT_USART_0 is not set
+YPORT_PORT=7970
+YPORT_BAUDRATE=115200
+YPORT_USART_CONFIG=YPORT_USART_CONFIG_8N1
+YPORT_USART_CONFIG_8N1=y
+# YPORT_USART_CONFIG_8E2 is not set
+YPORT_BUFFER_LEN=500
+YPORT_FLUSH=25
+# DEBUG_YPORT is not set
 # BSBPORT_SUPPORT is not set
+# BSBPORT_USART_0 is not set
+BSBPORT_PORT=3000
+BSBPORT_BAUDRATE=4800
+BSBPORT_BUFFER_LEN=32
+BSBPORT_FLUSH=25
+BSBPORT_MESSAGE_BUFFER_LEN=10
+BSBPORT_MESSAGE_MAX_LEN=25
+BSBPORT_OWNADDRESS=7
+# BSBPORT_POLLING_SUPPORT is not set
+# BSBPORT_MQTT_SUPPORT is not set
+# DEBUG_BSBPORT_RX is not set
+# DEBUG_BSBPORT_TX is not set
+# DEBUG_BSBPORT_ECMD is not set
+# DEBUG_BSBPORT_MQTT is not set
 # MSR1_SUPPORT is not set
+# MSR1_USART_0 is not set
+# DEBUG_MSR1 is not set
 # TO1_SUPPORT is not set
+# TO1_USART_0 is not set
+TO1_SENSOR_COUNT=1
+# DEBUG_TO1 is not set
 # SERIAL_LINE_LOG_SUPPORT is not set
+# SERIAL_LINE_LOG_USART_0 is not set
+SERIAL_LINE_LOG_TIMEOUT=20
+SERIAL_LINE_LOG_EOL=0A
+SERIAL_LINE_LOG_COUNT=60
+SERIAL_LINE_LOG_BAUDRATE=9600
+# SERIAL_LINE_LOG_SPACE_COMPRESSION is not set
 # NMEA_SUPPORT is not set
+# NMEA_USART_0 is not set
 # STELLA_PROTOCOL_SUPPORT is not set
 UDP_STELLA_PORT=2702
 # IOUDP_PROTOCOL_SUPPORT is not set
@@ -694,6 +766,12 @@ CW_WPM=12
 # CW_RFM12_ASK_SUPPORT is not set
 # DEBUG_CW is not set
 # SGC_SUPPORT is not set
+# SGC_USART_0 is not set
+SGC_BAUDRATE=9600
+# SGC_SHDN_SLEEP_ACTIVE is not set
+SGC_SLEEPMODE=0
+# SGC_TIMEOUT_COUNTER_SUPPORT is not set
+# SGC_ECMD_SEND_SUPPORT is not set
 
 #
 # Applications
@@ -707,15 +785,17 @@ CW_WPM=12
 # CLOCK_SUPPORT is not set
 # CLOCK_DATETIME_SUPPORT is not set
 # CLOCK_CRYSTAL_SUPPORT is not set
-# CLOCK_CPU_SUPPORT is not set
-# CLOCK_NTP_ADJUST_SUPPORT is not set
+# CLOCK_PERIODIC_SUPPORT is not set
 # DCF77_SUPPORT is not set
 # DEBUG_DCF77 is not set
 # NTP_SUPPORT is not set
+NTP_SERVER_IP="192.53.103.108"
+NTP_PORT=123
+NTP_QUERY_INTERVAL=1800
+# DEBUG_NTP is not set
 # NTPD_SUPPORT is not set
 # WHM_SUPPORT is not set
 # UPTIME_SUPPORT is not set
-# DEBUG_NTP_ADJUST is not set
 # CRON_SUPPORT is not set
 # CRON_DEFAULT_UTC is not set
 # CRON_SUPPORT_TEST is not set
@@ -739,6 +819,7 @@ DMX_FXSLOT_AMOUNT=4
 # DMX_FX_RANDOM is not set
 # DMX_FX_FIRE is not set
 # DMX_FX_WATER is not set
+# DMX_FX_RGB is not set
 # UDP_ECHO_NET_SUPPORT is not set
 # WOL_SUPPORT is not set
 # MOTD_SUPPORT is not set
@@ -782,6 +863,7 @@ STELLA_FADE_STEP_INIT=10
 STELLA_FADE_FUNCTION_INIT=stella_fade_func_0
 stella_fade_func_0=y
 # stella_fade_func_1 is not set
+# STELLA_USE_CIE1931 is not set
 # DEBUG_STELLA is not set
 # STARBURST_SUPPORT is not set
 # STARBURST_PCA9685 is not set
@@ -886,14 +968,9 @@ CONF_TIME2PRESS_RESET=40
 CONF_TIME2PRESS_POWER=40
 CONF_TIME2PRESS_POWERL=3
 # PROJECTOR_SANYO_Z700_SUPPORT is not set
+# SANYO_Z700_USART_0 is not set
+# DEBUG_SANYO_Z700 is not set
 # FREQCOUNT_SUPPORT is not set
-FREQCOUNT_CHANNELS=1
-# FREQCOUNT_BOOT_ON is not set
-FREQCOUNT_AVERAGE=8
-# FREQCOUNT_NOSLOW_SUPPORT is not set
-# FREQCOUNT_DUTY_SUPPORT is not set
-# FREQCOUNT_MOVING_AVERAGE_SUPPORT is not set
-# FREQCOUNT_DEBUGGING is not set
 # TANKLEVEL_SUPPORT is not set
 TANKLEVEL_ADC_CHANNEL=0
 # TANKLEVEL_STARTUP is not set
@@ -914,10 +991,12 @@ IPV4_SUPPORT=y
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -932,12 +1011,15 @@ avrispmkII=y
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -947,6 +1029,8 @@ avrispmkII=y
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -957,13 +1041,22 @@ avrispmkII=y
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -979,6 +1072,7 @@ avrispmkII=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set

--- a/scripts/profiles/netio_addon
+++ b/scripts/profiles/netio_addon
@@ -23,6 +23,7 @@ MCU=atmega644
 atmega644=y
 # atmega644p is not set
 # atmega1284p is not set
+# atmega2560 is not set
 # at90can32 is not set
 # at90can64 is not set
 # at90can128 is not set
@@ -32,6 +33,7 @@ FREQ=16000000
 # antares_IO is not set
 # antares_O is not set
 # Arduino_Duemilanove is not set
+# arduino_mega2560_r3 is not set
 # beteigeuze is not set
 # conrad_probot is not set
 # ehaserl is not set
@@ -74,7 +76,7 @@ EEPROM_PAGESIZE=0x8
 SPI_TIMEOUT=y
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="ac826dc"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 # DEBUG is not set
 # DEBUG_USE_SYSLOG is not set
@@ -82,6 +84,23 @@ GIT_VERSION="ac826dc"
 # SOFT_UART_SUPPORT is not set
 # DEBUG_HOOK is not set
 # DEBUG_RESET_REASON is not set
+
+#
+# Periodic / Scheduler
+#
+CONF_MTICKS_PER_SEC=50
+# PERIODIC_TIMER3_SUPPORT is not set
+CONF_PERIODIC_USE_TIMER=1
+# PERIODIC_TIMER_API_SUPPORT is not set
+# PERIODIC_ADJUST_SUPPORT is not set
+# DEBUG_PERIODIC is not set
+# DEBUG_PERIODIC_ECMD_SUPPORT is not set
+# DEBUG_PERIODIC_WAVEFORMS_SUPPORT is not set
+# DEBUG_PERIODIC_OC1A_SUPPORT is not set
+# SCHEDULER_SUPPORT is not set
+# SCHEDULER_DYNAMIC_SUPPORT is not set
+CONF_SCHEDULER_NUM_DYNAMIC_TIMERS=8
+# DEBUG_SCHEDULER_SUPPORT is not set
 STATUSLEDS=y
 # STATUSLED_POWER_SUPPORT is not set
 STATUSLED_BOOTED_SUPPORT=y
@@ -255,7 +274,6 @@ CONF_OPENVPN_PORT=1194
 # DEBUG_OPENVPN is not set
 # DEBUG_ROUTER is not set
 # DEBUG_UIP is not set
-# DEBUG_NTP is not set
 # DEBUG_UNKNOWN_PACKETS is not set
 
 #
@@ -328,8 +346,9 @@ CONF_HD44780_CONNECTION=HD44780_I2CSUPPORT
 HD44780_I2CSUPPORT=y
 # HD44780_SERLCD is not set
 # HD44780_2WIRE is not set
+# HD44780_BACKLIGHT_SUPPORT is not set
+# HD44780_MULTIENSUPPORT is not set
 # HD44780_READBACK is not set
-HD44780_PCF8574_ADR=32
 I2C_MASTER_SUPPORT=y
 I2C_PCF8574X_SUPPORT=y
 # HD44780_BACKLIGHT_INV is not set
@@ -341,6 +360,7 @@ I2C_PCF8574X_SUPPORT=y
 LCD_SUPPORT=y
 # DEBUG_HD44780 is not set
 # DEBUG_LCD_MENU is not set
+# DEBUG_HD44780_I2C is not set
 
 #
 # Storage
@@ -350,6 +370,7 @@ SD_READER_SUPPORT=y
 # SD_LFN_SUPPORT is not set
 # SD_READONLY is not set
 SD_WRITE_SUPPORT=y
+# SD_DATETIME_SUPPORT is not set
 SD_READ_TIMEOUT=y
 # SD_PING_READ is not set
 # SD_PING_READ_SUPPORT is not set
@@ -383,6 +404,7 @@ CONF_I2C_BAUD=100
 I2C_PCF8574X_SUPPORT=y
 # I2C_PCA9555_SUPPORT is not set
 # I2C_MAX7311_SUPPORT is not set
+# I2C_MCP23017_SUPPORT is not set
 # I2C_UDP_SUPPORT is not set
 # DEBUG_I2C is not set
 # I2C_SLAVE_SUPPORT is not set
@@ -474,26 +496,6 @@ IRSND_SUPPORT_NEC_PROTOCOL=y
 IRSND_SUPPORT_RC5_PROTOCOL=y
 IRSND_SUPPORT_GRUNDIG_PROTOCOL=y
 # PSB2186_SUPPORT is not set
-# PWM_SUPPORT is not set
-# PWM_GENERAL_SUPPORT is not set
-# PWM_GENERAL_INVERT_SUPPORT is not set
-# PWM_GENERAL_FADING_SUPPORT is not set
-# CH_A_PWM_GENERAL_SUPPORT is not set
-# CH_B_PWM_GENERAL_SUPPORT is not set
-# CH_C_PWM_GENERAL_SUPPORT is not set
-# PWM_WAV_SUPPORT is not set
-# VFS_PWM_WAV_SUPPORT is not set
-# PWM_MELODY_SUPPORT is not set
-# ENTCHEN_PWM_MELODY_SUPPORT is not set
-# TETRIS_PWM_MELODY_SUPPORT is not set
-# PWM_SERVO_SUPPORT is not set
-PWM_SERVOS=1
-# PWM_SERVO_INVERT is not set
-# PWM_SERVO_DEFAULT_ENABLED is not set
-# PWM_FREQ_SUPPORT is not set
-# PWM_DTMF_SUPPORT is not set
-# DEBUG_PWM is not set
-# DEBUG_PWM_SERVO is not set
 # ONEWIRE_SUPPORT is not set
 # ONEWIRE_DETECT_SUPPORT is not set
 # ONEWIRE_DS2502_SUPPORT is not set
@@ -525,6 +527,9 @@ PWM_SERVOS=1
 # ULTRASONIC_SUPPORT is not set
 # DEBUG_ULTRASONIC is not set
 # HBRIDGE_SUPPORT is not set
+# DUAL_HBRIDGE_SUPPORT is not set
+# SHARE_ENABLE_HBRIDGE_SUPPORT is not set
+# HBRIDGE_INVERTER_SUPPORT is not set
 # DEBUG_HBRIDGE is not set
 # MCUF_SUPPORT is not set
 # MCUF_SERIAL_SUPPORT is not set
@@ -569,6 +574,8 @@ MCUF_MODUL_DISPLAY_MODE_RANDOM=y
 CONF_ARTNET_PORT=6454
 CONF_ARTNET_INUNIVERSE=1
 CONF_ARTNET_OUTUNIVERSE=0
+CONF_ARTNET_OUTPUT_IP="192.168.0.255"
+# CONF_ARTNET_SEND_POLL_REPLY is not set
 # DEBUG_ARTNET is not set
 # DALI_SUPPORT is not set
 # DALI_RAW_SUPPORT is not set
@@ -614,12 +621,6 @@ ECMD_TCP_PORT=2701
 # DEBUG_ECMD_SCRIPT is not set
 # ELTAKOMS_SUPPORT is not set
 # EMS_SUPPORT is not set
-EMS_BUFFER_LEN=64
-EMS_PORT=7950
-# EMS_DEBUG_STATS is not set
-# EMS_PROTO_DEBUG is not set
-# EMS_IO_DEBUG is not set
-# EMS_ERROR_DEBUG is not set
 # FNORDLICHT_SUPPORT is not set
 # HTTPLOG_SUPPORT is not set
 CONF_HTTPLOG_SERVICE="volkszaehler.org"
@@ -640,6 +641,11 @@ CONF_IRC_REALNAME="Ethersex Wollmilchsau"
 # DEBUG_IRC is not set
 # MDNS_SD_SUPPORT is not set
 # MODBUS_SUPPORT is not set
+# MQTT_SUPPORT is not set
+MQTT_CALLBACK_SLOTS=1
+# MQTT_STATIC_CONF is not set
+# MQTT_DEBUG is not set
+# MQTT_PARSE_DEBUG is not set
 # MYSQL_SUPPORT is not set
 CONF_MYSQL_IP="192.168.23.254"
 CONF_MYSQL_USERNAME="root"
@@ -673,6 +679,8 @@ CONF_NETSTAT_API="/~habo/stat/"
 # PROTO_INTERTECHNO_SUPPORT is not set
 # PROTO_INTERTECHNO_SL_SUPPORT is not set
 # PROTO_OASEFMMASTER_SUPPORT is not set
+# PROTO_FA20RF_SUPPORT is not set
+# PROTO_SMOKEDETECTOR_SUPPORT is not set
 # SIP_SUPPORT is not set
 CONF_SIP_PROXY_IP="192.168.178.1"
 CONF_SIP_FROM="621"
@@ -763,15 +771,17 @@ DST_END_WEEK=5
 DST_END_DOW=0
 DST_END_HOUR=3
 # CLOCK_CRYSTAL_SUPPORT is not set
-# CLOCK_CPU_SUPPORT is not set
-# CLOCK_NTP_ADJUST_SUPPORT is not set
+# CLOCK_PERIODIC_SUPPORT is not set
 # DCF77_SUPPORT is not set
 # DEBUG_DCF77 is not set
 # NTP_SUPPORT is not set
+NTP_SERVER_IP="192.53.103.108"
+NTP_PORT=123
+NTP_QUERY_INTERVAL=1800
+# DEBUG_NTP is not set
 # NTPD_SUPPORT is not set
 # WHM_SUPPORT is not set
 # UPTIME_SUPPORT is not set
-# DEBUG_NTP_ADJUST is not set
 # CRON_SUPPORT is not set
 # CRON_DEFAULT_UTC is not set
 # CRON_SUPPORT_TEST is not set
@@ -795,6 +805,7 @@ DMX_FXSLOT_AMOUNT=4
 # DMX_FX_RANDOM is not set
 # DMX_FX_FIRE is not set
 # DMX_FX_WATER is not set
+# DMX_FX_RGB is not set
 # UDP_ECHO_NET_SUPPORT is not set
 # WOL_SUPPORT is not set
 # MOTD_SUPPORT is not set
@@ -838,6 +849,7 @@ STELLA_FADE_STEP_INIT=10
 STELLA_FADE_FUNCTION_INIT=stella_fade_func_0
 stella_fade_func_0=y
 # stella_fade_func_1 is not set
+# STELLA_USE_CIE1931 is not set
 # DEBUG_STELLA is not set
 # STARBURST_SUPPORT is not set
 # STARBURST_PCA9685 is not set
@@ -943,13 +955,6 @@ CONF_TIME2PRESS_POWER=40
 CONF_TIME2PRESS_POWERL=3
 # PROJECTOR_SANYO_Z700_SUPPORT is not set
 # FREQCOUNT_SUPPORT is not set
-FREQCOUNT_CHANNELS=1
-# FREQCOUNT_BOOT_ON is not set
-FREQCOUNT_AVERAGE=8
-# FREQCOUNT_NOSLOW_SUPPORT is not set
-# FREQCOUNT_DUTY_SUPPORT is not set
-# FREQCOUNT_MOVING_AVERAGE_SUPPORT is not set
-# FREQCOUNT_DEBUGGING is not set
 # TANKLEVEL_SUPPORT is not set
 TANKLEVEL_ADC_CHANNEL=0
 # TANKLEVEL_STARTUP is not set
@@ -970,10 +975,12 @@ IPV4_SUPPORT=y
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -988,12 +995,15 @@ avrispmkII=y
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -1003,6 +1013,8 @@ avrispmkII=y
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -1013,13 +1025,22 @@ avrispmkII=y
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -1035,6 +1056,7 @@ avrispmkII=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set

--- a/scripts/profiles/no-network
+++ b/scripts/profiles/no-network
@@ -23,6 +23,7 @@ atmega8=y
 # atmega644 is not set
 # atmega644p is not set
 # atmega1284p is not set
+# atmega2560 is not set
 # at90can32 is not set
 # at90can64 is not set
 # at90can128 is not set
@@ -32,6 +33,7 @@ FREQ=16000000
 # antares_IO is not set
 # antares_O is not set
 # Arduino_Duemilanove is not set
+# arduino_mega2560_r3 is not set
 # beteigeuze is not set
 # conrad_probot is not set
 # ehaserl is not set
@@ -74,7 +76,7 @@ TEENSY_SUPPORT=y
 # SPI_TIMEOUT is not set
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="ac826dc"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 # DEBUG is not set
 # DEBUG_USE_SYSLOG is not set
@@ -82,6 +84,23 @@ GIT_VERSION="ac826dc"
 # SOFT_UART_SUPPORT is not set
 # DEBUG_HOOK is not set
 # DEBUG_RESET_REASON is not set
+
+#
+# Periodic / Scheduler
+#
+CONF_MTICKS_PER_SEC=50
+# PERIODIC_TIMER3_SUPPORT is not set
+CONF_PERIODIC_USE_TIMER=1
+# PERIODIC_TIMER_API_SUPPORT is not set
+# PERIODIC_ADJUST_SUPPORT is not set
+# DEBUG_PERIODIC is not set
+# DEBUG_PERIODIC_ECMD_SUPPORT is not set
+# DEBUG_PERIODIC_WAVEFORMS_SUPPORT is not set
+# DEBUG_PERIODIC_OC1A_SUPPORT is not set
+# SCHEDULER_SUPPORT is not set
+# SCHEDULER_DYNAMIC_SUPPORT is not set
+CONF_SCHEDULER_NUM_DYNAMIC_TIMERS=8
+# DEBUG_SCHEDULER_SUPPORT is not set
 # STATUSLEDS is not set
 # STATUSLED_POWER_SUPPORT is not set
 # STATUSLED_BOOTED_SUPPORT is not set
@@ -228,6 +247,7 @@ USB_NET=y
 # USB_NET_SUPPORT is not set
 # DEBUG_USB_HID_KEYBOARD is not set
 # DEBUG_USB_HID_MOUSE is not set
+# ZBUS_SUPPORT is not set
 # ZBUS_RAW_SUPPORT is not set
 # ROUTER_SUPPORT is not set
 # UIP_SUPPORT is not set
@@ -262,7 +282,6 @@ CONF_OPENVPN_PORT=1194
 # DEBUG_OPENVPN is not set
 # DEBUG_ROUTER is not set
 # DEBUG_UIP is not set
-# DEBUG_NTP is not set
 # DEBUG_UNKNOWN_PACKETS is not set
 
 #
@@ -293,6 +312,7 @@ HC595_REGISTERS=5
 # HC165_INVERSE_OUTPUT is not set
 HC165_REGISTERS=1
 # SMS_SUPPORT is not set
+# SMS_USART_0 is not set
 # DEBUG_SMS is not set
 
 #
@@ -319,6 +339,8 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD Displays
 #
 # HD44780_SUPPORT is not set
+# HD44780_BACKLIGHT_SUPPORT is not set
+# HD44780_MULTIENSUPPORT is not set
 # HD44780_BACKLIGHT_INV is not set
 # HR20_LCD_SUPPORT is not set
 # S1D15G10_SUPPORT is not set
@@ -328,6 +350,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD_SUPPORT is not set
 # DEBUG_HD44780 is not set
 # DEBUG_LCD_MENU is not set
+# DEBUG_HD44780_I2C is not set
 
 #
 # Storage
@@ -355,12 +378,21 @@ CONF_LTC1257_NUM_DEVICES=4
 # I2C_PCF8574X_SUPPORT is not set
 # I2C_PCA9555_SUPPORT is not set
 # I2C_MAX7311_SUPPORT is not set
+# I2C_MCP23017_SUPPORT is not set
 # I2C_UDP_SUPPORT is not set
 # DEBUG_I2C is not set
 # I2C_SLAVE_SUPPORT is not set
 # DEBUG_I2C_SLAVE is not set
 # CAMERA_SUPPORT is not set
 # DC3840_SUPPORT is not set
+# CONFIG_DC3840_RES80 is not set
+# CONFIG_DC3840_RES160 is not set
+# CONFIG_DC3840_RES320 is not set
+# CONFIG_DC3840_RES640 is not set
+# DC3840_HIGH_COMPRESSION is not set
+# DC3840_BLACK_WHITE is not set
+# DC3840_USART_0 is not set
+# DC3840_UDP_DEBUG is not set
 
 #
 # Radio
@@ -443,26 +475,6 @@ REMOTE_IRMP_PORT=10001
 # DEBUG_IRMP is not set
 # DEBUG_REMOTE_IRMP is not set
 # PSB2186_SUPPORT is not set
-# PWM_SUPPORT is not set
-# PWM_GENERAL_SUPPORT is not set
-# PWM_GENERAL_INVERT_SUPPORT is not set
-# PWM_GENERAL_FADING_SUPPORT is not set
-# CH_A_PWM_GENERAL_SUPPORT is not set
-# CH_B_PWM_GENERAL_SUPPORT is not set
-# CH_C_PWM_GENERAL_SUPPORT is not set
-# PWM_WAV_SUPPORT is not set
-# VFS_PWM_WAV_SUPPORT is not set
-# PWM_MELODY_SUPPORT is not set
-# ENTCHEN_PWM_MELODY_SUPPORT is not set
-# TETRIS_PWM_MELODY_SUPPORT is not set
-# PWM_SERVO_SUPPORT is not set
-PWM_SERVOS=1
-# PWM_SERVO_INVERT is not set
-# PWM_SERVO_DEFAULT_ENABLED is not set
-# PWM_FREQ_SUPPORT is not set
-# PWM_DTMF_SUPPORT is not set
-# DEBUG_PWM is not set
-# DEBUG_PWM_SERVO is not set
 # ONEWIRE_SUPPORT is not set
 # ONEWIRE_DETECT_SUPPORT is not set
 # ONEWIRE_DS2502_SUPPORT is not set
@@ -494,9 +506,13 @@ PWM_SERVOS=1
 # ULTRASONIC_SUPPORT is not set
 # DEBUG_ULTRASONIC is not set
 # HBRIDGE_SUPPORT is not set
+# DUAL_HBRIDGE_SUPPORT is not set
+# SHARE_ENABLE_HBRIDGE_SUPPORT is not set
+# HBRIDGE_INVERTER_SUPPORT is not set
 # DEBUG_HBRIDGE is not set
 # MCUF_SUPPORT is not set
 # MCUF_SERIAL_SUPPORT is not set
+# MCUF_USART_0 is not set
 # MCUF_OUTPUT_SUPPORT is not set
 # BLP_SUPPORT is not set
 # LEDRG_SUPPORT is not set
@@ -538,17 +554,22 @@ MCUF_MODUL_DISPLAY_MODE_RANDOM=y
 CONF_ARTNET_PORT=6454
 CONF_ARTNET_INUNIVERSE=1
 CONF_ARTNET_OUTUNIVERSE=0
+CONF_ARTNET_OUTPUT_IP="192.168.0.255"
+# CONF_ARTNET_SEND_POLL_REPLY is not set
 # DEBUG_ARTNET is not set
 # DALI_SUPPORT is not set
 # DALI_RAW_SUPPORT is not set
 # DALI_RECEIVE_SUPPORT is not set
 # DMX_SUPPORT is not set
+DMX_OUTPUT_UNIVERSE=1
+# DMX_USART_0 is not set
 ECMD_PARSER_SUPPORT=y
 # ECMD_REMOVE_BACKSPACE_SUPPORT is not set
 # ALIASCMD_SUPPORT is not set
 # ECMD_PAM_SUPPORT is not set
 # ECMD_SCRIPT_SUPPORT is not set
 # ECMD_LOG_VIA_SYSLOG is not set
+# ECMD_SERIAL_USART_SUPPORT is not set
 # ECMD_TCP_SUPPORT is not set
 # ECMD_UDP_SUPPORT is not set
 # ECMD_SERIAL_I2C_SUPPORT is not set
@@ -577,14 +598,23 @@ ECMD_USB_SUPPORT=y
 # DEBUG_ECMD_RC5 is not set
 # DEBUG_ECMD_SCRIPT is not set
 # ELTAKOMS_SUPPORT is not set
+# ELTAKOMS_USART_0 is not set
+# DEBUG_ELTAKOMS is not set
 # EMS_SUPPORT is not set
 EMS_BUFFER_LEN=64
 EMS_PORT=7950
+# EMS_USART_0 is not set
 # EMS_DEBUG_STATS is not set
 # EMS_PROTO_DEBUG is not set
 # EMS_IO_DEBUG is not set
 # EMS_ERROR_DEBUG is not set
+# FNORDLICHT_BASIC_SUPPORT is not set
+FNORDLICHT_BAUDRATE=19200
+# FNORDLICHT_USART_0 is not set
 # FNORDLICHT_SUPPORT is not set
+CONF_FNORDLICHTER=1
+# FNORDLICHT_SERVO_SUPPORT is not set
+# DEBUG_FNORDLICHT is not set
 # HTTPLOG_SUPPORT is not set
 CONF_HTTPLOG_SERVICE="volkszaehler.org"
 CONF_HTTPLOG_PATH="/httplog/httplog.php"
@@ -604,6 +634,11 @@ CONF_IRC_REALNAME="Ethersex Wollmilchsau"
 # DEBUG_IRC is not set
 # MDNS_SD_SUPPORT is not set
 # MODBUS_SUPPORT is not set
+# MQTT_SUPPORT is not set
+MQTT_CALLBACK_SLOTS=1
+# MQTT_STATIC_CONF is not set
+# MQTT_DEBUG is not set
+# MQTT_PARSE_DEBUG is not set
 # MYSQL_SUPPORT is not set
 CONF_MYSQL_IP="192.168.23.254"
 CONF_MYSQL_USERNAME="root"
@@ -637,6 +672,8 @@ CONF_NETSTAT_API="/~habo/stat/"
 # PROTO_INTERTECHNO_SUPPORT is not set
 # PROTO_INTERTECHNO_SL_SUPPORT is not set
 # PROTO_OASEFMMASTER_SUPPORT is not set
+# PROTO_FA20RF_SUPPORT is not set
+# PROTO_SMOKEDETECTOR_SUPPORT is not set
 # SIP_SUPPORT is not set
 CONF_SIP_PROXY_IP="192.168.178.1"
 CONF_SIP_FROM="621"
@@ -680,11 +717,46 @@ CONF_USTREAM_IP="205.188.234.7"
 CONF_USTREAM_PORT=80
 # DEBUG_USTREAM is not set
 # YPORT_SUPPORT is not set
+# YPORT_USART_0 is not set
+YPORT_PORT=7970
+YPORT_BAUDRATE=115200
+YPORT_USART_CONFIG=YPORT_USART_CONFIG_8N1
+YPORT_USART_CONFIG_8N1=y
+# YPORT_USART_CONFIG_8E2 is not set
+YPORT_BUFFER_LEN=192
+YPORT_FLUSH=25
+# DEBUG_YPORT is not set
 # BSBPORT_SUPPORT is not set
+# BSBPORT_USART_0 is not set
+BSBPORT_PORT=3000
+BSBPORT_BAUDRATE=4800
+BSBPORT_BUFFER_LEN=32
+BSBPORT_FLUSH=25
+BSBPORT_MESSAGE_BUFFER_LEN=10
+BSBPORT_MESSAGE_MAX_LEN=25
+BSBPORT_OWNADDRESS=7
+# BSBPORT_POLLING_SUPPORT is not set
+# BSBPORT_MQTT_SUPPORT is not set
+# DEBUG_BSBPORT_RX is not set
+# DEBUG_BSBPORT_TX is not set
+# DEBUG_BSBPORT_ECMD is not set
+# DEBUG_BSBPORT_MQTT is not set
 # MSR1_SUPPORT is not set
+# MSR1_USART_0 is not set
+# DEBUG_MSR1 is not set
 # TO1_SUPPORT is not set
+# TO1_USART_0 is not set
+TO1_SENSOR_COUNT=1
+# DEBUG_TO1 is not set
 # SERIAL_LINE_LOG_SUPPORT is not set
+# SERIAL_LINE_LOG_USART_0 is not set
+SERIAL_LINE_LOG_TIMEOUT=20
+SERIAL_LINE_LOG_EOL=0A
+SERIAL_LINE_LOG_COUNT=60
+SERIAL_LINE_LOG_BAUDRATE=9600
+# SERIAL_LINE_LOG_SPACE_COMPRESSION is not set
 # NMEA_SUPPORT is not set
+# NMEA_USART_0 is not set
 # STELLA_PROTOCOL_SUPPORT is not set
 UDP_STELLA_PORT=2702
 # IOUDP_PROTOCOL_SUPPORT is not set
@@ -700,6 +772,12 @@ CW_WPM=12
 # CW_RFM12_ASK_SUPPORT is not set
 # DEBUG_CW is not set
 # SGC_SUPPORT is not set
+# SGC_USART_0 is not set
+SGC_BAUDRATE=9600
+# SGC_SHDN_SLEEP_ACTIVE is not set
+SGC_SLEEPMODE=0
+# SGC_TIMEOUT_COUNTER_SUPPORT is not set
+# SGC_ECMD_SEND_SUPPORT is not set
 
 #
 # Applications
@@ -714,15 +792,17 @@ CW_WPM=12
 # CLOCK_DATE_SUPPORT is not set
 # CLOCK_TIME_SUPPORT is not set
 # CLOCK_CRYSTAL_SUPPORT is not set
-# CLOCK_CPU_SUPPORT is not set
-# CLOCK_NTP_ADJUST_SUPPORT is not set
+# CLOCK_PERIODIC_SUPPORT is not set
 # DCF77_SUPPORT is not set
 # DEBUG_DCF77 is not set
 # NTP_SUPPORT is not set
+NTP_SERVER_IP="192.53.103.108"
+NTP_PORT=123
+NTP_QUERY_INTERVAL=1800
+# DEBUG_NTP is not set
 # NTPD_SUPPORT is not set
 # WHM_SUPPORT is not set
 # UPTIME_SUPPORT is not set
-# DEBUG_NTP_ADJUST is not set
 # CRON_SUPPORT is not set
 # CRON_DEFAULT_UTC is not set
 # CRON_EEPROM_SUPPORT is not set
@@ -744,6 +824,7 @@ DMX_FXSLOT_AMOUNT=4
 # DMX_FX_RANDOM is not set
 # DMX_FX_FIRE is not set
 # DMX_FX_WATER is not set
+# DMX_FX_RGB is not set
 # UDP_ECHO_NET_SUPPORT is not set
 # WOL_SUPPORT is not set
 # MOTD_SUPPORT is not set
@@ -787,6 +868,7 @@ STELLA_FADE_STEP_INIT=10
 STELLA_FADE_FUNCTION_INIT=stella_fade_func_0
 stella_fade_func_0=y
 # stella_fade_func_1 is not set
+# STELLA_USE_CIE1931 is not set
 # DEBUG_STELLA is not set
 # STARBURST_SUPPORT is not set
 # STARBURST_PCA9685 is not set
@@ -891,14 +973,9 @@ CONF_TIME2PRESS_RESET=40
 CONF_TIME2PRESS_POWER=40
 CONF_TIME2PRESS_POWERL=3
 # PROJECTOR_SANYO_Z700_SUPPORT is not set
+# SANYO_Z700_USART_0 is not set
+# DEBUG_SANYO_Z700 is not set
 # FREQCOUNT_SUPPORT is not set
-FREQCOUNT_CHANNELS=1
-# FREQCOUNT_BOOT_ON is not set
-FREQCOUNT_AVERAGE=8
-# FREQCOUNT_NOSLOW_SUPPORT is not set
-# FREQCOUNT_DUTY_SUPPORT is not set
-# FREQCOUNT_MOVING_AVERAGE_SUPPORT is not set
-# FREQCOUNT_DEBUGGING is not set
 # TANKLEVEL_SUPPORT is not set
 TANKLEVEL_ADC_CHANNEL=0
 # TANKLEVEL_STARTUP is not set
@@ -918,10 +995,12 @@ TANKLEVEL_HOLD_TIME=20
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -936,12 +1015,15 @@ avrispmkII=y
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -951,6 +1033,8 @@ avrispmkII=y
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -961,13 +1045,22 @@ avrispmkII=y
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -983,6 +1076,7 @@ avrispmkII=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set

--- a/scripts/profiles/probot
+++ b/scripts/profiles/probot
@@ -23,6 +23,7 @@ atmega128=y
 # atmega644 is not set
 # atmega644p is not set
 # atmega1284p is not set
+# atmega2560 is not set
 # at90can32 is not set
 # at90can64 is not set
 # at90can128 is not set
@@ -32,6 +33,7 @@ FREQ=14745000
 # antares_IO is not set
 # antares_O is not set
 # Arduino_Duemilanove is not set
+# arduino_mega2560_r3 is not set
 # beteigeuze is not set
 HARDWARE=conrad_probot
 conrad_probot=y
@@ -65,7 +67,7 @@ BOOTLOADER_SIZE=0
 BOOTLOADER_START_ADDRESS=0x20000
 FLASH_SIZE=0x20000
 EEPROM_SIZE=0x1000
-RAM_SIZE=0x1000
+RAM_SIZE=0x1100
 FLASH_PAGESIZE=0x100
 EEPROM_PAGESIZE=0x8
 # CRC_PAD_SUPPORT is not set
@@ -74,7 +76,7 @@ EEPROM_PAGESIZE=0x8
 # SPI_TIMEOUT is not set
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="ac826dc"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 # DEBUG is not set
 # DEBUG_USE_SYSLOG is not set
@@ -82,6 +84,23 @@ GIT_VERSION="ac826dc"
 # SOFT_UART_SUPPORT is not set
 # DEBUG_HOOK is not set
 # DEBUG_RESET_REASON is not set
+
+#
+# Periodic / Scheduler
+#
+CONF_MTICKS_PER_SEC=50
+# PERIODIC_TIMER3_SUPPORT is not set
+CONF_PERIODIC_USE_TIMER=1
+# PERIODIC_TIMER_API_SUPPORT is not set
+# PERIODIC_ADJUST_SUPPORT is not set
+# DEBUG_PERIODIC is not set
+# DEBUG_PERIODIC_ECMD_SUPPORT is not set
+# DEBUG_PERIODIC_WAVEFORMS_SUPPORT is not set
+# DEBUG_PERIODIC_OC1A_SUPPORT is not set
+# SCHEDULER_SUPPORT is not set
+# SCHEDULER_DYNAMIC_SUPPORT is not set
+CONF_SCHEDULER_NUM_DYNAMIC_TIMERS=8
+# DEBUG_SCHEDULER_SUPPORT is not set
 # STATUSLEDS is not set
 # STATUSLED_POWER_SUPPORT is not set
 # STATUSLED_BOOTED_SUPPORT is not set
@@ -257,7 +276,6 @@ CONF_OPENVPN_PORT=1194
 # DEBUG_OPENVPN is not set
 # DEBUG_ROUTER is not set
 # DEBUG_UIP is not set
-# DEBUG_NTP is not set
 # DEBUG_UNKNOWN_PACKETS is not set
 
 #
@@ -270,10 +288,11 @@ PORTIO_FULL_FEATURED=y
 # PORTIO_SIMPLE_SUPPORT is not set
 PORTIO_SUPPORT=y
 NAMED_PIN_SUPPORT=y
+# Jackalope is not set
+# arduino_mega2560 is not set
 _NP_CONFIG=conrad_probot
 conrad_probot=y
 # default is not set
-# Jackalope is not set
 # netio_k8io is not set
 # radig_web is not set
 NP_CONFIG=pinning/named_pin/conrad_probot
@@ -325,6 +344,8 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD Displays
 #
 # HD44780_SUPPORT is not set
+# HD44780_BACKLIGHT_SUPPORT is not set
+# HD44780_MULTIENSUPPORT is not set
 # HD44780_BACKLIGHT_INV is not set
 # HR20_LCD_SUPPORT_FULL is not set
 # S1D15G10_SUPPORT is not set
@@ -334,6 +355,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD_SUPPORT is not set
 # DEBUG_HD44780 is not set
 # DEBUG_LCD_MENU is not set
+# DEBUG_HD44780_I2C is not set
 
 #
 # Storage
@@ -363,6 +385,7 @@ CONF_I2C_24CXX_PAGESIZE=128
 # I2C_PCF8574X_SUPPORT is not set
 # I2C_PCA9555_SUPPORT is not set
 # I2C_MAX7311_SUPPORT is not set
+# I2C_MCP23017_SUPPORT is not set
 # I2C_UDP_SUPPORT is not set
 # DEBUG_I2C is not set
 # I2C_SLAVE_SUPPORT is not set
@@ -461,26 +484,6 @@ REMOTE_IRMP_PORT=10001
 # DEBUG_IRMP is not set
 # DEBUG_REMOTE_IRMP is not set
 # PSB2186_SUPPORT is not set
-# PWM_SUPPORT is not set
-# PWM_GENERAL_SUPPORT is not set
-# PWM_GENERAL_INVERT_SUPPORT is not set
-# PWM_GENERAL_FADING_SUPPORT is not set
-# CH_A_PWM_GENERAL_SUPPORT is not set
-# CH_B_PWM_GENERAL_SUPPORT is not set
-# CH_C_PWM_GENERAL_SUPPORT is not set
-# PWM_WAV_SUPPORT is not set
-# VFS_PWM_WAV_SUPPORT is not set
-# PWM_MELODY_SUPPORT is not set
-# ENTCHEN_PWM_MELODY_SUPPORT is not set
-# TETRIS_PWM_MELODY_SUPPORT is not set
-# PWM_SERVO_SUPPORT is not set
-PWM_SERVOS=1
-PWM_SERVO_INVERT=y
-# PWM_SERVO_DEFAULT_ENABLED is not set
-# PWM_FREQ_SUPPORT is not set
-# PWM_DTMF_SUPPORT is not set
-# DEBUG_PWM is not set
-# DEBUG_PWM_SERVO is not set
 # ONEWIRE_SUPPORT is not set
 # ONEWIRE_DETECT_SUPPORT is not set
 # ONEWIRE_DS2502_SUPPORT is not set
@@ -512,6 +515,9 @@ PWM_SERVO_INVERT=y
 # ULTRASONIC_SUPPORT is not set
 # DEBUG_ULTRASONIC is not set
 # HBRIDGE_SUPPORT is not set
+# DUAL_HBRIDGE_SUPPORT is not set
+# SHARE_ENABLE_HBRIDGE_SUPPORT is not set
+# HBRIDGE_INVERTER_SUPPORT is not set
 # DEBUG_HBRIDGE is not set
 # MCUF_SUPPORT is not set
 # MCUF_SERIAL_SUPPORT is not set
@@ -559,6 +565,8 @@ NET_MAX_FRAME_LENGTH_GT_571=y
 CONF_ARTNET_PORT=6454
 CONF_ARTNET_INUNIVERSE=1
 CONF_ARTNET_OUTUNIVERSE=0
+CONF_ARTNET_OUTPUT_IP="192.168.0.255"
+# CONF_ARTNET_SEND_POLL_REPLY is not set
 # DEBUG_ARTNET is not set
 # DALI_SUPPORT is not set
 # DALI_RAW_SUPPORT is not set
@@ -607,6 +615,8 @@ DMX_USE_USART=0
 # EMS_SUPPORT is not set
 EMS_BUFFER_LEN=64
 EMS_PORT=7950
+# EMS_USART_0 is not set
+# EMS_USART_1 is not set
 # EMS_DEBUG_STATS is not set
 # EMS_PROTO_DEBUG is not set
 # EMS_IO_DEBUG is not set
@@ -638,6 +648,11 @@ CONF_IRC_REALNAME="Ethersex Wollmilchsau"
 # DEBUG_IRC is not set
 # MDNS_SD_SUPPORT is not set
 # MODBUS_SUPPORT is not set
+# MQTT_SUPPORT is not set
+MQTT_CALLBACK_SLOTS=1
+# MQTT_STATIC_CONF is not set
+# MQTT_DEBUG is not set
+# MQTT_PARSE_DEBUG is not set
 # MYSQL_SUPPORT is not set
 CONF_MYSQL_IP="192.168.23.254"
 CONF_MYSQL_USERNAME="root"
@@ -671,6 +686,8 @@ CONF_NETSTAT_API="/~habo/stat/"
 # PROTO_INTERTECHNO_SUPPORT is not set
 # PROTO_INTERTECHNO_SL_SUPPORT is not set
 # PROTO_OASEFMMASTER_SUPPORT is not set
+# PROTO_FA20RF_SUPPORT is not set
+# PROTO_SMOKEDETECTOR_SUPPORT is not set
 # SIP_SUPPORT is not set
 CONF_SIP_PROXY_IP="192.168.178.1"
 CONF_SIP_FROM="621"
@@ -736,10 +753,11 @@ BSBPORT_MESSAGE_BUFFER_LEN=10
 BSBPORT_MESSAGE_MAX_LEN=25
 BSBPORT_OWNADDRESS=7
 # BSBPORT_POLLING_SUPPORT is not set
+# BSBPORT_MQTT_SUPPORT is not set
 # DEBUG_BSBPORT_RX is not set
 # DEBUG_BSBPORT_TX is not set
-# DEBUG_BSBPORT_PARSE is not set
 # DEBUG_BSBPORT_ECMD is not set
+# DEBUG_BSBPORT_MQTT is not set
 # MSR1_SUPPORT is not set
 MSR1_USART_0=y
 # MSR1_USART_1 is not set
@@ -812,15 +830,17 @@ DST_END_WEEK=5
 DST_END_DOW=0
 DST_END_HOUR=3
 # CLOCK_CRYSTAL_SUPPORT is not set
-# CLOCK_CPU_SUPPORT is not set
-# CLOCK_NTP_ADJUST_SUPPORT is not set
+# CLOCK_PERIODIC_SUPPORT is not set
 # DCF77_SUPPORT is not set
 # DEBUG_DCF77 is not set
 # NTP_SUPPORT is not set
+NTP_SERVER_IP="192.53.103.108"
+NTP_PORT=123
+NTP_QUERY_INTERVAL=1800
+# DEBUG_NTP is not set
 # NTPD_SUPPORT is not set
 WHM_SUPPORT=y
 # UPTIME_SUPPORT is not set
-# DEBUG_NTP_ADJUST is not set
 # CRON_SUPPORT is not set
 # CRON_DEFAULT_UTC is not set
 # CRON_SUPPORT_TEST is not set
@@ -844,6 +864,7 @@ DMX_FXSLOT_AMOUNT=4
 # DMX_FX_RANDOM is not set
 # DMX_FX_FIRE is not set
 # DMX_FX_WATER is not set
+# DMX_FX_RGB is not set
 # UDP_ECHO_NET_SUPPORT is not set
 # WOL_SUPPORT is not set
 # MOTD_SUPPORT is not set
@@ -887,6 +908,7 @@ STELLA_FADE_STEP_INIT=10
 STELLA_FADE_FUNCTION_INIT=stella_fade_func_0
 stella_fade_func_0=y
 # stella_fade_func_1 is not set
+# STELLA_USE_CIE1931 is not set
 # DEBUG_STELLA is not set
 # STARBURST_SUPPORT is not set
 # STARBURST_PCA9685 is not set
@@ -995,13 +1017,6 @@ CONF_TIME2PRESS_POWERL=3
 # SANYO_Z700_USART_1 is not set
 # DEBUG_SANYO_Z700 is not set
 # FREQCOUNT_SUPPORT is not set
-FREQCOUNT_CHANNELS=1
-# FREQCOUNT_BOOT_ON is not set
-FREQCOUNT_AVERAGE=8
-# FREQCOUNT_NOSLOW_SUPPORT is not set
-# FREQCOUNT_DUTY_SUPPORT is not set
-# FREQCOUNT_MOVING_AVERAGE_SUPPORT is not set
-# FREQCOUNT_DEBUGGING is not set
 # TANKLEVEL_SUPPORT is not set
 TANKLEVEL_ADC_CHANNEL=0
 # TANKLEVEL_STARTUP is not set
@@ -1021,10 +1036,12 @@ TANKLEVEL_HOLD_TIME=20
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -1039,12 +1056,15 @@ avrispmkII=y
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -1054,6 +1074,8 @@ avrispmkII=y
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -1064,13 +1086,22 @@ avrispmkII=y
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -1086,6 +1117,7 @@ avrispmkII=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set

--- a/scripts/profiles/radig
+++ b/scripts/profiles/radig
@@ -23,6 +23,7 @@ MCU=atmega644
 atmega644=y
 # atmega644p is not set
 # atmega1284p is not set
+# atmega2560 is not set
 # at90can32 is not set
 # at90can64 is not set
 # at90can128 is not set
@@ -32,6 +33,7 @@ FREQ=14745600
 # antares_IO is not set
 # antares_O is not set
 # Arduino_Duemilanove is not set
+# arduino_mega2560_r3 is not set
 # beteigeuze is not set
 # conrad_probot is not set
 # ehaserl is not set
@@ -74,7 +76,7 @@ EEPROM_PAGESIZE=0x8
 # SPI_TIMEOUT is not set
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="ac826dc"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 DEBUG=y
 DEBUG_OUTPUT=usart
@@ -88,6 +90,23 @@ DEBUG_USE_USART=0
 DEBUG_BAUDRATE=115200
 # DEBUG_HOOK is not set
 # DEBUG_RESET_REASON is not set
+
+#
+# Periodic / Scheduler
+#
+CONF_MTICKS_PER_SEC=50
+# PERIODIC_TIMER3_SUPPORT is not set
+CONF_PERIODIC_USE_TIMER=1
+# PERIODIC_TIMER_API_SUPPORT is not set
+# PERIODIC_ADJUST_SUPPORT is not set
+# DEBUG_PERIODIC is not set
+# DEBUG_PERIODIC_ECMD_SUPPORT is not set
+# DEBUG_PERIODIC_WAVEFORMS_SUPPORT is not set
+# DEBUG_PERIODIC_OC1A_SUPPORT is not set
+# SCHEDULER_SUPPORT is not set
+# SCHEDULER_DYNAMIC_SUPPORT is not set
+CONF_SCHEDULER_NUM_DYNAMIC_TIMERS=8
+# DEBUG_SCHEDULER_SUPPORT is not set
 # STATUSLEDS is not set
 # STATUSLED_POWER_SUPPORT is not set
 # STATUSLED_BOOTED_SUPPORT is not set
@@ -261,7 +280,6 @@ CONF_OPENVPN_PORT=1194
 # DEBUG_OPENVPN is not set
 # DEBUG_ROUTER is not set
 # DEBUG_UIP is not set
-# DEBUG_NTP is not set
 # DEBUG_UNKNOWN_PACKETS is not set
 
 #
@@ -321,6 +339,8 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD Displays
 #
 # HD44780_SUPPORT is not set
+# HD44780_BACKLIGHT_SUPPORT is not set
+# HD44780_MULTIENSUPPORT is not set
 # HD44780_BACKLIGHT_INV is not set
 # HR20_LCD_SUPPORT_FULL is not set
 # S1D15G10_SUPPORT is not set
@@ -330,6 +350,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD_SUPPORT is not set
 # DEBUG_HD44780 is not set
 # DEBUG_LCD_MENU is not set
+# DEBUG_HD44780_I2C is not set
 
 #
 # Storage
@@ -357,6 +378,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # I2C_PCF8574X_SUPPORT is not set
 # I2C_PCA9555_SUPPORT is not set
 # I2C_MAX7311_SUPPORT is not set
+# I2C_MCP23017_SUPPORT is not set
 # I2C_UDP_SUPPORT is not set
 # DEBUG_I2C is not set
 # I2C_SLAVE_SUPPORT is not set
@@ -445,26 +467,6 @@ REMOTE_IRMP_PORT=10001
 # DEBUG_IRMP is not set
 # DEBUG_REMOTE_IRMP is not set
 # PSB2186_SUPPORT is not set
-# PWM_SUPPORT is not set
-# PWM_GENERAL_SUPPORT is not set
-# PWM_GENERAL_INVERT_SUPPORT is not set
-# PWM_GENERAL_FADING_SUPPORT is not set
-# CH_A_PWM_GENERAL_SUPPORT is not set
-# CH_B_PWM_GENERAL_SUPPORT is not set
-# CH_C_PWM_GENERAL_SUPPORT is not set
-# PWM_WAV_SUPPORT is not set
-# VFS_PWM_WAV_SUPPORT is not set
-# PWM_MELODY_SUPPORT is not set
-# ENTCHEN_PWM_MELODY_SUPPORT is not set
-# TETRIS_PWM_MELODY_SUPPORT is not set
-# PWM_SERVO_SUPPORT is not set
-PWM_SERVOS=1
-# PWM_SERVO_INVERT is not set
-# PWM_SERVO_DEFAULT_ENABLED is not set
-# PWM_FREQ_SUPPORT is not set
-# PWM_DTMF_SUPPORT is not set
-# DEBUG_PWM is not set
-# DEBUG_PWM_SERVO is not set
 # ONEWIRE_SUPPORT is not set
 # ONEWIRE_DETECT_SUPPORT is not set
 # ONEWIRE_DS2502_SUPPORT is not set
@@ -496,6 +498,9 @@ PWM_SERVOS=1
 # ULTRASONIC_SUPPORT is not set
 # DEBUG_ULTRASONIC is not set
 # HBRIDGE_SUPPORT is not set
+# DUAL_HBRIDGE_SUPPORT is not set
+# SHARE_ENABLE_HBRIDGE_SUPPORT is not set
+# HBRIDGE_INVERTER_SUPPORT is not set
 # DEBUG_HBRIDGE is not set
 # MCUF_SUPPORT is not set
 # MCUF_SERIAL_SUPPORT is not set
@@ -540,6 +545,8 @@ NET_MAX_FRAME_LENGTH_GT_571=y
 CONF_ARTNET_PORT=6454
 CONF_ARTNET_INUNIVERSE=1
 CONF_ARTNET_OUTUNIVERSE=0
+CONF_ARTNET_OUTPUT_IP="192.168.0.255"
+# CONF_ARTNET_SEND_POLL_REPLY is not set
 # DEBUG_ARTNET is not set
 # DALI_SUPPORT is not set
 # DALI_RAW_SUPPORT is not set
@@ -551,6 +558,7 @@ ECMD_PARSER_SUPPORT=y
 # ECMD_PAM_SUPPORT is not set
 # ECMD_SCRIPT_SUPPORT is not set
 # ECMD_LOG_VIA_SYSLOG is not set
+# ECMD_SERIAL_USART_SUPPORT is not set
 ECMD_TCP_SUPPORT=y
 ECMD_TCP_PORT=2701
 # ECMD_UDP_SUPPORT is not set
@@ -579,12 +587,6 @@ ECMD_TCP_PORT=2701
 # DEBUG_ECMD_SCRIPT is not set
 # ELTAKOMS_SUPPORT is not set
 # EMS_SUPPORT is not set
-EMS_BUFFER_LEN=64
-EMS_PORT=7950
-# EMS_DEBUG_STATS is not set
-# EMS_PROTO_DEBUG is not set
-# EMS_IO_DEBUG is not set
-# EMS_ERROR_DEBUG is not set
 # FNORDLICHT_SUPPORT is not set
 # HTTPLOG_SUPPORT is not set
 CONF_HTTPLOG_SERVICE="volkszaehler.org"
@@ -605,6 +607,11 @@ CONF_IRC_REALNAME="Ethersex Wollmilchsau"
 # DEBUG_IRC is not set
 # MDNS_SD_SUPPORT is not set
 # MODBUS_SUPPORT is not set
+# MQTT_SUPPORT is not set
+MQTT_CALLBACK_SLOTS=1
+# MQTT_STATIC_CONF is not set
+# MQTT_DEBUG is not set
+# MQTT_PARSE_DEBUG is not set
 # MYSQL_SUPPORT is not set
 CONF_MYSQL_IP="192.168.23.254"
 CONF_MYSQL_USERNAME="root"
@@ -638,6 +645,8 @@ CONF_NETSTAT_API="/~habo/stat/"
 # PROTO_INTERTECHNO_SUPPORT is not set
 # PROTO_INTERTECHNO_SL_SUPPORT is not set
 # PROTO_OASEFMMASTER_SUPPORT is not set
+# PROTO_FA20RF_SUPPORT is not set
+# PROTO_SMOKEDETECTOR_SUPPORT is not set
 # SIP_SUPPORT is not set
 CONF_SIP_PROXY_IP="192.168.178.1"
 CONF_SIP_FROM="621"
@@ -714,15 +723,17 @@ CW_WPM=12
 # CLOCK_SUPPORT is not set
 # CLOCK_DATETIME_SUPPORT is not set
 # CLOCK_CRYSTAL_SUPPORT is not set
-# CLOCK_CPU_SUPPORT is not set
-# CLOCK_NTP_ADJUST_SUPPORT is not set
+# CLOCK_PERIODIC_SUPPORT is not set
 # DCF77_SUPPORT is not set
 # DEBUG_DCF77 is not set
 # NTP_SUPPORT is not set
+NTP_SERVER_IP="192.53.103.108"
+NTP_PORT=123
+NTP_QUERY_INTERVAL=1800
+# DEBUG_NTP is not set
 # NTPD_SUPPORT is not set
 # WHM_SUPPORT is not set
 # UPTIME_SUPPORT is not set
-# DEBUG_NTP_ADJUST is not set
 # CRON_SUPPORT is not set
 # CRON_DEFAULT_UTC is not set
 # CRON_SUPPORT_TEST is not set
@@ -746,6 +757,7 @@ DMX_FXSLOT_AMOUNT=4
 # DMX_FX_RANDOM is not set
 # DMX_FX_FIRE is not set
 # DMX_FX_WATER is not set
+# DMX_FX_RGB is not set
 # UDP_ECHO_NET_SUPPORT is not set
 # WOL_SUPPORT is not set
 # MOTD_SUPPORT is not set
@@ -789,6 +801,7 @@ STELLA_FADE_STEP_INIT=10
 STELLA_FADE_FUNCTION_INIT=stella_fade_func_0
 stella_fade_func_0=y
 # stella_fade_func_1 is not set
+# STELLA_USE_CIE1931 is not set
 # DEBUG_STELLA is not set
 # STARBURST_SUPPORT is not set
 # STARBURST_PCA9685 is not set
@@ -894,13 +907,6 @@ CONF_TIME2PRESS_POWER=40
 CONF_TIME2PRESS_POWERL=3
 # PROJECTOR_SANYO_Z700_SUPPORT is not set
 # FREQCOUNT_SUPPORT is not set
-FREQCOUNT_CHANNELS=1
-# FREQCOUNT_BOOT_ON is not set
-FREQCOUNT_AVERAGE=8
-# FREQCOUNT_NOSLOW_SUPPORT is not set
-# FREQCOUNT_DUTY_SUPPORT is not set
-# FREQCOUNT_MOVING_AVERAGE_SUPPORT is not set
-# FREQCOUNT_DEBUGGING is not set
 # TANKLEVEL_SUPPORT is not set
 TANKLEVEL_ADC_CHANNEL=0
 # TANKLEVEL_STARTUP is not set
@@ -921,10 +927,12 @@ IPV4_SUPPORT=y
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -939,12 +947,15 @@ avrispmkII=y
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -954,6 +965,8 @@ avrispmkII=y
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -964,13 +977,22 @@ avrispmkII=y
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -986,6 +1008,7 @@ avrispmkII=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set

--- a/scripts/profiles/rfm12-teensy
+++ b/scripts/profiles/rfm12-teensy
@@ -23,6 +23,7 @@ atmega8=y
 # atmega644 is not set
 # atmega644p is not set
 # atmega1284p is not set
+# atmega2560 is not set
 # at90can32 is not set
 # at90can64 is not set
 # at90can128 is not set
@@ -32,6 +33,7 @@ FREQ=8000000
 # antares_IO is not set
 # antares_O is not set
 # Arduino_Duemilanove is not set
+# arduino_mega2560_r3 is not set
 # beteigeuze is not set
 # conrad_probot is not set
 # ehaserl is not set
@@ -74,7 +76,7 @@ TEENSY_SUPPORT=y
 # SPI_TIMEOUT is not set
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="ac826dc"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 # DEBUG is not set
 # DEBUG_USE_SYSLOG is not set
@@ -82,6 +84,23 @@ GIT_VERSION="ac826dc"
 # SOFT_UART_SUPPORT is not set
 # DEBUG_HOOK is not set
 # DEBUG_RESET_REASON is not set
+
+#
+# Periodic / Scheduler
+#
+CONF_MTICKS_PER_SEC=50
+# PERIODIC_TIMER3_SUPPORT is not set
+CONF_PERIODIC_USE_TIMER=1
+# PERIODIC_TIMER_API_SUPPORT is not set
+# PERIODIC_ADJUST_SUPPORT is not set
+# DEBUG_PERIODIC is not set
+# DEBUG_PERIODIC_ECMD_SUPPORT is not set
+# DEBUG_PERIODIC_WAVEFORMS_SUPPORT is not set
+# DEBUG_PERIODIC_OC1A_SUPPORT is not set
+# SCHEDULER_SUPPORT is not set
+# SCHEDULER_DYNAMIC_SUPPORT is not set
+CONF_SCHEDULER_NUM_DYNAMIC_TIMERS=8
+# DEBUG_SCHEDULER_SUPPORT is not set
 # STATUSLEDS is not set
 # STATUSLED_POWER_SUPPORT is not set
 # STATUSLED_BOOTED_SUPPORT is not set
@@ -221,6 +240,7 @@ CONF_RFM12_IP4_NETMASK="255.255.255.0"
 # USB_NET_SUPPORT is not set
 # DEBUG_USB_HID_KEYBOARD is not set
 # DEBUG_USB_HID_MOUSE is not set
+# ZBUS_SUPPORT is not set
 # ZBUS_RAW_SUPPORT is not set
 # ROUTER_SUPPORT is not set
 UIP_SUPPORT=y
@@ -255,7 +275,6 @@ CONF_OPENVPN_PORT=1194
 # DEBUG_OPENVPN is not set
 # DEBUG_ROUTER is not set
 # DEBUG_UIP is not set
-# DEBUG_NTP is not set
 # DEBUG_UNKNOWN_PACKETS is not set
 
 #
@@ -286,6 +305,7 @@ HC595_REGISTERS=5
 # HC165_INVERSE_OUTPUT is not set
 HC165_REGISTERS=1
 # SMS_SUPPORT is not set
+# SMS_USART_0 is not set
 # DEBUG_SMS is not set
 
 #
@@ -312,6 +332,8 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD Displays
 #
 # HD44780_SUPPORT is not set
+# HD44780_BACKLIGHT_SUPPORT is not set
+# HD44780_MULTIENSUPPORT is not set
 # HD44780_BACKLIGHT_INV is not set
 # HR20_LCD_SUPPORT is not set
 # S1D15G10_SUPPORT is not set
@@ -321,6 +343,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD_SUPPORT is not set
 # DEBUG_HD44780 is not set
 # DEBUG_LCD_MENU is not set
+# DEBUG_HD44780_I2C is not set
 
 #
 # Storage
@@ -348,12 +371,21 @@ CONF_LTC1257_NUM_DEVICES=4
 # I2C_PCF8574X_SUPPORT is not set
 # I2C_PCA9555_SUPPORT is not set
 # I2C_MAX7311_SUPPORT is not set
+# I2C_MCP23017_SUPPORT is not set
 # I2C_UDP_SUPPORT is not set
 # DEBUG_I2C is not set
 # I2C_SLAVE_SUPPORT is not set
 # DEBUG_I2C_SLAVE is not set
 # CAMERA_SUPPORT is not set
 # DC3840_SUPPORT is not set
+# CONFIG_DC3840_RES80 is not set
+# CONFIG_DC3840_RES160 is not set
+# CONFIG_DC3840_RES320 is not set
+# CONFIG_DC3840_RES640 is not set
+# DC3840_HIGH_COMPRESSION is not set
+# DC3840_BLACK_WHITE is not set
+# DC3840_USART_0 is not set
+# DC3840_UDP_DEBUG is not set
 
 #
 # Radio
@@ -436,26 +468,6 @@ REMOTE_IRMP_PORT=10001
 # DEBUG_IRMP is not set
 # DEBUG_REMOTE_IRMP is not set
 # PSB2186_SUPPORT is not set
-# PWM_SUPPORT is not set
-# PWM_GENERAL_SUPPORT is not set
-# PWM_GENERAL_INVERT_SUPPORT is not set
-# PWM_GENERAL_FADING_SUPPORT is not set
-# CH_A_PWM_GENERAL_SUPPORT is not set
-# CH_B_PWM_GENERAL_SUPPORT is not set
-# CH_C_PWM_GENERAL_SUPPORT is not set
-# PWM_WAV_SUPPORT is not set
-# VFS_PWM_WAV_SUPPORT is not set
-# PWM_MELODY_SUPPORT is not set
-# ENTCHEN_PWM_MELODY_SUPPORT is not set
-# TETRIS_PWM_MELODY_SUPPORT is not set
-# PWM_SERVO_SUPPORT is not set
-PWM_SERVOS=1
-# PWM_SERVO_INVERT is not set
-# PWM_SERVO_DEFAULT_ENABLED is not set
-# PWM_FREQ_SUPPORT is not set
-# PWM_DTMF_SUPPORT is not set
-# DEBUG_PWM is not set
-# DEBUG_PWM_SERVO is not set
 # ONEWIRE_SUPPORT is not set
 # ONEWIRE_DETECT_SUPPORT is not set
 # ONEWIRE_DS2502_SUPPORT is not set
@@ -487,9 +499,13 @@ PWM_SERVOS=1
 # ULTRASONIC_SUPPORT is not set
 # DEBUG_ULTRASONIC is not set
 # HBRIDGE_SUPPORT is not set
+# DUAL_HBRIDGE_SUPPORT is not set
+# SHARE_ENABLE_HBRIDGE_SUPPORT is not set
+# HBRIDGE_INVERTER_SUPPORT is not set
 # DEBUG_HBRIDGE is not set
 # MCUF_SUPPORT is not set
 # MCUF_SERIAL_SUPPORT is not set
+# MCUF_USART_0 is not set
 # MCUF_OUTPUT_SUPPORT is not set
 # BLP_SUPPORT is not set
 # LEDRG_SUPPORT is not set
@@ -531,17 +547,22 @@ MCUF_MODUL_DISPLAY_MODE_RANDOM=y
 CONF_ARTNET_PORT=6454
 CONF_ARTNET_INUNIVERSE=1
 CONF_ARTNET_OUTUNIVERSE=0
+CONF_ARTNET_OUTPUT_IP="192.168.0.255"
+# CONF_ARTNET_SEND_POLL_REPLY is not set
 # DEBUG_ARTNET is not set
 # DALI_SUPPORT is not set
 # DALI_RAW_SUPPORT is not set
 # DALI_RECEIVE_SUPPORT is not set
 # DMX_SUPPORT is not set
+DMX_OUTPUT_UNIVERSE=1
+# DMX_USART_0 is not set
 ECMD_PARSER_SUPPORT=y
 # ECMD_REMOVE_BACKSPACE_SUPPORT is not set
 # ALIASCMD_SUPPORT is not set
 # ECMD_PAM_SUPPORT is not set
 # ECMD_SCRIPT_SUPPORT is not set
 # ECMD_LOG_VIA_SYSLOG is not set
+# ECMD_SERIAL_USART_SUPPORT is not set
 # ECMD_TCP_SUPPORT is not set
 ECMD_UDP_SUPPORT=y
 ECMD_UDP_PORT=2701
@@ -571,14 +592,23 @@ ECMD_UDP_PORT=2701
 # DEBUG_ECMD_RC5 is not set
 # DEBUG_ECMD_SCRIPT is not set
 # ELTAKOMS_SUPPORT is not set
+# ELTAKOMS_USART_0 is not set
+# DEBUG_ELTAKOMS is not set
 # EMS_SUPPORT is not set
 EMS_BUFFER_LEN=64
 EMS_PORT=7950
+# EMS_USART_0 is not set
 # EMS_DEBUG_STATS is not set
 # EMS_PROTO_DEBUG is not set
 # EMS_IO_DEBUG is not set
 # EMS_ERROR_DEBUG is not set
+# FNORDLICHT_BASIC_SUPPORT is not set
+FNORDLICHT_BAUDRATE=19200
+# FNORDLICHT_USART_0 is not set
 # FNORDLICHT_SUPPORT is not set
+CONF_FNORDLICHTER=1
+# FNORDLICHT_SERVO_SUPPORT is not set
+# DEBUG_FNORDLICHT is not set
 # HTTPLOG_SUPPORT is not set
 CONF_HTTPLOG_SERVICE="volkszaehler.org"
 CONF_HTTPLOG_PATH="/httplog/httplog.php"
@@ -598,6 +628,11 @@ CONF_IRC_REALNAME="Ethersex Wollmilchsau"
 # DEBUG_IRC is not set
 # MDNS_SD_SUPPORT is not set
 # MODBUS_SUPPORT is not set
+# MQTT_SUPPORT is not set
+MQTT_CALLBACK_SLOTS=1
+# MQTT_STATIC_CONF is not set
+# MQTT_DEBUG is not set
+# MQTT_PARSE_DEBUG is not set
 # MYSQL_SUPPORT is not set
 CONF_MYSQL_IP="192.168.23.254"
 CONF_MYSQL_USERNAME="root"
@@ -631,6 +666,8 @@ CONF_NETSTAT_API="/~habo/stat/"
 # PROTO_INTERTECHNO_SUPPORT is not set
 # PROTO_INTERTECHNO_SL_SUPPORT is not set
 # PROTO_OASEFMMASTER_SUPPORT is not set
+# PROTO_FA20RF_SUPPORT is not set
+# PROTO_SMOKEDETECTOR_SUPPORT is not set
 # SIP_SUPPORT is not set
 CONF_SIP_PROXY_IP="192.168.178.1"
 CONF_SIP_FROM="621"
@@ -674,11 +711,46 @@ CONF_USTREAM_IP="205.188.234.7"
 CONF_USTREAM_PORT=80
 # DEBUG_USTREAM is not set
 # YPORT_SUPPORT is not set
+# YPORT_USART_0 is not set
+YPORT_PORT=7970
+YPORT_BAUDRATE=115200
+YPORT_USART_CONFIG=YPORT_USART_CONFIG_8N1
+YPORT_USART_CONFIG_8N1=y
+# YPORT_USART_CONFIG_8E2 is not set
+YPORT_BUFFER_LEN=192
+YPORT_FLUSH=25
+# DEBUG_YPORT is not set
 # BSBPORT_SUPPORT is not set
+# BSBPORT_USART_0 is not set
+BSBPORT_PORT=3000
+BSBPORT_BAUDRATE=4800
+BSBPORT_BUFFER_LEN=32
+BSBPORT_FLUSH=25
+BSBPORT_MESSAGE_BUFFER_LEN=10
+BSBPORT_MESSAGE_MAX_LEN=25
+BSBPORT_OWNADDRESS=7
+# BSBPORT_POLLING_SUPPORT is not set
+# BSBPORT_MQTT_SUPPORT is not set
+# DEBUG_BSBPORT_RX is not set
+# DEBUG_BSBPORT_TX is not set
+# DEBUG_BSBPORT_ECMD is not set
+# DEBUG_BSBPORT_MQTT is not set
 # MSR1_SUPPORT is not set
+# MSR1_USART_0 is not set
+# DEBUG_MSR1 is not set
 # TO1_SUPPORT is not set
+# TO1_USART_0 is not set
+TO1_SENSOR_COUNT=1
+# DEBUG_TO1 is not set
 # SERIAL_LINE_LOG_SUPPORT is not set
+# SERIAL_LINE_LOG_USART_0 is not set
+SERIAL_LINE_LOG_TIMEOUT=20
+SERIAL_LINE_LOG_EOL=0A
+SERIAL_LINE_LOG_COUNT=60
+SERIAL_LINE_LOG_BAUDRATE=9600
+# SERIAL_LINE_LOG_SPACE_COMPRESSION is not set
 # NMEA_SUPPORT is not set
+# NMEA_USART_0 is not set
 # STELLA_PROTOCOL_SUPPORT is not set
 UDP_STELLA_PORT=2702
 # IOUDP_PROTOCOL_SUPPORT is not set
@@ -694,6 +766,12 @@ CW_WPM=12
 # CW_RFM12_ASK_SUPPORT is not set
 # DEBUG_CW is not set
 # SGC_SUPPORT is not set
+# SGC_USART_0 is not set
+SGC_BAUDRATE=9600
+# SGC_SHDN_SLEEP_ACTIVE is not set
+SGC_SLEEPMODE=0
+# SGC_TIMEOUT_COUNTER_SUPPORT is not set
+# SGC_ECMD_SEND_SUPPORT is not set
 
 #
 # Applications
@@ -708,15 +786,17 @@ CW_WPM=12
 # CLOCK_DATE_SUPPORT is not set
 # CLOCK_TIME_SUPPORT is not set
 # CLOCK_CRYSTAL_SUPPORT is not set
-# CLOCK_CPU_SUPPORT is not set
-# CLOCK_NTP_ADJUST_SUPPORT is not set
+# CLOCK_PERIODIC_SUPPORT is not set
 # DCF77_SUPPORT is not set
 # DEBUG_DCF77 is not set
 # NTP_SUPPORT is not set
+NTP_SERVER_IP="192.53.103.108"
+NTP_PORT=123
+NTP_QUERY_INTERVAL=1800
+# DEBUG_NTP is not set
 # NTPD_SUPPORT is not set
 # WHM_SUPPORT is not set
 # UPTIME_SUPPORT is not set
-# DEBUG_NTP_ADJUST is not set
 # CRON_SUPPORT is not set
 # CRON_DEFAULT_UTC is not set
 # CRON_EEPROM_SUPPORT is not set
@@ -738,6 +818,7 @@ DMX_FXSLOT_AMOUNT=4
 # DMX_FX_RANDOM is not set
 # DMX_FX_FIRE is not set
 # DMX_FX_WATER is not set
+# DMX_FX_RGB is not set
 # UDP_ECHO_NET_SUPPORT is not set
 # WOL_SUPPORT is not set
 # MOTD_SUPPORT is not set
@@ -781,6 +862,7 @@ STELLA_FADE_STEP_INIT=10
 STELLA_FADE_FUNCTION_INIT=stella_fade_func_0
 stella_fade_func_0=y
 # stella_fade_func_1 is not set
+# STELLA_USE_CIE1931 is not set
 # DEBUG_STELLA is not set
 # STARBURST_SUPPORT is not set
 # STARBURST_PCA9685 is not set
@@ -885,14 +967,9 @@ CONF_TIME2PRESS_RESET=40
 CONF_TIME2PRESS_POWER=40
 CONF_TIME2PRESS_POWERL=3
 # PROJECTOR_SANYO_Z700_SUPPORT is not set
+# SANYO_Z700_USART_0 is not set
+# DEBUG_SANYO_Z700 is not set
 # FREQCOUNT_SUPPORT is not set
-FREQCOUNT_CHANNELS=1
-# FREQCOUNT_BOOT_ON is not set
-FREQCOUNT_AVERAGE=8
-# FREQCOUNT_NOSLOW_SUPPORT is not set
-# FREQCOUNT_DUTY_SUPPORT is not set
-# FREQCOUNT_MOVING_AVERAGE_SUPPORT is not set
-# FREQCOUNT_DEBUGGING is not set
 # TANKLEVEL_SUPPORT is not set
 TANKLEVEL_ADC_CHANNEL=0
 # TANKLEVEL_STARTUP is not set
@@ -913,10 +990,12 @@ IPV4_SUPPORT=y
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -931,12 +1010,15 @@ avrispmkII=y
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -946,6 +1028,8 @@ avrispmkII=y
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -956,13 +1040,22 @@ avrispmkII=y
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -978,6 +1071,7 @@ avrispmkII=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set

--- a/scripts/profiles/usb-rfm12-dongle
+++ b/scripts/profiles/usb-rfm12-dongle
@@ -23,6 +23,7 @@ atmega8=y
 # atmega644 is not set
 # atmega644p is not set
 # atmega1284p is not set
+# atmega2560 is not set
 # at90can32 is not set
 # at90can64 is not set
 # at90can128 is not set
@@ -32,6 +33,7 @@ FREQ=16000000
 # antares_IO is not set
 # antares_O is not set
 # Arduino_Duemilanove is not set
+# arduino_mega2560_r3 is not set
 # beteigeuze is not set
 # conrad_probot is not set
 # ehaserl is not set
@@ -74,7 +76,7 @@ TEENSY_SUPPORT=y
 # SPI_TIMEOUT is not set
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="ac826dc"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 # DEBUG is not set
 # DEBUG_USE_SYSLOG is not set
@@ -82,6 +84,23 @@ GIT_VERSION="ac826dc"
 # SOFT_UART_SUPPORT is not set
 # DEBUG_HOOK is not set
 # DEBUG_RESET_REASON is not set
+
+#
+# Periodic / Scheduler
+#
+CONF_MTICKS_PER_SEC=50
+# PERIODIC_TIMER3_SUPPORT is not set
+CONF_PERIODIC_USE_TIMER=1
+# PERIODIC_TIMER_API_SUPPORT is not set
+# PERIODIC_ADJUST_SUPPORT is not set
+# DEBUG_PERIODIC is not set
+# DEBUG_PERIODIC_ECMD_SUPPORT is not set
+# DEBUG_PERIODIC_WAVEFORMS_SUPPORT is not set
+# DEBUG_PERIODIC_OC1A_SUPPORT is not set
+# SCHEDULER_SUPPORT is not set
+# SCHEDULER_DYNAMIC_SUPPORT is not set
+CONF_SCHEDULER_NUM_DYNAMIC_TIMERS=8
+# DEBUG_SCHEDULER_SUPPORT is not set
 # STATUSLEDS is not set
 # STATUSLED_POWER_SUPPORT is not set
 # STATUSLED_BOOTED_SUPPORT is not set
@@ -232,6 +251,7 @@ CONF_USB_NET_IP4_NETMASK="255.255.255.0"
 # USB_ARP_PROXY is not set
 # DEBUG_USB_HID_KEYBOARD is not set
 # DEBUG_USB_HID_MOUSE is not set
+# ZBUS_SUPPORT is not set
 # ZBUS_RAW_SUPPORT is not set
 ROUTER_SUPPORT=y
 UIP_SUPPORT=y
@@ -266,7 +286,6 @@ CONF_OPENVPN_PORT=1194
 # DEBUG_OPENVPN is not set
 # DEBUG_ROUTER is not set
 # DEBUG_UIP is not set
-# DEBUG_NTP is not set
 # DEBUG_UNKNOWN_PACKETS is not set
 
 #
@@ -297,6 +316,7 @@ HC595_REGISTERS=5
 # HC165_INVERSE_OUTPUT is not set
 HC165_REGISTERS=1
 # SMS_SUPPORT is not set
+# SMS_USART_0 is not set
 # DEBUG_SMS is not set
 
 #
@@ -323,6 +343,8 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD Displays
 #
 # HD44780_SUPPORT is not set
+# HD44780_BACKLIGHT_SUPPORT is not set
+# HD44780_MULTIENSUPPORT is not set
 # HD44780_BACKLIGHT_INV is not set
 # HR20_LCD_SUPPORT is not set
 # S1D15G10_SUPPORT is not set
@@ -332,6 +354,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD_SUPPORT is not set
 # DEBUG_HD44780 is not set
 # DEBUG_LCD_MENU is not set
+# DEBUG_HD44780_I2C is not set
 
 #
 # Storage
@@ -359,12 +382,21 @@ CONF_LTC1257_NUM_DEVICES=4
 # I2C_PCF8574X_SUPPORT is not set
 # I2C_PCA9555_SUPPORT is not set
 # I2C_MAX7311_SUPPORT is not set
+# I2C_MCP23017_SUPPORT is not set
 # I2C_UDP_SUPPORT is not set
 # DEBUG_I2C is not set
 # I2C_SLAVE_SUPPORT is not set
 # DEBUG_I2C_SLAVE is not set
 # CAMERA_SUPPORT is not set
 # DC3840_SUPPORT is not set
+# CONFIG_DC3840_RES80 is not set
+# CONFIG_DC3840_RES160 is not set
+# CONFIG_DC3840_RES320 is not set
+# CONFIG_DC3840_RES640 is not set
+# DC3840_HIGH_COMPRESSION is not set
+# DC3840_BLACK_WHITE is not set
+# DC3840_USART_0 is not set
+# DC3840_UDP_DEBUG is not set
 
 #
 # Radio
@@ -447,26 +479,6 @@ REMOTE_IRMP_PORT=10001
 # DEBUG_IRMP is not set
 # DEBUG_REMOTE_IRMP is not set
 # PSB2186_SUPPORT is not set
-# PWM_SUPPORT is not set
-# PWM_GENERAL_SUPPORT is not set
-# PWM_GENERAL_INVERT_SUPPORT is not set
-# PWM_GENERAL_FADING_SUPPORT is not set
-# CH_A_PWM_GENERAL_SUPPORT is not set
-# CH_B_PWM_GENERAL_SUPPORT is not set
-# CH_C_PWM_GENERAL_SUPPORT is not set
-# PWM_WAV_SUPPORT is not set
-# VFS_PWM_WAV_SUPPORT is not set
-# PWM_MELODY_SUPPORT is not set
-# ENTCHEN_PWM_MELODY_SUPPORT is not set
-# TETRIS_PWM_MELODY_SUPPORT is not set
-# PWM_SERVO_SUPPORT is not set
-PWM_SERVOS=1
-# PWM_SERVO_INVERT is not set
-# PWM_SERVO_DEFAULT_ENABLED is not set
-# PWM_FREQ_SUPPORT is not set
-# PWM_DTMF_SUPPORT is not set
-# DEBUG_PWM is not set
-# DEBUG_PWM_SERVO is not set
 # ONEWIRE_SUPPORT is not set
 # ONEWIRE_DETECT_SUPPORT is not set
 # ONEWIRE_DS2502_SUPPORT is not set
@@ -498,9 +510,13 @@ PWM_SERVOS=1
 # ULTRASONIC_SUPPORT is not set
 # DEBUG_ULTRASONIC is not set
 # HBRIDGE_SUPPORT is not set
+# DUAL_HBRIDGE_SUPPORT is not set
+# SHARE_ENABLE_HBRIDGE_SUPPORT is not set
+# HBRIDGE_INVERTER_SUPPORT is not set
 # DEBUG_HBRIDGE is not set
 # MCUF_SUPPORT is not set
 # MCUF_SERIAL_SUPPORT is not set
+# MCUF_USART_0 is not set
 # MCUF_OUTPUT_SUPPORT is not set
 # BLP_SUPPORT is not set
 # LEDRG_SUPPORT is not set
@@ -542,17 +558,22 @@ MCUF_MODUL_DISPLAY_MODE_RANDOM=y
 CONF_ARTNET_PORT=6454
 CONF_ARTNET_INUNIVERSE=1
 CONF_ARTNET_OUTUNIVERSE=0
+CONF_ARTNET_OUTPUT_IP="192.168.0.255"
+# CONF_ARTNET_SEND_POLL_REPLY is not set
 # DEBUG_ARTNET is not set
 # DALI_SUPPORT is not set
 # DALI_RAW_SUPPORT is not set
 # DALI_RECEIVE_SUPPORT is not set
 # DMX_SUPPORT is not set
+DMX_OUTPUT_UNIVERSE=1
+# DMX_USART_0 is not set
 ECMD_PARSER_SUPPORT=y
 # ECMD_REMOVE_BACKSPACE_SUPPORT is not set
 # ALIASCMD_SUPPORT is not set
 # ECMD_PAM_SUPPORT is not set
 # ECMD_SCRIPT_SUPPORT is not set
 # ECMD_LOG_VIA_SYSLOG is not set
+# ECMD_SERIAL_USART_SUPPORT is not set
 # ECMD_TCP_SUPPORT is not set
 ECMD_UDP_SUPPORT=y
 ECMD_UDP_PORT=2701
@@ -582,14 +603,23 @@ ECMD_UDP_PORT=2701
 # DEBUG_ECMD_RC5 is not set
 # DEBUG_ECMD_SCRIPT is not set
 # ELTAKOMS_SUPPORT is not set
+# ELTAKOMS_USART_0 is not set
+# DEBUG_ELTAKOMS is not set
 # EMS_SUPPORT is not set
 EMS_BUFFER_LEN=64
 EMS_PORT=7950
+# EMS_USART_0 is not set
 # EMS_DEBUG_STATS is not set
 # EMS_PROTO_DEBUG is not set
 # EMS_IO_DEBUG is not set
 # EMS_ERROR_DEBUG is not set
+# FNORDLICHT_BASIC_SUPPORT is not set
+FNORDLICHT_BAUDRATE=19200
+# FNORDLICHT_USART_0 is not set
 # FNORDLICHT_SUPPORT is not set
+CONF_FNORDLICHTER=1
+# FNORDLICHT_SERVO_SUPPORT is not set
+# DEBUG_FNORDLICHT is not set
 # HTTPLOG_SUPPORT is not set
 CONF_HTTPLOG_SERVICE="volkszaehler.org"
 CONF_HTTPLOG_PATH="/httplog/httplog.php"
@@ -609,6 +639,11 @@ CONF_IRC_REALNAME="Ethersex Wollmilchsau"
 # DEBUG_IRC is not set
 # MDNS_SD_SUPPORT is not set
 # MODBUS_SUPPORT is not set
+# MQTT_SUPPORT is not set
+MQTT_CALLBACK_SLOTS=1
+# MQTT_STATIC_CONF is not set
+# MQTT_DEBUG is not set
+# MQTT_PARSE_DEBUG is not set
 # MYSQL_SUPPORT is not set
 CONF_MYSQL_IP="192.168.23.254"
 CONF_MYSQL_USERNAME="root"
@@ -642,6 +677,8 @@ CONF_NETSTAT_API="/~habo/stat/"
 # PROTO_INTERTECHNO_SUPPORT is not set
 # PROTO_INTERTECHNO_SL_SUPPORT is not set
 # PROTO_OASEFMMASTER_SUPPORT is not set
+# PROTO_FA20RF_SUPPORT is not set
+# PROTO_SMOKEDETECTOR_SUPPORT is not set
 # SIP_SUPPORT is not set
 CONF_SIP_PROXY_IP="192.168.178.1"
 CONF_SIP_FROM="621"
@@ -685,11 +722,46 @@ CONF_USTREAM_IP="205.188.234.7"
 CONF_USTREAM_PORT=80
 # DEBUG_USTREAM is not set
 # YPORT_SUPPORT is not set
+# YPORT_USART_0 is not set
+YPORT_PORT=7970
+YPORT_BAUDRATE=115200
+YPORT_USART_CONFIG=YPORT_USART_CONFIG_8N1
+YPORT_USART_CONFIG_8N1=y
+# YPORT_USART_CONFIG_8E2 is not set
+YPORT_BUFFER_LEN=192
+YPORT_FLUSH=25
+# DEBUG_YPORT is not set
 # BSBPORT_SUPPORT is not set
+# BSBPORT_USART_0 is not set
+BSBPORT_PORT=3000
+BSBPORT_BAUDRATE=4800
+BSBPORT_BUFFER_LEN=32
+BSBPORT_FLUSH=25
+BSBPORT_MESSAGE_BUFFER_LEN=10
+BSBPORT_MESSAGE_MAX_LEN=25
+BSBPORT_OWNADDRESS=7
+# BSBPORT_POLLING_SUPPORT is not set
+# BSBPORT_MQTT_SUPPORT is not set
+# DEBUG_BSBPORT_RX is not set
+# DEBUG_BSBPORT_TX is not set
+# DEBUG_BSBPORT_ECMD is not set
+# DEBUG_BSBPORT_MQTT is not set
 # MSR1_SUPPORT is not set
+# MSR1_USART_0 is not set
+# DEBUG_MSR1 is not set
 # TO1_SUPPORT is not set
+# TO1_USART_0 is not set
+TO1_SENSOR_COUNT=1
+# DEBUG_TO1 is not set
 # SERIAL_LINE_LOG_SUPPORT is not set
+# SERIAL_LINE_LOG_USART_0 is not set
+SERIAL_LINE_LOG_TIMEOUT=20
+SERIAL_LINE_LOG_EOL=0A
+SERIAL_LINE_LOG_COUNT=60
+SERIAL_LINE_LOG_BAUDRATE=9600
+# SERIAL_LINE_LOG_SPACE_COMPRESSION is not set
 # NMEA_SUPPORT is not set
+# NMEA_USART_0 is not set
 # STELLA_PROTOCOL_SUPPORT is not set
 UDP_STELLA_PORT=2702
 # IOUDP_PROTOCOL_SUPPORT is not set
@@ -705,6 +777,12 @@ CW_WPM=12
 # CW_RFM12_ASK_SUPPORT is not set
 # DEBUG_CW is not set
 # SGC_SUPPORT is not set
+# SGC_USART_0 is not set
+SGC_BAUDRATE=9600
+# SGC_SHDN_SLEEP_ACTIVE is not set
+SGC_SLEEPMODE=0
+# SGC_TIMEOUT_COUNTER_SUPPORT is not set
+# SGC_ECMD_SEND_SUPPORT is not set
 
 #
 # Applications
@@ -719,15 +797,17 @@ CW_WPM=12
 # CLOCK_DATE_SUPPORT is not set
 # CLOCK_TIME_SUPPORT is not set
 # CLOCK_CRYSTAL_SUPPORT is not set
-# CLOCK_CPU_SUPPORT is not set
-# CLOCK_NTP_ADJUST_SUPPORT is not set
+# CLOCK_PERIODIC_SUPPORT is not set
 # DCF77_SUPPORT is not set
 # DEBUG_DCF77 is not set
 # NTP_SUPPORT is not set
+NTP_SERVER_IP="192.53.103.108"
+NTP_PORT=123
+NTP_QUERY_INTERVAL=1800
+# DEBUG_NTP is not set
 # NTPD_SUPPORT is not set
 # WHM_SUPPORT is not set
 # UPTIME_SUPPORT is not set
-# DEBUG_NTP_ADJUST is not set
 # CRON_SUPPORT is not set
 # CRON_DEFAULT_UTC is not set
 # CRON_EEPROM_SUPPORT is not set
@@ -749,6 +829,7 @@ DMX_FXSLOT_AMOUNT=4
 # DMX_FX_RANDOM is not set
 # DMX_FX_FIRE is not set
 # DMX_FX_WATER is not set
+# DMX_FX_RGB is not set
 # UDP_ECHO_NET_SUPPORT is not set
 # WOL_SUPPORT is not set
 # MOTD_SUPPORT is not set
@@ -792,6 +873,7 @@ STELLA_FADE_STEP_INIT=10
 STELLA_FADE_FUNCTION_INIT=stella_fade_func_0
 stella_fade_func_0=y
 # stella_fade_func_1 is not set
+# STELLA_USE_CIE1931 is not set
 # DEBUG_STELLA is not set
 # STARBURST_SUPPORT is not set
 # STARBURST_PCA9685 is not set
@@ -896,14 +978,9 @@ CONF_TIME2PRESS_RESET=40
 CONF_TIME2PRESS_POWER=40
 CONF_TIME2PRESS_POWERL=3
 # PROJECTOR_SANYO_Z700_SUPPORT is not set
+# SANYO_Z700_USART_0 is not set
+# DEBUG_SANYO_Z700 is not set
 # FREQCOUNT_SUPPORT is not set
-FREQCOUNT_CHANNELS=1
-# FREQCOUNT_BOOT_ON is not set
-FREQCOUNT_AVERAGE=8
-# FREQCOUNT_NOSLOW_SUPPORT is not set
-# FREQCOUNT_DUTY_SUPPORT is not set
-# FREQCOUNT_MOVING_AVERAGE_SUPPORT is not set
-# FREQCOUNT_DEBUGGING is not set
 # TANKLEVEL_SUPPORT is not set
 TANKLEVEL_ADC_CHANNEL=0
 # TANKLEVEL_STARTUP is not set
@@ -924,10 +1001,12 @@ IPV4_SUPPORT=y
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -942,12 +1021,15 @@ avrispmkII=y
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -957,6 +1039,8 @@ avrispmkII=y
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -967,13 +1051,22 @@ avrispmkII=y
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -989,6 +1082,7 @@ avrispmkII=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set

--- a/scripts/profiles/usb-teensy
+++ b/scripts/profiles/usb-teensy
@@ -23,6 +23,7 @@ atmega8=y
 # atmega644 is not set
 # atmega644p is not set
 # atmega1284p is not set
+# atmega2560 is not set
 # at90can32 is not set
 # at90can64 is not set
 # at90can128 is not set
@@ -32,6 +33,7 @@ FREQ=16000000
 # antares_IO is not set
 # antares_O is not set
 # Arduino_Duemilanove is not set
+# arduino_mega2560_r3 is not set
 # beteigeuze is not set
 # conrad_probot is not set
 # ehaserl is not set
@@ -74,7 +76,7 @@ TEENSY_SUPPORT=y
 # SPI_TIMEOUT is not set
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="ac826dc"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 # DEBUG is not set
 # DEBUG_USE_SYSLOG is not set
@@ -82,6 +84,23 @@ GIT_VERSION="ac826dc"
 # SOFT_UART_SUPPORT is not set
 # DEBUG_HOOK is not set
 # DEBUG_RESET_REASON is not set
+
+#
+# Periodic / Scheduler
+#
+CONF_MTICKS_PER_SEC=50
+# PERIODIC_TIMER3_SUPPORT is not set
+CONF_PERIODIC_USE_TIMER=1
+# PERIODIC_TIMER_API_SUPPORT is not set
+# PERIODIC_ADJUST_SUPPORT is not set
+# DEBUG_PERIODIC is not set
+# DEBUG_PERIODIC_ECMD_SUPPORT is not set
+# DEBUG_PERIODIC_WAVEFORMS_SUPPORT is not set
+# DEBUG_PERIODIC_OC1A_SUPPORT is not set
+# SCHEDULER_SUPPORT is not set
+# SCHEDULER_DYNAMIC_SUPPORT is not set
+CONF_SCHEDULER_NUM_DYNAMIC_TIMERS=8
+# DEBUG_SCHEDULER_SUPPORT is not set
 # STATUSLEDS is not set
 # STATUSLED_POWER_SUPPORT is not set
 # STATUSLED_BOOTED_SUPPORT is not set
@@ -232,6 +251,7 @@ CONF_USB_NET_IP4_NETMASK="255.255.255.0"
 # USB_ARP_PROXY is not set
 # DEBUG_USB_HID_KEYBOARD is not set
 # DEBUG_USB_HID_MOUSE is not set
+# ZBUS_SUPPORT is not set
 # ZBUS_RAW_SUPPORT is not set
 # ROUTER_SUPPORT is not set
 UIP_SUPPORT=y
@@ -266,7 +286,6 @@ CONF_OPENVPN_PORT=1194
 # DEBUG_OPENVPN is not set
 # DEBUG_ROUTER is not set
 # DEBUG_UIP is not set
-# DEBUG_NTP is not set
 # DEBUG_UNKNOWN_PACKETS is not set
 
 #
@@ -297,6 +316,7 @@ HC595_REGISTERS=5
 # HC165_INVERSE_OUTPUT is not set
 HC165_REGISTERS=1
 # SMS_SUPPORT is not set
+# SMS_USART_0 is not set
 # DEBUG_SMS is not set
 
 #
@@ -323,6 +343,8 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD Displays
 #
 # HD44780_SUPPORT is not set
+# HD44780_BACKLIGHT_SUPPORT is not set
+# HD44780_MULTIENSUPPORT is not set
 # HD44780_BACKLIGHT_INV is not set
 # HR20_LCD_SUPPORT is not set
 # S1D15G10_SUPPORT is not set
@@ -332,6 +354,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD_SUPPORT is not set
 # DEBUG_HD44780 is not set
 # DEBUG_LCD_MENU is not set
+# DEBUG_HD44780_I2C is not set
 
 #
 # Storage
@@ -359,12 +382,21 @@ CONF_LTC1257_NUM_DEVICES=4
 # I2C_PCF8574X_SUPPORT is not set
 # I2C_PCA9555_SUPPORT is not set
 # I2C_MAX7311_SUPPORT is not set
+# I2C_MCP23017_SUPPORT is not set
 # I2C_UDP_SUPPORT is not set
 # DEBUG_I2C is not set
 # I2C_SLAVE_SUPPORT is not set
 # DEBUG_I2C_SLAVE is not set
 # CAMERA_SUPPORT is not set
 # DC3840_SUPPORT is not set
+# CONFIG_DC3840_RES80 is not set
+# CONFIG_DC3840_RES160 is not set
+# CONFIG_DC3840_RES320 is not set
+# CONFIG_DC3840_RES640 is not set
+# DC3840_HIGH_COMPRESSION is not set
+# DC3840_BLACK_WHITE is not set
+# DC3840_USART_0 is not set
+# DC3840_UDP_DEBUG is not set
 
 #
 # Radio
@@ -447,26 +479,6 @@ REMOTE_IRMP_PORT=10001
 # DEBUG_IRMP is not set
 # DEBUG_REMOTE_IRMP is not set
 # PSB2186_SUPPORT is not set
-# PWM_SUPPORT is not set
-# PWM_GENERAL_SUPPORT is not set
-# PWM_GENERAL_INVERT_SUPPORT is not set
-# PWM_GENERAL_FADING_SUPPORT is not set
-# CH_A_PWM_GENERAL_SUPPORT is not set
-# CH_B_PWM_GENERAL_SUPPORT is not set
-# CH_C_PWM_GENERAL_SUPPORT is not set
-# PWM_WAV_SUPPORT is not set
-# VFS_PWM_WAV_SUPPORT is not set
-# PWM_MELODY_SUPPORT is not set
-# ENTCHEN_PWM_MELODY_SUPPORT is not set
-# TETRIS_PWM_MELODY_SUPPORT is not set
-# PWM_SERVO_SUPPORT is not set
-PWM_SERVOS=1
-# PWM_SERVO_INVERT is not set
-# PWM_SERVO_DEFAULT_ENABLED is not set
-# PWM_FREQ_SUPPORT is not set
-# PWM_DTMF_SUPPORT is not set
-# DEBUG_PWM is not set
-# DEBUG_PWM_SERVO is not set
 # ONEWIRE_SUPPORT is not set
 # ONEWIRE_DETECT_SUPPORT is not set
 # ONEWIRE_DS2502_SUPPORT is not set
@@ -498,9 +510,13 @@ PWM_SERVOS=1
 # ULTRASONIC_SUPPORT is not set
 # DEBUG_ULTRASONIC is not set
 # HBRIDGE_SUPPORT is not set
+# DUAL_HBRIDGE_SUPPORT is not set
+# SHARE_ENABLE_HBRIDGE_SUPPORT is not set
+# HBRIDGE_INVERTER_SUPPORT is not set
 # DEBUG_HBRIDGE is not set
 # MCUF_SUPPORT is not set
 # MCUF_SERIAL_SUPPORT is not set
+# MCUF_USART_0 is not set
 # MCUF_OUTPUT_SUPPORT is not set
 # BLP_SUPPORT is not set
 # LEDRG_SUPPORT is not set
@@ -542,17 +558,22 @@ MCUF_MODUL_DISPLAY_MODE_RANDOM=y
 CONF_ARTNET_PORT=6454
 CONF_ARTNET_INUNIVERSE=1
 CONF_ARTNET_OUTUNIVERSE=0
+CONF_ARTNET_OUTPUT_IP="192.168.0.255"
+# CONF_ARTNET_SEND_POLL_REPLY is not set
 # DEBUG_ARTNET is not set
 # DALI_SUPPORT is not set
 # DALI_RAW_SUPPORT is not set
 # DALI_RECEIVE_SUPPORT is not set
 # DMX_SUPPORT is not set
+DMX_OUTPUT_UNIVERSE=1
+# DMX_USART_0 is not set
 ECMD_PARSER_SUPPORT=y
 # ECMD_REMOVE_BACKSPACE_SUPPORT is not set
 # ALIASCMD_SUPPORT is not set
 # ECMD_PAM_SUPPORT is not set
 # ECMD_SCRIPT_SUPPORT is not set
 # ECMD_LOG_VIA_SYSLOG is not set
+# ECMD_SERIAL_USART_SUPPORT is not set
 # ECMD_TCP_SUPPORT is not set
 ECMD_UDP_SUPPORT=y
 ECMD_UDP_PORT=2701
@@ -582,14 +603,23 @@ ECMD_UDP_PORT=2701
 # DEBUG_ECMD_RC5 is not set
 # DEBUG_ECMD_SCRIPT is not set
 # ELTAKOMS_SUPPORT is not set
+# ELTAKOMS_USART_0 is not set
+# DEBUG_ELTAKOMS is not set
 # EMS_SUPPORT is not set
 EMS_BUFFER_LEN=64
 EMS_PORT=7950
+# EMS_USART_0 is not set
 # EMS_DEBUG_STATS is not set
 # EMS_PROTO_DEBUG is not set
 # EMS_IO_DEBUG is not set
 # EMS_ERROR_DEBUG is not set
+# FNORDLICHT_BASIC_SUPPORT is not set
+FNORDLICHT_BAUDRATE=19200
+# FNORDLICHT_USART_0 is not set
 # FNORDLICHT_SUPPORT is not set
+CONF_FNORDLICHTER=1
+# FNORDLICHT_SERVO_SUPPORT is not set
+# DEBUG_FNORDLICHT is not set
 # HTTPLOG_SUPPORT is not set
 CONF_HTTPLOG_SERVICE="volkszaehler.org"
 CONF_HTTPLOG_PATH="/httplog/httplog.php"
@@ -609,6 +639,11 @@ CONF_IRC_REALNAME="Ethersex Wollmilchsau"
 # DEBUG_IRC is not set
 # MDNS_SD_SUPPORT is not set
 # MODBUS_SUPPORT is not set
+# MQTT_SUPPORT is not set
+MQTT_CALLBACK_SLOTS=1
+# MQTT_STATIC_CONF is not set
+# MQTT_DEBUG is not set
+# MQTT_PARSE_DEBUG is not set
 # MYSQL_SUPPORT is not set
 CONF_MYSQL_IP="192.168.23.254"
 CONF_MYSQL_USERNAME="root"
@@ -642,6 +677,8 @@ CONF_NETSTAT_API="/~habo/stat/"
 # PROTO_INTERTECHNO_SUPPORT is not set
 # PROTO_INTERTECHNO_SL_SUPPORT is not set
 # PROTO_OASEFMMASTER_SUPPORT is not set
+# PROTO_FA20RF_SUPPORT is not set
+# PROTO_SMOKEDETECTOR_SUPPORT is not set
 # SIP_SUPPORT is not set
 CONF_SIP_PROXY_IP="192.168.178.1"
 CONF_SIP_FROM="621"
@@ -685,11 +722,46 @@ CONF_USTREAM_IP="205.188.234.7"
 CONF_USTREAM_PORT=80
 # DEBUG_USTREAM is not set
 # YPORT_SUPPORT is not set
+# YPORT_USART_0 is not set
+YPORT_PORT=7970
+YPORT_BAUDRATE=115200
+YPORT_USART_CONFIG=YPORT_USART_CONFIG_8N1
+YPORT_USART_CONFIG_8N1=y
+# YPORT_USART_CONFIG_8E2 is not set
+YPORT_BUFFER_LEN=192
+YPORT_FLUSH=25
+# DEBUG_YPORT is not set
 # BSBPORT_SUPPORT is not set
+# BSBPORT_USART_0 is not set
+BSBPORT_PORT=3000
+BSBPORT_BAUDRATE=4800
+BSBPORT_BUFFER_LEN=32
+BSBPORT_FLUSH=25
+BSBPORT_MESSAGE_BUFFER_LEN=10
+BSBPORT_MESSAGE_MAX_LEN=25
+BSBPORT_OWNADDRESS=7
+# BSBPORT_POLLING_SUPPORT is not set
+# BSBPORT_MQTT_SUPPORT is not set
+# DEBUG_BSBPORT_RX is not set
+# DEBUG_BSBPORT_TX is not set
+# DEBUG_BSBPORT_ECMD is not set
+# DEBUG_BSBPORT_MQTT is not set
 # MSR1_SUPPORT is not set
+# MSR1_USART_0 is not set
+# DEBUG_MSR1 is not set
 # TO1_SUPPORT is not set
+# TO1_USART_0 is not set
+TO1_SENSOR_COUNT=1
+# DEBUG_TO1 is not set
 # SERIAL_LINE_LOG_SUPPORT is not set
+# SERIAL_LINE_LOG_USART_0 is not set
+SERIAL_LINE_LOG_TIMEOUT=20
+SERIAL_LINE_LOG_EOL=0A
+SERIAL_LINE_LOG_COUNT=60
+SERIAL_LINE_LOG_BAUDRATE=9600
+# SERIAL_LINE_LOG_SPACE_COMPRESSION is not set
 # NMEA_SUPPORT is not set
+# NMEA_USART_0 is not set
 # STELLA_PROTOCOL_SUPPORT is not set
 UDP_STELLA_PORT=2702
 # IOUDP_PROTOCOL_SUPPORT is not set
@@ -705,6 +777,12 @@ CW_WPM=12
 # CW_RFM12_ASK_SUPPORT is not set
 # DEBUG_CW is not set
 # SGC_SUPPORT is not set
+# SGC_USART_0 is not set
+SGC_BAUDRATE=9600
+# SGC_SHDN_SLEEP_ACTIVE is not set
+SGC_SLEEPMODE=0
+# SGC_TIMEOUT_COUNTER_SUPPORT is not set
+# SGC_ECMD_SEND_SUPPORT is not set
 
 #
 # Applications
@@ -719,15 +797,17 @@ CW_WPM=12
 # CLOCK_DATE_SUPPORT is not set
 # CLOCK_TIME_SUPPORT is not set
 # CLOCK_CRYSTAL_SUPPORT is not set
-# CLOCK_CPU_SUPPORT is not set
-# CLOCK_NTP_ADJUST_SUPPORT is not set
+# CLOCK_PERIODIC_SUPPORT is not set
 # DCF77_SUPPORT is not set
 # DEBUG_DCF77 is not set
 # NTP_SUPPORT is not set
+NTP_SERVER_IP="192.53.103.108"
+NTP_PORT=123
+NTP_QUERY_INTERVAL=1800
+# DEBUG_NTP is not set
 # NTPD_SUPPORT is not set
 # WHM_SUPPORT is not set
 # UPTIME_SUPPORT is not set
-# DEBUG_NTP_ADJUST is not set
 # CRON_SUPPORT is not set
 # CRON_DEFAULT_UTC is not set
 # CRON_EEPROM_SUPPORT is not set
@@ -749,6 +829,7 @@ DMX_FXSLOT_AMOUNT=4
 # DMX_FX_RANDOM is not set
 # DMX_FX_FIRE is not set
 # DMX_FX_WATER is not set
+# DMX_FX_RGB is not set
 # UDP_ECHO_NET_SUPPORT is not set
 # WOL_SUPPORT is not set
 # MOTD_SUPPORT is not set
@@ -792,6 +873,7 @@ STELLA_FADE_STEP_INIT=10
 STELLA_FADE_FUNCTION_INIT=stella_fade_func_0
 stella_fade_func_0=y
 # stella_fade_func_1 is not set
+# STELLA_USE_CIE1931 is not set
 # DEBUG_STELLA is not set
 # STARBURST_SUPPORT is not set
 # STARBURST_PCA9685 is not set
@@ -896,14 +978,9 @@ CONF_TIME2PRESS_RESET=40
 CONF_TIME2PRESS_POWER=40
 CONF_TIME2PRESS_POWERL=3
 # PROJECTOR_SANYO_Z700_SUPPORT is not set
+# SANYO_Z700_USART_0 is not set
+# DEBUG_SANYO_Z700 is not set
 # FREQCOUNT_SUPPORT is not set
-FREQCOUNT_CHANNELS=1
-# FREQCOUNT_BOOT_ON is not set
-FREQCOUNT_AVERAGE=8
-# FREQCOUNT_NOSLOW_SUPPORT is not set
-# FREQCOUNT_DUTY_SUPPORT is not set
-# FREQCOUNT_MOVING_AVERAGE_SUPPORT is not set
-# FREQCOUNT_DEBUGGING is not set
 # TANKLEVEL_SUPPORT is not set
 TANKLEVEL_ADC_CHANNEL=0
 # TANKLEVEL_STARTUP is not set
@@ -924,10 +1001,12 @@ IPV4_SUPPORT=y
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -942,12 +1021,15 @@ avrispmkII=y
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -957,6 +1039,8 @@ avrispmkII=y
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -967,13 +1051,22 @@ avrispmkII=y
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -989,6 +1082,7 @@ avrispmkII=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set

--- a/scripts/profiles/zbus-teensy
+++ b/scripts/profiles/zbus-teensy
@@ -23,6 +23,7 @@ atmega8=y
 # atmega644 is not set
 # atmega644p is not set
 # atmega1284p is not set
+# atmega2560 is not set
 # at90can32 is not set
 # at90can64 is not set
 # at90can128 is not set
@@ -32,6 +33,7 @@ FREQ=8000000
 # antares_IO is not set
 # antares_O is not set
 # Arduino_Duemilanove is not set
+# arduino_mega2560_r3 is not set
 # beteigeuze is not set
 # conrad_probot is not set
 # ehaserl is not set
@@ -74,7 +76,7 @@ TEENSY_SUPPORT=y
 # SPI_TIMEOUT is not set
 # USART_SPI_SUPPORT is not set
 # SOFT_SPI_SUPPORT is not set
-GIT_VERSION="ac826dc"
+GIT_VERSION="15356a6"
 # DEBUG_DISCARD_SOME is not set
 # DEBUG is not set
 # DEBUG_USE_SYSLOG is not set
@@ -82,6 +84,23 @@ GIT_VERSION="ac826dc"
 # SOFT_UART_SUPPORT is not set
 # DEBUG_HOOK is not set
 # DEBUG_RESET_REASON is not set
+
+#
+# Periodic / Scheduler
+#
+CONF_MTICKS_PER_SEC=50
+# PERIODIC_TIMER3_SUPPORT is not set
+CONF_PERIODIC_USE_TIMER=1
+# PERIODIC_TIMER_API_SUPPORT is not set
+# PERIODIC_ADJUST_SUPPORT is not set
+# DEBUG_PERIODIC is not set
+# DEBUG_PERIODIC_ECMD_SUPPORT is not set
+# DEBUG_PERIODIC_WAVEFORMS_SUPPORT is not set
+# DEBUG_PERIODIC_OC1A_SUPPORT is not set
+# SCHEDULER_SUPPORT is not set
+# SCHEDULER_DYNAMIC_SUPPORT is not set
+CONF_SCHEDULER_NUM_DYNAMIC_TIMERS=8
+# DEBUG_SCHEDULER_SUPPORT is not set
 # STATUSLEDS is not set
 # STATUSLED_POWER_SUPPORT is not set
 # STATUSLED_BOOTED_SUPPORT is not set
@@ -222,6 +241,7 @@ CONF_RFM12_IP4_NETMASK="255.255.255.0"
 # DEBUG_USB_HID_KEYBOARD is not set
 # DEBUG_USB_HID_MOUSE is not set
 ZBUS_SUPPORT=y
+# ZBUS_USART_0 is not set
 CONF_ZBUS_BAUDRATE=19200
 CONF_ZBUS_IP="192.168.23.244"
 CONF_ZBUS_IP4_NETMASK="255.255.255.0"
@@ -262,7 +282,6 @@ CONF_OPENVPN_PORT=1194
 # DEBUG_OPENVPN is not set
 # DEBUG_ROUTER is not set
 # DEBUG_UIP is not set
-# DEBUG_NTP is not set
 # DEBUG_UNKNOWN_PACKETS is not set
 
 #
@@ -293,6 +312,7 @@ HC595_REGISTERS=5
 # HC165_INVERSE_OUTPUT is not set
 HC165_REGISTERS=1
 # SMS_SUPPORT is not set
+# SMS_USART_0 is not set
 # DEBUG_SMS is not set
 
 #
@@ -319,6 +339,8 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD Displays
 #
 # HD44780_SUPPORT is not set
+# HD44780_BACKLIGHT_SUPPORT is not set
+# HD44780_MULTIENSUPPORT is not set
 # HD44780_BACKLIGHT_INV is not set
 # HR20_LCD_SUPPORT is not set
 # S1D15G10_SUPPORT is not set
@@ -328,6 +350,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # LCD_SUPPORT is not set
 # DEBUG_HD44780 is not set
 # DEBUG_LCD_MENU is not set
+# DEBUG_HD44780_I2C is not set
 
 #
 # Storage
@@ -355,6 +378,7 @@ CONF_LTC1257_NUM_DEVICES=4
 # I2C_PCF8574X_SUPPORT is not set
 # I2C_PCA9555_SUPPORT is not set
 # I2C_MAX7311_SUPPORT is not set
+# I2C_MCP23017_SUPPORT is not set
 # I2C_UDP_SUPPORT is not set
 # DEBUG_I2C is not set
 # I2C_SLAVE_SUPPORT is not set
@@ -443,26 +467,6 @@ REMOTE_IRMP_PORT=10001
 # DEBUG_IRMP is not set
 # DEBUG_REMOTE_IRMP is not set
 # PSB2186_SUPPORT is not set
-# PWM_SUPPORT is not set
-# PWM_GENERAL_SUPPORT is not set
-# PWM_GENERAL_INVERT_SUPPORT is not set
-# PWM_GENERAL_FADING_SUPPORT is not set
-# CH_A_PWM_GENERAL_SUPPORT is not set
-# CH_B_PWM_GENERAL_SUPPORT is not set
-# CH_C_PWM_GENERAL_SUPPORT is not set
-# PWM_WAV_SUPPORT is not set
-# VFS_PWM_WAV_SUPPORT is not set
-# PWM_MELODY_SUPPORT is not set
-# ENTCHEN_PWM_MELODY_SUPPORT is not set
-# TETRIS_PWM_MELODY_SUPPORT is not set
-# PWM_SERVO_SUPPORT is not set
-PWM_SERVOS=1
-# PWM_SERVO_INVERT is not set
-# PWM_SERVO_DEFAULT_ENABLED is not set
-# PWM_FREQ_SUPPORT is not set
-# PWM_DTMF_SUPPORT is not set
-# DEBUG_PWM is not set
-# DEBUG_PWM_SERVO is not set
 # ONEWIRE_SUPPORT is not set
 # ONEWIRE_DETECT_SUPPORT is not set
 # ONEWIRE_DS2502_SUPPORT is not set
@@ -494,6 +498,9 @@ PWM_SERVOS=1
 # ULTRASONIC_SUPPORT is not set
 # DEBUG_ULTRASONIC is not set
 # HBRIDGE_SUPPORT is not set
+# DUAL_HBRIDGE_SUPPORT is not set
+# SHARE_ENABLE_HBRIDGE_SUPPORT is not set
+# HBRIDGE_INVERTER_SUPPORT is not set
 # DEBUG_HBRIDGE is not set
 # MCUF_SUPPORT is not set
 # MCUF_SERIAL_SUPPORT is not set
@@ -538,6 +545,8 @@ MCUF_MODUL_DISPLAY_MODE_RANDOM=y
 CONF_ARTNET_PORT=6454
 CONF_ARTNET_INUNIVERSE=1
 CONF_ARTNET_OUTUNIVERSE=0
+CONF_ARTNET_OUTPUT_IP="192.168.0.255"
+# CONF_ARTNET_SEND_POLL_REPLY is not set
 # DEBUG_ARTNET is not set
 # DALI_SUPPORT is not set
 # DALI_RAW_SUPPORT is not set
@@ -579,12 +588,6 @@ ECMD_UDP_PORT=2701
 # DEBUG_ECMD_SCRIPT is not set
 # ELTAKOMS_SUPPORT is not set
 # EMS_SUPPORT is not set
-EMS_BUFFER_LEN=64
-EMS_PORT=7950
-# EMS_DEBUG_STATS is not set
-# EMS_PROTO_DEBUG is not set
-# EMS_IO_DEBUG is not set
-# EMS_ERROR_DEBUG is not set
 # FNORDLICHT_SUPPORT is not set
 # HTTPLOG_SUPPORT is not set
 CONF_HTTPLOG_SERVICE="volkszaehler.org"
@@ -605,6 +608,11 @@ CONF_IRC_REALNAME="Ethersex Wollmilchsau"
 # DEBUG_IRC is not set
 # MDNS_SD_SUPPORT is not set
 # MODBUS_SUPPORT is not set
+# MQTT_SUPPORT is not set
+MQTT_CALLBACK_SLOTS=1
+# MQTT_STATIC_CONF is not set
+# MQTT_DEBUG is not set
+# MQTT_PARSE_DEBUG is not set
 # MYSQL_SUPPORT is not set
 CONF_MYSQL_IP="192.168.23.254"
 CONF_MYSQL_USERNAME="root"
@@ -638,6 +646,8 @@ CONF_NETSTAT_API="/~habo/stat/"
 # PROTO_INTERTECHNO_SUPPORT is not set
 # PROTO_INTERTECHNO_SL_SUPPORT is not set
 # PROTO_OASEFMMASTER_SUPPORT is not set
+# PROTO_FA20RF_SUPPORT is not set
+# PROTO_SMOKEDETECTOR_SUPPORT is not set
 # SIP_SUPPORT is not set
 CONF_SIP_PROXY_IP="192.168.178.1"
 CONF_SIP_FROM="621"
@@ -715,15 +725,17 @@ CW_WPM=12
 # CLOCK_DATE_SUPPORT is not set
 # CLOCK_TIME_SUPPORT is not set
 # CLOCK_CRYSTAL_SUPPORT is not set
-# CLOCK_CPU_SUPPORT is not set
-# CLOCK_NTP_ADJUST_SUPPORT is not set
+# CLOCK_PERIODIC_SUPPORT is not set
 # DCF77_SUPPORT is not set
 # DEBUG_DCF77 is not set
 # NTP_SUPPORT is not set
+NTP_SERVER_IP="192.53.103.108"
+NTP_PORT=123
+NTP_QUERY_INTERVAL=1800
+# DEBUG_NTP is not set
 # NTPD_SUPPORT is not set
 # WHM_SUPPORT is not set
 # UPTIME_SUPPORT is not set
-# DEBUG_NTP_ADJUST is not set
 # CRON_SUPPORT is not set
 # CRON_DEFAULT_UTC is not set
 # CRON_EEPROM_SUPPORT is not set
@@ -745,6 +757,7 @@ DMX_FXSLOT_AMOUNT=4
 # DMX_FX_RANDOM is not set
 # DMX_FX_FIRE is not set
 # DMX_FX_WATER is not set
+# DMX_FX_RGB is not set
 # UDP_ECHO_NET_SUPPORT is not set
 # WOL_SUPPORT is not set
 # MOTD_SUPPORT is not set
@@ -788,6 +801,7 @@ STELLA_FADE_STEP_INIT=10
 STELLA_FADE_FUNCTION_INIT=stella_fade_func_0
 stella_fade_func_0=y
 # stella_fade_func_1 is not set
+# STELLA_USE_CIE1931 is not set
 # DEBUG_STELLA is not set
 # STARBURST_SUPPORT is not set
 # STARBURST_PCA9685 is not set
@@ -893,13 +907,6 @@ CONF_TIME2PRESS_POWER=40
 CONF_TIME2PRESS_POWERL=3
 # PROJECTOR_SANYO_Z700_SUPPORT is not set
 # FREQCOUNT_SUPPORT is not set
-FREQCOUNT_CHANNELS=1
-# FREQCOUNT_BOOT_ON is not set
-FREQCOUNT_AVERAGE=8
-# FREQCOUNT_NOSLOW_SUPPORT is not set
-# FREQCOUNT_DUTY_SUPPORT is not set
-# FREQCOUNT_MOVING_AVERAGE_SUPPORT is not set
-# FREQCOUNT_DEBUGGING is not set
 # TANKLEVEL_SUPPORT is not set
 TANKLEVEL_ADC_CHANNEL=0
 # TANKLEVEL_STARTUP is not set
@@ -921,10 +928,12 @@ IPV4_SUPPORT=y
 # AVRDUDE configuration
 #
 # _2232HIO is not set
+# _4232h is not set
 # _89isp is not set
 # abcmini is not set
 # alf is not set
 # arduino is not set
+# _arduino_ft232r is not set
 # atisp is not set
 # avr109 is not set
 # avr910 is not set
@@ -939,12 +948,15 @@ avrispmkII=y
 # blaster is not set
 # bsd is not set
 # buspirate is not set
+# buspirate_bb is not set
 # butterfly is not set
 # butterfly_mk is not set
+# bwmega is not set
 # c2n232i is not set
 # dapa is not set
 # dasa is not set
 # dasa3 is not set
+# diecimila is not set
 # dragon_dw is not set
 # dragon_hvsp is not set
 # dragon_isp is not set
@@ -954,6 +966,8 @@ avrispmkII=y
 # dt006 is not set
 # _ere_isp_avr is not set
 # _frank_stk200 is not set
+# ft232r is not set
+# ft245r is not set
 # futurlec is not set
 # jtag1 is not set
 # jtag1slow is not set
@@ -964,13 +978,22 @@ avrispmkII=y
 # jtag2isp is not set
 # jtag2pdi is not set
 # jtag2slow is not set
+# jtag3 is not set
+# jtag3dw is not set
+# jtag3isp is not set
+# jtag3pdi is not set
 # jtagkey is not set
 # jtagmkI is not set
 # jtagmkII is not set
 # jtagmkII_avr32 is not set
+# lm3s811 is not set
 # mib510 is not set
 # mkbutterfly is not set
+# nibobee is not set
+# _o_link is not set
+# openmoko is not set
 # pavr is not set
+# pickit2 is not set
 # picoweb is not set
 # _pony_stk200 is not set
 # ponyser is not set
@@ -986,6 +1009,7 @@ avrispmkII=y
 # stk600hvsp is not set
 # stk600pp is not set
 # usbasp is not set
+# _usbasp_clone is not set
 # usbtiny is not set
 # wiring is not set
 # xil is not set


### PR DESCRIPTION
This is a small patch to fully support RTU modbus.
 * Added 8e1 support (which is the default port config in RTU modbus standard) to usart.h;
 * Added modbus options (port baud and parity/bit settings) to the menuconfig;
 * Added RS485TE pin definition in netio.m4