### PR TITLE
Fix regression in portio for last port

### DIFF
--- a/core/portio/ecmd_simple.c
+++ b/core/portio/ecmd_simple.c
@@ -108,7 +108,7 @@ int16_t parse_cmd_io(char *cmd, char *output, uint16_t len)
     return ECMD_ERR_PARSE_ERROR;
   /* translate it to the portaddress */
   
-#ifndef PINA
+#ifdef PINA
   switch (value)
 #else
   switch (value + 1)


### PR DESCRIPTION
The last commit rewrote the logic for boards without PINA, but got it backwards.