### PR TITLE
Bluetooth stats are available only if debugging is active

### DIFF
--- a/hardware/radio/bluetooth/Makefile
+++ b/hardware/radio/bluetooth/Makefile
@@ -5,7 +5,7 @@ $(BLUETOOTH_SUPPORT)_SRC += \
 	hardware/radio/bluetooth/bt.c \
 	hardware/radio/bluetooth/bt_usart.c
 
-$(BLUETOOTH_ECMD)_ECMD_SRC += hardware/radio/bluetooth/bt_ecmd.c
+$(ARCH_AVR)_ECMD_SRC += hardware/radio/bluetooth/bt_ecmd.c
 
 ##############################################################################
 # generic fluff

--- a/hardware/radio/bluetooth/bt_ecmd.c
+++ b/hardware/radio/bluetooth/bt_ecmd.c
@@ -29,6 +29,7 @@
 #include "bt_usart.h"
 #include "bt_ecmd.h"
 
+#ifdef BLUETOOTH_ECMD_AT
 int16_t
 parse_cmd_bt_at(char *cmd, char *output, uint16_t len)
 {
@@ -41,7 +42,9 @@ parse_cmd_bt_at(char *cmd, char *output, uint16_t len)
 
   return ECMD_FINAL(bt_send_with_response(output, len, cmd));
 }
+#endif
 
+#if defined(DEBUG_BLUETOOTH)
 int16_t
 parse_cmd_bt_stats(char *cmd, char *output, uint16_t len)
 {
@@ -55,10 +58,15 @@ parse_cmd_bt_stats(char *cmd, char *output, uint16_t len)
                              bt_rx_count,
                              bt_tx_count));
 }
+#endif
 
 /*
   -- Ethersex META --
   block(Bluetooth SPP Module ([[Bluetooth]]))
-  ecmd_feature(bt_at, "bt cmd",,send an AT command)
-  ecmd_feature(bt_stats, "bt stats",,report statistics counter)
+  ecmd_ifdef(BLUETOOTH_ECMD_AT)
+    ecmd_feature(bt_at, "bt cmd",,send an AT command)
+  ecmd_endif()
+  ecmd_ifdef(DEBUG_BLUETOOTH)
+    ecmd_feature(bt_stats, "bt stats",,report statistics counter)
+  ecmd_endif()
 */

--- a/hardware/radio/bluetooth/bt_usart.c
+++ b/hardware/radio/bluetooth/bt_usart.c
@@ -32,7 +32,7 @@
 #ifdef ECMD_BLUETOOTH_SUPPORT
 bool bt_init_finished;
 #endif
-#ifdef BLUETOOTH_ECMD
+#if defined(ECMD_PARSER_SUPPORT) && defined(DEBUG_BLUETOOTH)
 uint16_t bt_rx_frameerror;
 uint16_t bt_rx_overflow;
 uint16_t bt_rx_parityerror;
@@ -97,7 +97,7 @@ ISR(usart(USART, _UDRE_vect))
   }
   usart(UDR) = tx_buff[tx_out];
   ROLLOVER(tx_out, NELEMS(tx_buff));
-#ifdef BLUETOOTH_ECMD
+#if defined(ECMD_PARSER_SUPPORT) && defined(DEBUG_BLUETOOTH)
   bt_tx_count++;
 #endif
 }
@@ -109,7 +109,7 @@ ISR(usart(USART, _RX_vect))
   uint8_t flags = usart(UCSR, A);
   if (flags & (_BV(usart(FE)) | _BV(usart(DOR)) | _BV(usart(UPE))))
   {
-#ifdef BLUETOOTH_ECMD
+#if defined(ECMD_PARSER_SUPPORT) && defined(DEBUG_BLUETOOTH)
     if (flags & _BV(usart(FE)))
       bt_rx_frameerror++;
     if (flags & _BV(usart(DOR)))
@@ -131,7 +131,7 @@ ISR(usart(USART, _RX_vect))
 
   rx_buff[rx_in] = usart(UDR);
   rx_in = i;
-#ifdef BLUETOOTH_ECMD
+#if defined(ECMD_PARSER_SUPPORT) && defined(DEBUG_BLUETOOTH)
   bt_rx_count++;
 #endif
 #ifdef ECMD_BLUETOOTH_SUPPORT

--- a/hardware/radio/bluetooth/config.in
+++ b/hardware/radio/bluetooth/config.in
@@ -11,9 +11,9 @@ if [ "$BLUETOOTH_SUPPORT" = y -o $USARTS -gt $USARTS_USED ]; then
 
     comment  "ECMD"
     if [ "$TEENSY_SUPPORT" = "y" ]; then
-      dep_bool 'AT Command Interface' BLUETOOTH_ECMD $BLUETOOTH_SUPPORT n
+      dep_bool 'AT Command Interface' BLUETOOTH_ECMD_AT $BLUETOOTH_SUPPORT n
     else
-      dep_bool 'AT Command Interface' BLUETOOTH_ECMD $BLUETOOTH_SUPPORT
+      dep_bool 'AT Command Interface' BLUETOOTH_ECMD_AT $BLUETOOTH_SUPPORT
     fi
 
     comment  "Debugging Flags"
@@ -22,5 +22,5 @@ if [ "$BLUETOOTH_SUPPORT" = y -o $USARTS -gt $USARTS_USED ]; then
   endmenu
 else
   define_bool BLUETOOTH_SUPPORT n
-  comment "BLUETOOTH not available. No free usart. ($USARTS_USED/$USARTS)"
+  comment "Bluetooth not available. No free usart. ($USARTS_USED/$USARTS)"
 fi


### PR DESCRIPTION
Compile in the ecmds for the bluetooth module independently from each other.