### PR TITLE
Fix jumps between application and bootloader section for ATmega256.

### DIFF
--- a/ethersex.c
+++ b/ethersex.c
@@ -240,6 +240,9 @@ main (void)
       ACSR &= ~_BV (ACIE);
 #endif
       cli();
+#ifdef _ATMEGA2560
+      EIND = 0x01;
+#endif
       jump_to_bootloader();
     }
 #endif
@@ -256,6 +259,9 @@ main (void)
     if (status.request_reset)
     {
       cli();
+#ifdef _ATMEGA2560
+      EIND = 0x00;
+#endif
       void (*reset) (void) = NULL;
       reset();
     }

--- a/scripts/meta_magic.m4
+++ b/scripts/meta_magic.m4
@@ -252,6 +252,9 @@ divert(eval(timer_divert_base`+'timer_divert_last` * 2 + 2'))
 #ifdef USE_WATCHDOG
       wdt_disable();
 #endif
+#ifdef _ATMEGA2560
+      EIND = 0x00;
+#endif
       void (*jump_to_application)(void) = NULL;
       jump_to_application();
     }

--- a/scripts/meta_magic_scheduler.m4
+++ b/scripts/meta_magic_scheduler.m4
@@ -465,6 +465,9 @@ void periodic_process(void)
 #ifdef USE_WATCHDOG
           wdt_disable();
 #endif
+#ifdef _ATMEGA2560
+          EIND = 0x00;
+#endif
           void (*jump_to_application)(void) = NULL;
           jump_to_application();
         }

--- a/services/tftp/tftp-bootload.c
+++ b/services/tftp/tftp-bootload.c
@@ -74,6 +74,8 @@ flash_page(uint32_t page, uint8_t * buf)
   for (i = 0; i < SPM_PAGESIZE; i++)
     if (buf[i] != __pgm_read_byte(page + i))
       goto commit_changes;
+
+  debug_putchar('-');
   return;                               /* no changes */
 
 commit_changes:
@@ -95,6 +97,8 @@ commit_changes:
 
     boot_rww_enable();                  /* reenable RWW-section again. */
   }
+
+  debug_putchar('+');
 }
 
 
@@ -246,8 +250,8 @@ tftp_handle_packet(void)
 #ifdef MBR_SUPPORT
             mbr_config.flashed = 1;
             write_mbr();
-            debug_putstr("\nApp flashed\n");
 #endif
+            debug_putstr("\nApp flashed\n");
           }
         }
         bootload_delay = 1;             /* give time to ack packet,


### PR DESCRIPTION
For jumps over 128k boundary extended indirect calls/jumps are used, which use the register EIND (see Atmel assembler description for details). Prepare EIND before the actual jump.