### PR TITLE
ONEWIRE_NAMING_SUPPORT is not available if TEENSY_SUPPORT is set

### DIFF
--- a/config.h
+++ b/config.h
@@ -1,5 +1,4 @@
 /*
- *
  * (c) by Alexander Neumann <alexander@bumpern.de>
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -115,18 +114,20 @@
 /* ADC Reference Flags */
 #define ADC_AREF	0
 #define ADC_AVCC	0x40
-#define ADC_1_1	    0x80
-#define ADC_2_56    0xC0
+#define ADC_1_1		0x80
+#define ADC_2_56	0xC0
 
 /* Figure out whether we need access to EEPROM:
-
    - ECMD without TEENSY (IP address configuration etc.)
    - BOOTP with to-EEPROM-feature
-   - STELLA with eeprom load/write support */
+   - STELLA with eeprom load/write support
+   - JABBER with configuration in eeprom
+   - ONEWIRE temperature sensors with names in eeprom */
 #if (defined(ECMD_PARSER_SUPPORT) && !defined(TEENSY_SUPPORT))   || \
     (defined(BOOTP_SUPPORT) && defined(BOOTP_TO_EEPROM_SUPPORT)) || \
     (defined(STELLA_SUPPORT) && !defined(TEENSY_SUPPORT))        || \
-    defined(JABBER_EEPROM_SUPPORT)
+    defined(JABBER_EEPROM_SUPPORT)                               || \
+    (defined(ONEWIRE_NAMING_SUPPORT) && !defined(TEENSY_SUPPORT))
 #  define EEPROM_SUPPORT 1
 #endif
 
@@ -148,7 +149,6 @@
     !defined(VFS_DC3840_SUPPORT)
 #  define VFS_TEENSY 1
 #endif
-
 
 
 #endif /* _CONFIG_H */

--- a/doc/Configure.help
+++ b/doc/Configure.help
@@ -2259,6 +2259,7 @@ Onewire naming support
 ONEWIRE_NAMING_SUPPORT
   Depends on:
    * Onewire support (ONEWIRE_SUPPORT)
+   * !NOT! TEENSY_SUPPORT
 
   Enable mapping of onewire rom addresses to names. Mapping table is stored in
   EEPROM and could be edited by ECMD commands:
@@ -3610,3 +3611,4 @@ BLUETOOTH_PIN
 
   The pairing pin code. Alphanumeric password. 16 characters max.
   Default: 1234
+

--- a/hardware/onewire/config.in
+++ b/hardware/onewire/config.in
@@ -9,7 +9,11 @@ dep_bool_menu "Onewire support" ONEWIRE_SUPPORT $ARCH_AVR
 	fi
 	int "Time between 1w-bus discoveries in 1s steps" OW_DISCOVER_INTERVAL 600
 	int "Time between polling in 1s steps" OW_POLLING_INTERVAL 30
-	dep_bool "Onewire naming support" ONEWIRE_NAMING_SUPPORT $ONEWIRE_DEVICES
+	if [ "$TEENSY_SUPPORT" = "n" ]; then
+		dep_bool "Onewire naming support" ONEWIRE_NAMING_SUPPORT $ONEWIRE_DEVICES
+	else
+		dep_bool "Onewire naming support" ONEWIRE_NAMING_SUPPORT $ONEWIRE_DEVICES n
+	fi
 	dep_bool "Hooks" ONEWIRE_HOOK_SUPPORT $ONEWIRE_DEVICES
 	int "Maximum sensor count" OW_SENSORS_COUNT 10
 	dep_bool "Onewire SNMP support" ONEWIRE_SNMP_SUPPORT $ONEWIRE_DS18XX_SUPPORT $SNMP_SUPPORT


### PR DESCRIPTION
TEENSY_SUPPORT disables EEPROM_SUPPORT, which is needed for storing the names.

Fixes #419 