### PR TITLE
Fix für Anzeige der Temperaturwerte für ds1631 bei Nachkomma-Werten

### DIFF
--- a/hardware/i2c/master/i2c_ds1631.c
+++ b/hardware/i2c/master/i2c_ds1631.c
@@ -55,7 +55,7 @@ end:
 	return ret;
 }
 
-uint16_t i2c_ds1631_read_temperature(const uint8_t chipaddress, int16_t *temp, int16_t *stemp)
+uint16_t i2c_ds1631_read_temperature(const uint8_t chipaddress, int16_t *temp, uint16_t *stemp)
 {
 	int16_t data[2];
 	uint16_t ret = 0xffff;
@@ -124,7 +124,7 @@ uint16_t i2c_ds1631_read_temperature(const uint8_t chipaddress, int16_t *temp, i
 	*stemp = ((data[0] >> 4) * 625);
 
 #ifdef DEBUG_I2C
-	debug_printf("I2C: i2c_ds1631_read_temp: temp: %d.%d\n",*temp,*stemp);
+	debug_printf("I2C: i2c_ds1631_read_temp: temp: %d.%04u\n",*temp,*stemp);
 #endif
 
 	ret = 0x0;

--- a/hardware/i2c/master/i2c_ds1631.h
+++ b/hardware/i2c/master/i2c_ds1631.h
@@ -27,6 +27,6 @@
 #define I2C_SLA_DS1631 0x48 // same as for LM75!
 
 uint16_t i2c_ds1631_start_stop(const uint8_t address, const uint8_t startstop); // startstop == 0 -> stop, all other -> start
-uint16_t i2c_ds1631_read_temperature(const uint8_t address, int16_t *temp, int16_t *stemp);
+uint16_t i2c_ds1631_read_temperature(const uint8_t address, int16_t *temp, uint16_t *stemp);
 
 #endif /* _I2C_DS1631_H */

--- a/hardware/i2c/master/i2c_ds1631_ecmd.c
+++ b/hardware/i2c/master/i2c_ds1631_ecmd.c
@@ -57,7 +57,7 @@ parse_cmd_i2c_ds1631_read_temperature(char *cmd, char *output, uint16_t len)
 {
   uint8_t adr;
   int16_t temp;
-  int16_t stemp;
+  uint16_t stemp;
   sscanf_P(cmd, PSTR("%hhu"), &adr);
   if (adr > 7)
     return ECMD_ERR_PARSE_ERROR;
@@ -68,9 +68,9 @@ parse_cmd_i2c_ds1631_read_temperature(char *cmd, char *output, uint16_t len)
 #ifdef ECMD_MIRROR_REQUEST
   return
     ECMD_FINAL(snprintf_P
-               (output, len, PSTR("ds1631 temp %d %d.%d"), adr, temp, stemp));
+               (output, len, PSTR("ds1631 temp %d %d.04%u"), adr, temp, stemp));
 #else
-  return ECMD_FINAL(snprintf_P(output, len, PSTR("%d.%d"), temp, stemp));
+  return ECMD_FINAL(snprintf_P(output, len, PSTR("%d.04%u"), temp, stemp));
 #endif
 }
 


### PR DESCRIPTION
Fix für die Ausgabe der Temperaturwerte für DS1631 bei Nachkomma-Werten kleiner 0.1 über ECMD. Hier fehlte eine 0 vor dem Nachkomma-Wert (z. B. alt: 0.625 ->
korrekt: 0.0625)

