### PR TITLE
fix ecmd via usart no echo

### DIFF
--- a/protocols/ecmd/via_usart/ecmd_usart.c
+++ b/protocols/ecmd/via_usart/ecmd_usart.c
@@ -121,9 +121,9 @@ ISR(usart(USART,_RX_vect))
     return ;
   }
 
-#ifndef ECMD_SERIAL_USART_NO_ECHO
+#ifndef ECMD_SERIAL_NO_ECHO
   usart(UDR) = data;
-#endif /* ECMD_SERIAL_USART_NO_ECHO */
+#endif /* ECMD_SERIAL_NO_ECHO */
 
   recv_buffer[recv_len++] = data;
 }

--- a/protocols/ecmd/via_usart/ecmd_usart.c
+++ b/protocols/ecmd/via_usart/ecmd_usart.c
@@ -114,10 +114,12 @@ ISR(usart(USART,_RX_vect))
   if (data == '\n' || data == '\r' || recv_len == sizeof(recv_buffer)) {
     recv_buffer[recv_len] = 0;
     must_parse = 1;
+#ifndef ECMD_SERIAL_NO_ECHO
     usart(UDR) = '\r';
     while (!(usart(UCSR,A) & _BV(usart(UDRE))));
     usart(UDR) = '\n';
     while (!(usart(UCSR,A) & _BV(usart(UDRE))));
+#endif /* ECMD_SERIAL_NO_ECHO */
     return ;
   }
 


### PR DESCRIPTION
Fix broken define in ecmd_usart

## Description

## Motivation and Context
Config option "No Echo" in protocol ecmd usart had no effect

## How Has This Been Tested?
Tested on my hardware and no echoed chars anymore

- [X ] My code follows the [code style of this project](http://www.ethersex.de/index.php/Contributing#Coding_Style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

