### PR TITLE
Allow watchdog in debug mode.

### DIFF
--- a/config.h
+++ b/config.h
@@ -70,7 +70,7 @@
 #include "pinning.c"
 
 /* use watchdog only when not debugging */
-#ifndef DEBUG
+#if !defined(DEBUG) || defined(DEBUG_USE_WATCHDOG)
 #   define USE_WATCHDOG
 #endif
 

--- a/config.in
+++ b/config.in
@@ -169,6 +169,7 @@ fi
 		elif [ "$SOFT_UART_SUPPORT" = y ]; then
 			int "Software-UART Baudrate" DEBUG_BAUDRATE 19200
 		fi
+		dep_bool 'Watchdog in debug mode' DEBUG_USE_WATCHDOG $DEBUG
 		comment  'Debugging Flags'
 		dep_bool 'Hooks' DEBUG_HOOK $DEBUG
 		dep_bool 'Reset Reason' DEBUG_RESET_REASON $DEBUG

--- a/doc/Configure.help
+++ b/doc/Configure.help
@@ -3612,3 +3612,10 @@ BLUETOOTH_PIN
   The pairing pin code. Alphanumeric password. 16 characters max.
   Default: 1234
 
+Watchdog in debug mode
+DEBUG_USE_WATCHDOG
+  Depends on: 
+   * Enable Debugging (DEBUG)
+
+  Activate the watchdog also in debug mode. Default is deactivated.
+


### PR DESCRIPTION
## Description
By default, the watchdog is disabled in debug mode. With this PR the behaviour is configurable.

## How Has This Been Tested?
Build and run Ethersex with and without watchdog in a Pollin Netio board. The changes have no side effect on other functionality.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the [code style of this project](http://www.ethersex.de/index.php/Contributing#Coding_Style).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

