### PR TITLE
Improve link-time-optmization

### DIFF
--- a/scripts/defaults.mk
+++ b/scripts/defaults.mk
@@ -88,6 +88,8 @@ CFLAGS += -funsigned-char
 CFLAGS += -funsigned-bitfields
 CFLAGS += -fpack-struct
 CFLAGS += -fshort-enums
+CFLAGS += -flto
+LDFLAGS += -flto
 
 ifneq ($(ARCH_HOST),y)
   CFLAGS += -mcall-prologues


### PR DESCRIPTION
## Description
By combining link time optimization from both GCC and Binutils one can reduce AVR FLASH usage by up to 5%.

## How Has This Been Tested?
I have been using this for the past months in production on both Pollin's Netio and several Arduino boards.

Without ```-flto -fwhole-program```
```
Program (.text + .data) : 42454 bytes
Data (.data + .bss)     : 4383 bytes
```
With ```-flto -fwhole-program```
```
Program (.text + .data) : 41152 bytes
Data (.data + .bss)     : 4371 bytes
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the [code style of this project](http://www.ethersex.de/index.php/Contributing#Coding_Style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

