### PR TITLE
Fix for #486

### DIFF
--- a/protocols/uip/uip.c
+++ b/protocols/uip/uip.c
@@ -1829,7 +1829,8 @@ ip_check_end:
     goto drop;
 
   case UIP_TIME_WAIT:
-    goto tcp_send_ack;
+    //goto tcp_send_ack;
+    goto drop;
 
   case UIP_CLOSING:
     if(uip_flags & UIP_ACKDATA) {


### PR DESCRIPTION
RFC793: do not send ACKs in TIME_WAIT state

<!--- Provide a general summary of your changes in the Title above -->

## Description
UIP as well as Contiki sends ACK in TCP state TIME_WAIT. According to RFC793 incoming packets should be silently dropped.

## Motivation and Context
Fix for issue #486 .
I opened an issue against Contiki, but no fix so far (https://github.com/contiki-os/contiki/issues/2160)

## How Has This Been Tested?
Author of issue #486 has testet this in his setup.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style of this project](http://www.ethersex.de/index.php/Contributing#Coding_Style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

