### PR TITLE
Fix c6 mqtt example to include 1wire rom_code in topic

### DIFF
--- a/control6/examples/mqtt.src
+++ b/control6/examples/mqtt.src
@@ -174,15 +174,15 @@ c6_poll_cb(void)
 #else
       {
         snprintf_P(name, sizeof(name),
-                 PSTR("%02x%02x%02x%02x%02x%02x%02x%02x"),
-                 ow_sensors[j].ow_rom_code.bytewise[0],
-                 ow_sensors[j].ow_rom_code.bytewise[1],
-                 ow_sensors[j].ow_rom_code.bytewise[2],
-                 ow_sensors[j].ow_rom_code.bytewise[3],
-                 ow_sensors[j].ow_rom_code.bytewise[4],
-                 ow_sensors[j].ow_rom_code.bytewise[5],
-                 ow_sensors[j].ow_rom_code.bytewise[6],
-                 ow_sensors[j].ow_rom_code.bytewise[7]);
+                   PSTR("%02x%02x%02x%02x%02x%02x%02x%02x"),
+                   ow_sensors[j].ow_rom_code.bytewise[0],
+                   ow_sensors[j].ow_rom_code.bytewise[1],
+                   ow_sensors[j].ow_rom_code.bytewise[2],
+                   ow_sensors[j].ow_rom_code.bytewise[3],
+                   ow_sensors[j].ow_rom_code.bytewise[4],
+                   ow_sensors[j].ow_rom_code.bytewise[5],
+                   ow_sensors[j].ow_rom_code.bytewise[6],
+                   ow_sensors[j].ow_rom_code.bytewise[7]);
       }
 #endif
       name[NAME_LENGTH - 1] = '\0';

--- a/control6/examples/mqtt.src
+++ b/control6/examples/mqtt.src
@@ -173,7 +173,7 @@ c6_poll_cb(void)
       else
 #else
       {
-        snprintf(name, sizeof(name),
+        snprintf_P(name, sizeof(name),
                  PSTR("%02x%02x%02x%02x%02x%02x%02x%02x"),
                  ow_sensors[j].ow_rom_code.bytewise[0],
                  ow_sensors[j].ow_rom_code.bytewise[1],

--- a/control6/examples/mqtt.src
+++ b/control6/examples/mqtt.src
@@ -78,7 +78,7 @@
 #endif
 
 /* Sensors */
-#define C6_SENSOR_PUBLISH_FORMAT   C6_MQTT_TOPIC "/%s/%S"
+#define C6_SENSOR_PUBLISH_FORMAT   C6_MQTT_TOPIC "/sensor/%s/%S"
 #define DATA_LENGTH                8
 #ifdef ONEWIRE_NAMING_SUPPORT
 #define NAME_LENGTH                (17 > OW_NAME_LENGTH ? 17 : OW_NAME_LENGTH)


### PR DESCRIPTION
When ONEWIRE_NAMING_SUPPORT is not defined, example should use ow_rom_code for topic name, which wasn't the case.

## Description
using snprintf_P instead of snprintf, as it is also done in other parts of the sources (e.g. onewire_ecmd.c)

## Motivation and Context
No open issue - reported/discussed in IRC

## How Has This Been Tested?
Tested using ethersex and a DS18B20, diagnostic on Wireshark and Node-RED, to see the topic name changed from `<clientid>/<unprintable chars>/temp` to `<clientid>/<ow_rom_code>/temp`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the [code style of this project](http://www.ethersex.de/index.php/Contributing#Coding_Style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

