### PR TITLE
Feature/c6mqtt fix named pin support

### DIFF
--- a/control6/examples/mqtt.src
+++ b/control6/examples/mqtt.src
@@ -113,7 +113,6 @@ static void
 c6_poll_cb(void)
 {
   uint8_t len;
-  uint8_t topic_len;
   char buf[DATA_LENGTH];
   char topic[TOPIC_LENGTH];
   char name[NAME_LENGTH];
@@ -132,9 +131,7 @@ c6_poll_cb(void)
     {
       snprintf_P(name, sizeof(name), dht_sensors[i].name);
       name[NAME_LENGTH - 1] = '\0';
-      topic_len = snprintf_P(topic, TOPIC_LENGTH,
-                             PSTR(C6_SENSOR_PUBLISH_FORMAT),
-                             name, PSTR("temp"));
+      snprintf_P(topic, TOPIC_LENGTH, PSTR(C6_SENSOR_PUBLISH_FORMAT), name, PSTR("temp"));
       topic[TOPIC_LENGTH - 1] = '\0';
       len = itoa_fixedpoint(dht_sensors[i].temp, 1, buf, sizeof(buf));
 
@@ -147,9 +144,7 @@ c6_poll_cb(void)
     {
       snprintf_P(name, sizeof(name), dht_sensors[i].name);
       name[NAME_LENGTH - 1] = '\0';
-      topic_len = snprintf_P(topic, TOPIC_LENGTH,
-                             PSTR(C6_SENSOR_PUBLISH_FORMAT),
-                             name, PSTR("humid"));
+      snprintf_P(topic, TOPIC_LENGTH, PSTR(C6_SENSOR_PUBLISH_FORMAT), name, PSTR("humid"));
       topic[TOPIC_LENGTH - 1] = '\0';
       len = itoa_fixedpoint(dht_sensors[i].humid, 1, buf, sizeof(buf));
 
@@ -190,9 +185,7 @@ c6_poll_cb(void)
       }
 #endif
       name[NAME_LENGTH - 1] = '\0';
-      topic_len = snprintf_P(topic, TOPIC_LENGTH,
-                             PSTR(C6_SENSOR_PUBLISH_FORMAT),
-                             name, PSTR("temp"));
+      snprintf_P(topic, TOPIC_LENGTH, PSTR(C6_SENSOR_PUBLISH_FORMAT), name, PSTR("temp"));
       topic[TOPIC_LENGTH - 1] = '\0';
       len = itoa_fixedpoint(ow_sensors[j].temp.val,
                             ow_sensors[j].temp.twodigits + 1,

--- a/control6/examples/mqtt.src
+++ b/control6/examples/mqtt.src
@@ -35,7 +35,7 @@
   Optional:
    DHT_SUPPORT
    ONEWIRE_DS18XX_SUPPORT
-   NAMED_PIN_SUPPORT
+   NAMED_PIN_SUPPORT, PORTIO_SUPPORT
 */
 
 #include <stdint.h>
@@ -56,9 +56,13 @@
 #include "hardware/onewire/onewire.h"
 #endif
 #ifdef NAMED_PIN_SUPPORT
+#ifndef PORTIO_SUPPORT
+#error MQTT example needs PORTIO_SUPPORT (I/O abstraction model: full featured) when using NAMED_PIN_SUPPORT
+#else
 #include "core/bit-macros.h"
 #include "core/portio/portio.h"
 #include "core/portio/named_pin.h"
+#endif
 #endif
 #include "protocols/mqtt/mqtt.h"
 #include "core/debug.h"
@@ -213,7 +217,7 @@ c6_poll_cb(void)
 }
 #endif /* DHT_SUPPORT || ONEWIRE_DS18XX_SUPPORT */
 
-#ifdef NAMED_PIN_SUPPORT
+#if defined(NAMED_PIN_SUPPORT) && defined(PORTIO_SUPPORT)
 static void
 c6_publish_cb(const char *topic, uint16_t topic_length,
               const void *payload, uint16_t payload_length)
@@ -287,7 +291,7 @@ out:
   if (strvalue != NULL)
     free(strvalue);
 }
-#endif /* NAMED_PIN_SUPPORT */
+#endif /* NAMED_PIN_SUPPORT && PORTIO_SUPPORT */
 
 static void
 c6_connack_cb(void)
@@ -299,7 +303,7 @@ c6_connack_cb(void)
   ow_last_values = calloc(OW_SENSORS_COUNT, sizeof(ow_temp_t));
 #endif
 
-#ifdef NAMED_PIN_SUPPORT
+#if defined(NAMED_PIN_SUPPORT) && defined(PORTIO_SUPPORT)
   const char *topic = PSTR(C6_NAMED_PIN_SUBSCRIBE);
   C6DEBUG("subscribe %S", topic);
   if (mqtt_construct_subscribe_packet_P(topic) == false)
@@ -328,7 +332,7 @@ static const mqtt_callback_config_t c6_mqtt_callback_config PROGMEM = {
   .poll_callback = NULL,
 #endif
   .close_callback = c6_close_cb,
-#ifdef NAMED_PIN_SUPPORT
+#if defined(NAMED_PIN_SUPPORT) && defined(PORTIO_SUPPORT)
   .publish_callback = c6_publish_cb
 #else
   .publish_callback = NULL


### PR DESCRIPTION
## Description
### Add PORTIO_SUPPORT to control6 mqtt example

Without PORTIO_SUPPORT, exampe can't compile, because portio_pincfg struct (defined by core/portio/named_pin.h) doesn't exist.
So introduce a compile error, when NAMED_PIN_SUPPORT without PORTIO_SUPPORT is enabled (I/O abstraction model set to "simple" which is the default)

### Fix unused variable topic_len warning for c6 mqtt example
self-explaining ;)

## Motivation and Context
see above

## How Has This Been Tested?
Test driven development: Start with wrong configuration, see it fail.
Make compile output a proper error message
Fix configuration an see it complile (and run) properly

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style of this project](http://www.ethersex.de/index.php/Contributing#Coding_Style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

