### PR TITLE
Allow static IP configuration even when in DHCP mode

### DIFF
--- a/config.in
+++ b/config.in
@@ -257,6 +257,9 @@ mainmenu_option next_comment
 		dep_bool "DHCP support" DHCP_SUPPORT "n"
 	else
 		dep_bool "DHCP support" DHCP_SUPPORT $BROADCAST_SUPPORT $ENC28J60_SUPPORT $IPV4_SUPPORT
+		if [ "$DHCP_SUPPORT" = "y" ]; then
+			dep_bool "  Allow also static configuration" DHCP_SUPPORT_STATIC $DHCP_SUPPORT
+		fi
 	fi
 
 	comment "Tunneling protocols"

--- a/hardware/ethernet/ethernet_config.c
+++ b/hardware/ethernet/ethernet_config.c
@@ -48,8 +48,15 @@ network_config_load (void)
 #endif
 #endif
 
-#if (defined(IPV4_SUPPORT) && !defined(BOOTP_SUPPORT) && !defined(DHCP_SUPPORT)) || defined(IPV6_STATIC_SUPPORT)
+#if (defined(IPV4_SUPPORT) && !defined(BOOTP_SUPPORT) && !defined(DHCP_SUPPORT)) || \
+    (defined(IPV4_SUPPORT) && defined(DHCP_SUPPORT) && defined(DHCP_SUPPORT_STATIC)) || \
+     defined(IPV6_STATIC_SUPPORT)
   uip_ipaddr_t ip;
+
+#ifdef DHCP_SUPPORT_STATIC
+  uip_ipaddr_t emptyIp;
+  uip_ipaddr(&emptyIp, 0, 0, 0, 0);
+#endif
 
   /* Configure the IP address. */
 #ifdef EEPROM_SUPPORT
@@ -57,6 +64,10 @@ network_config_load (void)
   eeprom_restore_ip (ip, &ip);
 #else
   set_CONF_ETHERSEX_IP (&ip);
+#endif
+
+#ifdef DHCP_SUPPORT_STATIC
+  if (!uip_ipaddr_cmp(&ip, &emptyIp))
 #endif
   uip_sethostaddr (&ip);
 
@@ -73,6 +84,9 @@ network_config_load (void)
 #else
   set_CONF_ETHERSEX_IP4_NETMASK (&ip);
 #endif
+#ifdef DHCP_SUPPORT_STATIC
+  if (!uip_ipaddr_cmp(&ip, &emptyIp))
+#endif
   uip_setnetmask (&ip);
 #endif /* IPV4_SUPPORT */
 
@@ -82,6 +96,9 @@ network_config_load (void)
   eeprom_restore_ip (gateway, &ip);
 #else
   set_CONF_ETHERSEX_GATEWAY (&ip);
+#endif
+#ifdef DHCP_SUPPORT_STATIC
+  if (!uip_ipaddr_cmp(&ip, &emptyIp))
 #endif
   uip_setdraddr (&ip);
 #endif /* No autoconfiguration. */


### PR DESCRIPTION
If the IP is set to 0.0.0.0 dhcp mode will be used otherwise the given IP is applied.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
If the code is compiled with DHCP_SUPPORT it was no more possible to set a static ip/netmask/gw. With this patch a ip/netmask/gw enables a static assignment while a value of 0.0.0.0 enables the dhcp mode.

## How Has This Been Tested?
Tested several combinations of static and dynamic assignments.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the [code style of this project](http://www.ethersex.de/index.php/Contributing#Coding_Style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

