### PR TITLE
firmware hangs while initializing named pins on an HC595 port extension

### DIFF
--- a/control6/examples/mqtt.src
+++ b/control6/examples/mqtt.src
@@ -174,15 +174,15 @@ c6_poll_cb(void)
 #else
       {
         snprintf_P(name, sizeof(name),
-                 PSTR("%02x%02x%02x%02x%02x%02x%02x%02x"),
-                 ow_sensors[j].ow_rom_code.bytewise[0],
-                 ow_sensors[j].ow_rom_code.bytewise[1],
-                 ow_sensors[j].ow_rom_code.bytewise[2],
-                 ow_sensors[j].ow_rom_code.bytewise[3],
-                 ow_sensors[j].ow_rom_code.bytewise[4],
-                 ow_sensors[j].ow_rom_code.bytewise[5],
-                 ow_sensors[j].ow_rom_code.bytewise[6],
-                 ow_sensors[j].ow_rom_code.bytewise[7]);
+                   PSTR("%02x%02x%02x%02x%02x%02x%02x%02x"),
+                   ow_sensors[j].ow_rom_code.bytewise[0],
+                   ow_sensors[j].ow_rom_code.bytewise[1],
+                   ow_sensors[j].ow_rom_code.bytewise[2],
+                   ow_sensors[j].ow_rom_code.bytewise[3],
+                   ow_sensors[j].ow_rom_code.bytewise[4],
+                   ow_sensors[j].ow_rom_code.bytewise[5],
+                   ow_sensors[j].ow_rom_code.bytewise[6],
+                   ow_sensors[j].ow_rom_code.bytewise[7]);
       }
 #endif
       name[NAME_LENGTH - 1] = '\0';

--- a/control6/examples/mqtt.src
+++ b/control6/examples/mqtt.src
@@ -173,7 +173,7 @@ c6_poll_cb(void)
       else
 #else
       {
-        snprintf(name, sizeof(name),
+        snprintf_P(name, sizeof(name),
                  PSTR("%02x%02x%02x%02x%02x%02x%02x%02x"),
                  ow_sensors[j].ow_rom_code.bytewise[0],
                  ow_sensors[j].ow_rom_code.bytewise[1],

--- a/control6/examples/mqtt.src
+++ b/control6/examples/mqtt.src
@@ -1,0 +1,353 @@
+/*
+ * Copyright (c) 2018 by Erik Kunze <ethersex@erik-kunze.de>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+/*
+  MQTT Example
+
+  - sends values auf DHT and 1w sensors
+    /host/sensor/<sensors_name>/temp
+    /host/sensor/<sensors_name>/humid
+
+  - control named pins (in and out)
+    /host/pin/<named_pin>
+     out: payload "0" | "1"
+     in : no payload
+
+  Requires:
+   MQTT_SUPPORT
+
+  Optional:
+   DHT_SUPPORT
+   ONEWIRE_DS18XX_SUPPORT
+   NAMED_PIN_SUPPORT
+*/
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+
+#include "config.h"
+#ifndef MQTT_SUPPORT
+#error Please define mqtt support
+#endif
+#include "core/util/fixedpoint.h"
+#ifdef DHT_SUPPORT
+#include "hardware/dht/dht.h"
+#endif
+#ifdef ONEWIRE_DS18XX_SUPPORT
+#include "hardware/onewire/onewire.h"
+#endif
+#ifdef NAMED_PIN_SUPPORT
+#include "core/bit-macros.h"
+#include "core/portio/portio.h"
+#include "core/portio/named_pin.h"
+#endif
+#include "protocols/mqtt/mqtt.h"
+#include "core/debug.h"
+
+//#ifdef MQTT_DEBUG
+#ifdef DEBUG
+#define C6DEBUG(s, ...) debug_printf("MQTT: " s "\n", ## __VA_ARGS__)
+#else
+#define C6DEBUG(...)    do { } while(0)
+#endif
+
+/* Prefix */
+#ifdef MQTT_STATIC_CONF
+#define C6_MQTT_TOPIC              MQTT_STATIC_CONF_CLIENTID
+#else
+#define C6_MQTT_TOPIC              CONF_HOSTNAME
+#endif
+
+/* Sensors */
+#define C6_SENSOR_PUBLISH_FORMAT   C6_MQTT_TOPIC "/%s/%S"
+#define DATA_LENGTH                8
+#ifdef ONEWIRE_NAMING_SUPPORT
+#define NAME_LENGTH                (17 > OW_NAME_LENGTH ? 17 : OW_NAME_LENGTH)
+#else
+#define NAME_LENGTH                17
+#endif
+#define TOPIC_LENGTH               (sizeof(C6_SENSOR_PUBLISH_FORMAT) + NAME_LENGTH +  5)
+
+/* Named pin */
+#define C6_NAMED_PIN_TOPIC         C6_MQTT_TOPIC "/pin/"
+#define C6_NAMED_PIN_SUBSCRIBE     C6_NAMED_PIN_TOPIC "#"
+
+
+#if defined(DHT_SUPPORT) || defined(ONEWIRE_DS18XX_SUPPORT)
+#ifdef DHT_SUPPORT
+typedef struct
+{
+  int16_t temp;
+  int16_t humid;
+} dht_values_t;
+static dht_values_t *dht_last_values;
+#endif
+#ifdef ONEWIRE_DS18XX_SUPPORT
+static ow_temp_t *ow_last_values;
+#endif
+
+static void
+c6_poll_cb(void)
+{
+  uint8_t len;
+  uint8_t topic_len;
+  char buf[DATA_LENGTH];
+  char topic[TOPIC_LENGTH];
+  char name[NAME_LENGTH];
+
+#ifdef DHT_SUPPORT
+  static uint8_t i = 0;
+#endif
+#ifdef ONEWIRE_DS18XX_SUPPORT
+  static uint8_t j = 0;
+#endif
+
+#ifdef DHT_SUPPORT
+  if (i < dht_sensors_count)
+  {
+    if (dht_sensors[i].temp != dht_last_values[i].temp)
+    {
+      snprintf_P(name, sizeof(name), dht_sensors[i].name);
+      name[NAME_LENGTH - 1] = '\0';
+      topic_len = snprintf_P(topic, TOPIC_LENGTH,
+                             PSTR(C6_SENSOR_PUBLISH_FORMAT),
+                             name, PSTR("temp"));
+      topic[TOPIC_LENGTH - 1] = '\0';
+      len = itoa_fixedpoint(dht_sensors[i].temp, 1, buf, sizeof(buf));
+
+      C6DEBUG("poll: %s=%s", topic, buf);
+      mqtt_construct_publish_packet(topic, buf, len, false);
+
+      dht_last_values[i].temp = dht_sensors[i].temp;
+    }
+    if (dht_sensors[i].humid != dht_last_values[i].humid)
+    {
+      snprintf_P(name, sizeof(name), dht_sensors[i].name);
+      name[NAME_LENGTH - 1] = '\0';
+      topic_len = snprintf_P(topic, TOPIC_LENGTH,
+                             PSTR(C6_SENSOR_PUBLISH_FORMAT),
+                             name, PSTR("humid"));
+      topic[TOPIC_LENGTH - 1] = '\0';
+      len = itoa_fixedpoint(dht_sensors[i].humid, 1, buf, sizeof(buf));
+
+      C6DEBUG("poll %s=%s", topic, buf);
+      mqtt_construct_publish_packet(topic, buf, len, false);
+
+      dht_last_values[i].humid = dht_sensors[i].humid;
+    }
+    i++;
+    return;
+  }
+#endif
+#ifdef ONEWIRE_DS18XX_SUPPORT
+  if (j < OW_SENSORS_COUNT)
+  {
+    if (ow_sensors[j].present == 1 &&
+        ow_sensors[j].conv_error == 0 &&
+        ow_sensors[j].temp.val != ow_last_values[j].val)
+    {
+#ifdef ONEWIRE_NAMING_SUPPORT
+      if (ow_sensors[j].named == 1)
+      {
+        snprintf(name, sizeof(name), ow_sensors[j].name);
+      }
+      else
+#else
+      {
+        snprintf(name, sizeof(name),
+                 PSTR("%02x%02x%02x%02x%02x%02x%02x%02x"),
+                 ow_sensors[j].ow_rom_code.bytewise[0],
+                 ow_sensors[j].ow_rom_code.bytewise[1],
+                 ow_sensors[j].ow_rom_code.bytewise[2],
+                 ow_sensors[j].ow_rom_code.bytewise[3],
+                 ow_sensors[j].ow_rom_code.bytewise[4],
+                 ow_sensors[j].ow_rom_code.bytewise[5],
+                 ow_sensors[j].ow_rom_code.bytewise[6],
+                 ow_sensors[j].ow_rom_code.bytewise[7]);
+      }
+#endif
+      name[NAME_LENGTH - 1] = '\0';
+      topic_len = snprintf_P(topic, TOPIC_LENGTH,
+                             PSTR(C6_SENSOR_PUBLISH_FORMAT),
+                             name, PSTR("temp"));
+      topic[TOPIC_LENGTH - 1] = '\0';
+      len = itoa_fixedpoint(ow_sensors[j].temp.val,
+                            ow_sensors[j].temp.twodigits + 1,
+                            buf, sizeof(buf));
+
+      C6DEBUG("poll %s=%s", topic, buf);
+      mqtt_construct_publish_packet(topic, buf, len, false);
+
+      ow_last_values[j] = ow_sensors[j].temp;
+    }
+    j++;
+    return;
+  }
+#endif
+
+#ifdef DHT_SUPPORT
+  i = 0;
+#endif
+#ifdef ONEWIRE_DS18XX_SUPPORT
+  j = 0;
+#endif
+}
+#endif /* DHT_SUPPORT || ONEWIRE_DS18XX_SUPPORT */
+
+#ifdef NAMED_PIN_SUPPORT
+static void
+c6_publish_cb(const char *topic, uint16_t topic_length,
+              const void *payload, uint16_t payload_length)
+{
+  char *strvalue = malloc(topic_length + 1);
+  if (strvalue == NULL)
+    goto out;
+
+  memcpy(strvalue, topic, topic_length);
+  strvalue[topic_length] = '\0';
+  C6DEBUG("publish %s", strvalue);
+
+  if (strncmp_P(topic, PSTR(C6_NAMED_PIN_TOPIC), sizeof(C6_NAMED_PIN_TOPIC) - 1) == 0)
+  {
+    const char *name = strvalue + sizeof(C6_NAMED_PIN_TOPIC) - 1;
+    C6DEBUG("pin %s", name);
+
+    uint8_t pincfg = named_pin_by_name(name);
+    if (pincfg == 255)
+    {
+       C6DEBUG("...unknown");
+       goto out;
+    }
+
+    uint8_t port = pgm_read_byte(&portio_pincfg[pincfg].port);
+    uint8_t pin = pgm_read_byte(&portio_pincfg[pincfg].pin);
+    uint8_t active_high = pgm_read_byte(&portio_pincfg[pincfg].active_high);
+
+    if (payload_length > 0) /* Write */
+    {
+      /* Set only if it is output */
+      if (vport[port].read_ddr(port) & _BV(pin))
+      {
+        free(strvalue);
+        strvalue = malloc(payload_length + 1);
+        if (strvalue == NULL)
+          goto out;
+        memcpy(strvalue, payload, payload_length);
+        strvalue[payload_length] = 0;
+        C6DEBUG("out %s", strvalue);
+
+        uint8_t on;
+        if (sscanf_P(strvalue, PSTR("%hhd"), &on) != 1)
+          goto out;
+
+        uint8_t val = vport[port].read_port(port);
+        if (XOR_LOG(on, !active_high))
+          val |= _BV(pin);
+        else
+          val &= ~_BV(pin);
+        vport[port].write_port(port, val);
+      }
+    }
+    else /* Read */
+    {
+      uint8_t val = XOR_LOG(vport[port].read_pin(port) & _BV(pin), !(active_high));
+      uint8_t buf[2];
+      buf[0] = '0' + val;
+      buf[1] = '\0';
+      C6DEBUG("in %c", buf[0]);
+
+      mqtt_construct_publish_packet(topic, buf, 1, false);
+    }
+  }
+  else
+  {
+    C6DEBUG("parse error");
+  }
+
+out:
+  if (strvalue != NULL)
+    free(strvalue);
+}
+#endif /* NAMED_PIN_SUPPORT */
+
+static void
+c6_connack_cb(void)
+{
+#ifdef DHT_SUPPORT
+  dht_last_values = calloc(dht_sensors_count, sizeof(dht_values_t));
+#endif
+#ifdef ONEWIRE_DS18XX_SUPPORT
+  ow_last_values = calloc(OW_SENSORS_COUNT, sizeof(ow_temp_t));
+#endif
+
+#ifdef NAMED_PIN_SUPPORT
+  const char *topic = PSTR(C6_NAMED_PIN_SUBSCRIBE);
+  C6DEBUG("subscribe %S", topic);
+  if (mqtt_construct_subscribe_packet_P(topic) == false)
+  {
+    C6DEBUG("...failed");
+  }
+#endif
+}
+
+static void
+c6_close_cb(void)
+{
+#ifdef DHT_SUPPORT
+  free(dht_last_values);
+#endif
+#ifdef ONEWIRE_DS18XX_SUPPORT
+  free(ow_last_values);
+#endif
+}
+
+static const mqtt_callback_config_t c6_mqtt_callback_config PROGMEM = {
+  .connack_callback = c6_connack_cb,
+#if defined(DHT_SUPPORT) || defined(ONEWIRE_DS18XX_SUPPORT)
+  .poll_callback = c6_poll_cb,
+#else
+  .poll_callback = NULL,
+#endif
+  .close_callback = c6_close_cb,
+#ifdef NAMED_PIN_SUPPORT
+  .publish_callback = c6_publish_cb
+#else
+  .publish_callback = NULL
+#endif
+};
+
+static void
+c6_mqtt_init(void)
+{
+  mqtt_register_callback(&c6_mqtt_callback_config);
+}
+
+
+CONTROL_START
+
+  ON STARTUP DO
+    c6_mqtt_init();
+  END
+
+CONTROL_END
+
+dnl EOF

--- a/control6/examples/mqtt.src
+++ b/control6/examples/mqtt.src
@@ -78,7 +78,7 @@
 #endif
 
 /* Sensors */
-#define C6_SENSOR_PUBLISH_FORMAT   C6_MQTT_TOPIC "/%s/%S"
+#define C6_SENSOR_PUBLISH_FORMAT   C6_MQTT_TOPIC "/sensor/%s/%S"
 #define DATA_LENGTH                8
 #ifdef ONEWIRE_NAMING_SUPPORT
 #define NAME_LENGTH                (17 > OW_NAME_LENGTH ? 17 : OW_NAME_LENGTH)

--- a/control6/examples/mqtt.src
+++ b/control6/examples/mqtt.src
@@ -216,7 +216,8 @@ c6_poll_cb(void)
 #ifdef NAMED_PIN_SUPPORT
 static void
 c6_publish_cb(const char *topic, uint16_t topic_length,
-              const void *payload, uint16_t payload_length)
+              const void *payload, uint16_t payload_length,
+              bool retained)
 {
   char *strvalue = malloc(topic_length + 1);
   if (strvalue == NULL)

--- a/core/portio/portio.c
+++ b/core/portio/portio.c
@@ -60,6 +60,10 @@ void portio_init(void)
     memset(&vport[i], 0, sizeof(virtual_port_t));
     vport[i].write_port = hc595_write_port;
     vport[i].read_port = hc595_read_port;
+    vport[i].read_ddr = hc595_read_ddr;
+    vport[i].write_ddr = hc595_write_ddr;
+    vport[i].read_pin = hc595_read_port;
+    vport[i].mask = 0xFF ;
   }
 #endif
 
@@ -71,39 +75,39 @@ void portio_init(void)
 #   ifdef NAMED_PIN_SUPPORT
     named_pin_init();
 #   endif
-} 
+}
 
 
-static uint8_t 
-portio_read_port(uint8_t port) 
+static uint8_t
+portio_read_port(uint8_t port)
 {
   return ACCESS_IO(ports[port]);
 }
 
-static uint8_t 
-portio_write_port(uint8_t port, uint8_t data) 
+static uint8_t
+portio_write_port(uint8_t port, uint8_t data)
 {
   ACCESS_IO(ports[port]) = ((uint8_t)ACCESS_IO(ports[port]) & vport[port].mask) |
                         ((uint8_t)data & ~vport[port].mask);
   return 0;
 }
 
-static uint8_t 
-portio_read_ddr(uint8_t port) 
+static uint8_t
+portio_read_ddr(uint8_t port)
 {
   return ACCESS_IO(ddrs[port]);
 }
 
-static uint8_t 
-portio_write_ddr(uint8_t port, uint8_t data) 
+static uint8_t
+portio_write_ddr(uint8_t port, uint8_t data)
 {
   ACCESS_IO(ddrs[port]) = ((uint8_t)ACCESS_IO(ddrs[port]) & vport[port].mask) |
                        ((uint8_t)data & ~vport[port].mask);
   return 0;
 }
 
-static uint8_t 
-portio_read_pin(uint8_t port) 
+static uint8_t
+portio_read_pin(uint8_t port)
 {
   return ACCESS_IO(pins[port]);
 }

--- a/doc/Configure.help
+++ b/doc/Configure.help
@@ -3628,3 +3628,12 @@ I2C_BH1750_SUPPORT
   Includes conversion routines to get visible light in lux.
   Datasheet http://www.rohm.com/
 
+BH1750 automatic resolution adjustment
+I2C_BH1750_AUTO_RESOLUTION
+  Depends on:
+   * I2C BH1750 light sensor (I2C_BH1750_SUPPORT)
+   * (not TEENSY_SUPPORT)
+
+  Enable automatic resolution adjustment according to the brightness.
+  Increases measurement time and code size noticeably.
+

--- a/doc/Configure.help
+++ b/doc/Configure.help
@@ -3619,3 +3619,12 @@ DEBUG_USE_WATCHDOG
 
   Activate the watchdog also in debug mode. Default is deactivated.
 
+I2C BH1750  light sensor
+I2C_BH1750_SUPPORT
+  Depends on:
+   * I2C master (I2C_MASTER_SUPPORT)
+
+  Support for the BH1750 digital light sensor via I2C.
+  Includes conversion routines to get visible light in lux.
+  Datasheet http://www.rohm.com/
+

--- a/hardware/i2c/master/Makefile
+++ b/hardware/i2c/master/Makefile
@@ -35,6 +35,9 @@ $(I2C_TSL2561_SUPPORT)_ECMD_SRC += hardware/i2c/master/i2c_tsl2561_ecmd.c
 $(I2C_BMP085_SUPPORT)_SRC += hardware/i2c/master/i2c_bmp085.c
 $(I2C_BMP085_SUPPORT)_ECMD_SRC += hardware/i2c/master/i2c_bmp085_ecmd.c
 
+$(I2C_BMP280_SUPPORT)_SRC += hardware/i2c/master/i2c_bmp280.c
+$(I2C_BMP280_SUPPORT)_ECMD_SRC += hardware/i2c/master/i2c_bmp280_ecmd.c
+
 $(I2C_PCA9531_SUPPORT)_SRC += hardware/i2c/master/i2c_pca9531.c
 $(I2C_PCA9531_SUPPORT)_ECMD_SRC += hardware/i2c/master/i2c_pca9531_ecmd.c
 

--- a/hardware/i2c/master/Makefile
+++ b/hardware/i2c/master/Makefile
@@ -23,6 +23,9 @@ $(I2C_PCF8583_SUPPORT)_SRC += hardware/i2c/master/i2c_pcf8583.c
 $(I2C_24CXX_SUPPORT)_SRC += hardware/i2c/master/i2c_24CXX.c
 $(I2C_24CXX_SUPPORT)_ECMD_SRC += hardware/i2c/master/i2c_24CXX_ecmd.c
 
+$(I2C_BH1750_SUPPORT)_SRC += hardware/i2c/master/i2c_bh1750.c
+$(I2C_BH1750_SUPPORT)_ECMD_SRC += hardware/i2c/master/i2c_bh1750_ecmd.c
+
 $(I2C_TSL2550_SUPPORT)_SRC += hardware/i2c/master/i2c_tsl2550.c
 $(I2C_TSL2550_SUPPORT)_ECMD_SRC += hardware/i2c/master/i2c_tsl2550_ecmd.c
 

--- a/hardware/i2c/master/config.in
+++ b/hardware/i2c/master/config.in
@@ -30,6 +30,10 @@ dep_bool_menu "I2C master" I2C_MASTER_SUPPORT "$(not $I2C_SLAVE_SUPPORT)" $ARCH_
     fi
   fi
   dep_bool "I2C BH1750  light sensor" I2C_BH1750_SUPPORT $I2C_MASTER_SUPPORT
+  if [ "$I2C_BH1750_SUPPORT" = "y" ]; then
+   dep_bool "  BH1750 automatic resolution adjustment" I2C_BH1750_AUTO_RESOLUTION $I2C_BH1750_SUPPORT "$(not $TEENSY_SUPPORT)"
+  fi
+
   dep_bool "I2C TSL2550 light sensor" I2C_TSL2550_SUPPORT $I2C_MASTER_SUPPORT
   dep_bool "I2C TSL2561 light sensor" I2C_TSL2561_SUPPORT $I2C_MASTER_SUPPORT
 

--- a/hardware/i2c/master/config.in
+++ b/hardware/i2c/master/config.in
@@ -11,9 +11,9 @@ dep_bool_menu "I2C master" I2C_MASTER_SUPPORT "$(not $I2C_SLAVE_SUPPORT)" $ARCH_
   if [ "$I2C_24CXX_SUPPORT" = "y" ]; then
     int "I2C 24CXX Pagesize" CONF_I2C_24CXX_PAGESIZE 128
   fi
+  dep_bool "I2C DS1631 temperature sensor" I2C_DS1631_SUPPORT $I2C_MASTER_SUPPORT
   dep_bool "I2C LM75   temperature sensor" I2C_LM75_SUPPORT $I2C_MASTER_SUPPORT
   dep_bool "I2C TMP175 temperature sensor" I2C_TMP175_SUPPORT $I2C_MASTER_SUPPORT
-  dep_bool "I2C DS1631 temperature sensor" I2C_DS1631_SUPPORT $I2C_MASTER_SUPPORT
   dep_bool "I2C DS13X7  RTC" I2C_DS13X7_SUPPORT $I2C_MASTER_SUPPORT
   if [ "$I2C_DS13X7_SUPPORT" = "y" ]; then
     choice 'RTC Type'       \
@@ -29,6 +29,7 @@ dep_bool_menu "I2C master" I2C_MASTER_SUPPORT "$(not $I2C_SLAVE_SUPPORT)" $ARCH_
       int "  Sync period in sec" I2C_PCF8583_SYNC_PERIOD 60 $I2C_PCF8583_SYNC
     fi
   fi
+  dep_bool "I2C BH1750  light sensor" I2C_BH1750_SUPPORT $I2C_MASTER_SUPPORT
   dep_bool "I2C TSL2550 light sensor" I2C_TSL2550_SUPPORT $I2C_MASTER_SUPPORT
   dep_bool "I2C TSL2561 light sensor" I2C_TSL2561_SUPPORT $I2C_MASTER_SUPPORT
 
@@ -43,11 +44,11 @@ dep_bool_menu "I2C master" I2C_MASTER_SUPPORT "$(not $I2C_SLAVE_SUPPORT)" $ARCH_
            '3' I2C_BMP085_OVERSAMPLING
   fi
 
-  dep_bool "I2C PCA9531  8-bit LED dimmer" I2C_PCA9531_SUPPORT $I2C_MASTER_SUPPORT
-  dep_bool "I2C PCA9685 12-bit LED dimmer" I2C_PCA9685_SUPPORT $I2C_MASTER_SUPPORT
-  dep_bool "I2C PCF8574X 8-bit port extension" I2C_PCF8574X_SUPPORT $I2C_MASTER_SUPPORT
-  dep_bool "I2C PCA9555 16-bit port extension" I2C_PCA9555_SUPPORT $I2C_MASTER_SUPPORT
-  dep_bool "I2C MAX7311 16-bit port extension" I2C_MAX7311_SUPPORT $I2C_MASTER_SUPPORT
+  dep_bool "I2C PCA9531   8-bit LED dimmer" I2C_PCA9531_SUPPORT $I2C_MASTER_SUPPORT
+  dep_bool "I2C PCA9685  12-bit LED dimmer" I2C_PCA9685_SUPPORT $I2C_MASTER_SUPPORT
+  dep_bool "I2C PCF8574X  8-bit port extension" I2C_PCF8574X_SUPPORT $I2C_MASTER_SUPPORT
+  dep_bool "I2C PCA9555  16-bit port extension" I2C_PCA9555_SUPPORT $I2C_MASTER_SUPPORT
+  dep_bool "I2C MAX7311  16-bit port extension" I2C_MAX7311_SUPPORT $I2C_MASTER_SUPPORT
   dep_bool "I2C MCP23017 16-bit port extension" I2C_MCP23017_SUPPORT $I2C_MASTER_SUPPORT
   dep_bool "I2C to UDP gateway" I2C_UDP_SUPPORT $I2C_MASTER_SUPPORT $UDP_SUPPORT
   if [ "$I2C_UDP_SUPPORT" = "y" ]; then

--- a/hardware/i2c/master/config.in
+++ b/hardware/i2c/master/config.in
@@ -47,6 +47,7 @@ dep_bool_menu "I2C master" I2C_MASTER_SUPPORT "$(not $I2C_SLAVE_SUPPORT)" $ARCH_
             3    BMP085_OSS_3"                \
            '3' I2C_BMP085_OVERSAMPLING
   fi
+  dep_bool "I2C BMP280 barometric pressure sensor" I2C_BMP280_SUPPORT $I2C_MASTER_SUPPORT
 
   dep_bool "I2C PCA9531   8-bit LED dimmer" I2C_PCA9531_SUPPORT $I2C_MASTER_SUPPORT
   dep_bool "I2C PCA9685  12-bit LED dimmer" I2C_PCA9685_SUPPORT $I2C_MASTER_SUPPORT

--- a/hardware/i2c/master/i2c_bh1750.c
+++ b/hardware/i2c/master/i2c_bh1750.c
@@ -268,7 +268,7 @@ i2c_bh1750_get_raw(void)
 
   val[0] = TWDR;
 
-  if (i2c_master_transmit_with_ack() != TW_MR_DATA_ACK)
+  if (i2c_master_transmit() != TW_MR_DATA_NACK)
     goto end;
 
   val[1] = TWDR;

--- a/hardware/i2c/master/i2c_bh1750.c
+++ b/hardware/i2c/master/i2c_bh1750.c
@@ -1,0 +1,399 @@
+/*
+ * Copyright (c) 2018 by Erik Kunze <ethersex@erik-kunze.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ * For more information on the GPL, please go to:
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+/*
+ * Ambient Light Sensor IC BH1750FVI
+ *
+ * http://www.rohm.com/
+ * http://s6z.de/cms/index.php/arduino/sensoren/15-umgebungslichtsensor-bh1750
+ * https://github.com/hexenmeister/AS_BH1750
+ */
+
+#include <avr/io.h>
+#include <util/twi.h>
+#include <util/delay.h>
+
+#include "config.h"
+#include "core/debug.h"
+#include "i2c_master.h"
+#include "i2c_bh1750.h"
+
+
+#define BH1750_ADDR1        0x23  /* Default address */
+#define BH1750_ADDR2        0x5C  /* Alternative address */
+
+#define BH1750_POWER_DOWN   0x00
+#define BH1750_POWER_ON     0x01
+#define BH1750_RESET        0x07
+
+typedef enum
+{
+  UNCONFIGURED = 0,
+  CONTINUOUS_HIGH_RES_MODE = 0x10,
+  CONTINUOUS_HIGH_RES_MODE2 = 0x11,
+  CONTINUOUS_LOW_RES_MODE = 0x13,
+  ONE_TIME_HIGH_RES_MODE = 0x20,
+  ONE_TIME_HIGH_RES_MODE2 = 0x21,
+  ONE_TIME_LOW_RES_MODE = 0x23
+} i2c_bh1750_mode;
+
+#define SENSITIVITY_DEFAULT  69U
+#define SENSITIVITY_MIN      31U
+#define SENSITIVITY_MAX     254U
+
+typedef uint8_t i2c_bh1750_sensitivity;
+
+
+static struct
+{
+  uint8_t addr;
+  uint8_t auto_power_down;
+  i2c_bh1750_resolution resolution;
+  i2c_bh1750_mode mode;
+  uint8_t sensitivity;
+} i2c_bh1750_data =
+{
+  .sensitivity = SENSITIVITY_DEFAULT
+};
+
+
+static uint8_t
+i2c_bh1750_select(uint8_t twi_mode)
+{
+  if (i2c_bh1750_data.addr != 0)
+    return i2c_master_select(i2c_bh1750_data.addr, twi_mode);
+
+  if (i2c_master_select(BH1750_ADDR1, twi_mode) != 0)
+  {
+    I2CDEBUG("bh1750 addr=%02x\n", BH1750_ADDR1);
+    i2c_bh1750_data.addr = BH1750_ADDR1;
+    return 1;
+  }
+
+  if (i2c_master_select(BH1750_ADDR2, twi_mode) != 0)
+  {
+    I2CDEBUG("bh1750 addr=0x%02x\n", BH1750_ADDR2);
+    i2c_bh1750_data.addr = BH1750_ADDR2;
+    return 1;
+  }
+
+  return 0;
+}
+
+
+static int8_t
+i2c_bh1750_set_mode(const i2c_bh1750_mode mode)
+{
+  int8_t result = BH1750_RESULT_NODEV;
+
+  if (!i2c_bh1750_select(TW_WRITE))
+    goto end;
+
+  result = BH1750_RESULT_ERROR;
+
+  TWDR = mode;
+  if (i2c_master_transmit_with_ack() != TW_MT_DATA_ACK)
+    goto end;
+
+  result = BH1750_RESULT_OK;
+  i2c_bh1750_data.mode = mode;
+
+end:
+  i2c_master_stop();
+  return result;
+}
+
+
+/*
+ * Sensor resolution mode:
+ *
+ * RESOLUTION_LOW:
+ *  Physical sensor mode with 4 lx resolution. Measuring time approx. 16ms. Range 0-54612.
+ * RESOLUTION_NORMAL:
+ *  Physical sensor mode with 1 lx resolution. Measuring time approx. 120ms. Range 0-54612.
+ * RESOLUTION_HIGH:
+ *  Physical sensor mode with 0.5 lx resolution. Measuring time approx. 120ms. Range 0-54612.
+ *  (The measuring ranges can be shifted by changing the MTreg.)
+ * RESOLUTION_AUTO_HIGH:
+ *  The values in the MTreg are automatically adjusted according to the brightness
+ *  that a maximum possible resolution and measuring range are achieved.
+ *  The measurable values start from 0.11 lx and go up to over 100000 lx.
+ *  Lower resolution 0.13 lx, middle 0.5 lx, upper 1-2 lx.
+ *
+ * The measuring times are extended by multiple measurements and
+ * the changes from Measurement Time (MTreg) to max. about 500 ms.
+ */
+int8_t
+i2c_bh1750_set_operating_mode(const i2c_bh1750_resolution resolution,
+                              const uint8_t auto_power_down)
+{
+  i2c_bh1750_mode mode = UNCONFIGURED;
+
+  switch (resolution)
+  {
+    case RESOLUTION_LOW:
+      mode = auto_power_down ? ONE_TIME_LOW_RES_MODE
+                             : CONTINUOUS_LOW_RES_MODE;
+      break;
+    case RESOLUTION_NORMAL:
+      mode = auto_power_down ? ONE_TIME_HIGH_RES_MODE
+                             : CONTINUOUS_HIGH_RES_MODE;
+      break;
+    case RESOLUTION_HIGH:
+      mode = auto_power_down ? ONE_TIME_HIGH_RES_MODE2
+                             : CONTINUOUS_HIGH_RES_MODE2;
+      break;
+    case RESOLUTION_AUTO_HIGH:
+      mode = CONTINUOUS_LOW_RES_MODE;
+      break;
+    default:
+      return BH1750_RESULT_INVAL;
+  }
+
+  I2CDEBUG("bh1750 mode=0x%02x\n", mode);
+
+  int8_t result = i2c_bh1750_set_mode(mode);
+  if (result == BH1750_RESULT_OK)
+  {
+    i2c_bh1750_data.resolution = resolution;
+    i2c_bh1750_data.auto_power_down = auto_power_down;
+  }
+
+  return result;
+}
+
+
+/*
+ * Sensitivity of the sensor:
+ *
+ * SENSITIVITY_MIN:
+ *  Sensitivity: default * 0.45
+ * SENSITIVITY_MAX:
+ *  Sensitivity: default * 3.68
+ * SENSITIVITY_DEFAULT:
+ *  Sensitivity: 69
+ *
+ * Sensitivity changes the reading time (higher Sensitivity means
+ * longer time span).
+ */
+static int8_t
+i2c_bh1750_set_sensitivity(const i2c_bh1750_sensitivity sensitivity)
+{
+  if (sensitivity == i2c_bh1750_data.sensitivity)
+    return BH1750_RESULT_OK;
+
+  if (sensitivity < SENSITIVITY_MIN || sensitivity > SENSITIVITY_MAX)
+    return BH1750_RESULT_INVAL;
+
+  I2CDEBUG("bh1750 sensitivity=%u\n", sensitivity);
+
+  /* Change measurement time
+   * Two-step transfer: 3 bits and 5 bits, each with a prefix.
+   *   High bit: 01000_MT[7,6,5]
+   *   Low bit:  011_MT[4,3,2,1,0]
+   */
+
+  int8_t result = BH1750_RESULT_NODEV;
+
+  if (!i2c_bh1750_select(TW_WRITE))
+    goto end;
+
+  TWDR = 0x40 | (sensitivity >> 5);
+  if (i2c_master_transmit_with_ack() != TW_MT_DATA_ACK)
+    goto end;
+
+  TWDR = 0x60 | (sensitivity & 0x1f);
+  if (i2c_master_transmit_with_ack() != TW_MT_DATA_ACK)
+    goto end;
+
+  i2c_bh1750_data.sensitivity = sensitivity;
+  result = BH1750_RESULT_OK;
+
+end:
+  i2c_master_stop();
+  return result;
+}
+
+
+static int32_t
+i2c_bh1750_get_raw(void)
+{
+  int32_t result = BH1750_RESULT_NODEV;
+
+  if (!i2c_bh1750_select(TW_WRITE))
+    goto end;
+
+  result = BH1750_RESULT_ERROR;
+
+  /* Do a repeated start condition */
+  if (i2c_master_start() != TW_REP_START)
+    goto end;
+
+  TWDR = (i2c_bh1750_data.addr << 1) | TW_READ;
+  if (i2c_master_transmit() != TW_MR_SLA_ACK)
+    goto end;
+
+  uint8_t val[2];
+
+  if (i2c_master_transmit_with_ack() != TW_MR_DATA_ACK)
+    goto end;
+
+  val[0] = TWDR;
+
+  if (i2c_master_transmit_with_ack() != TW_MR_DATA_ACK)
+    goto end;
+
+  val[1] = TWDR;
+
+  result = (int16_t) ((val[0] << 8) | val[1]);
+
+end:
+  i2c_master_stop();
+  return result;
+}
+
+
+int32_t
+i2c_bh1750_get_lux(void)
+{
+  if (UNCONFIGURED == i2c_bh1750_data.mode)
+  {
+    I2CDEBUG("bh1750 lux: mode not set\n");
+    return BH1750_RESULT_INVAL;
+  }
+
+  int8_t result;
+
+  /* The automatic mode requires special treatment.
+   * First the brightness is read in LowRes mode,
+   * depending on the area (dark, normal, very bright) the values of
+   * MTreg is set and then the actual measurement is made.
+   *
+   * The fixed limits may cause a 'jump' in
+   * the trace. In this case, an ongoing adjustment would be from MTreg
+   * probably better in borderline areas.
+   * For our purposes, this is irrelevant.
+   */
+  if (i2c_bh1750_data.resolution == RESOLUTION_AUTO_HIGH)
+  {
+    result = i2c_bh1750_set_sensitivity(SENSITIVITY_DEFAULT);
+    if (result < BH1750_RESULT_OK)
+      return result;
+
+    result = i2c_bh1750_set_mode(CONTINUOUS_LOW_RES_MODE);
+    if (result < BH1750_RESULT_OK)
+      return result;
+
+    i2c_bh1750_sensitivity sensitivity;
+    i2c_bh1750_mode mode;
+    uint8_t auto_power_down = i2c_bh1750_data.auto_power_down;
+
+    int32_t level = i2c_bh1750_get_raw();
+    if (level < BH1750_RESULT_OK)
+      return result;
+
+    if (level < 10)
+    {
+      /* Dark, sensitivity to maximum.
+       * The value is random. From about 16000 this approach would be possible.
+       * You only need this accuracy in the dark areas
+       * (to recognize when it is really dark).
+       */
+      I2CDEBUG("bh1750 level 0: dark\n");
+      sensitivity = SENSITIVITY_MAX;
+      mode = auto_power_down ? ONE_TIME_HIGH_RES_MODE2
+                             : CONTINUOUS_HIGH_RES_MODE2;
+    }
+    else if (level < 32767)
+    {
+      /* So far, the 0.5 lx mode is enough. Normal sensitivity. */
+      I2CDEBUG("bh1750 level 1: normal\n");
+      sensitivity = SENSITIVITY_DEFAULT;
+      mode = auto_power_down ? ONE_TIME_HIGH_RES_MODE2
+                             : CONTINUOUS_HIGH_RES_MODE2;
+    }
+    else if (level < 60000)
+    {
+      /* High range, 1 lx mode, normal sensitivity. The value of
+       * 60000 is more or less random, it just has to be a high one
+       * Value to be close to the limit.
+       */
+      I2CDEBUG("bh1750 level 2: bright\n");
+      sensitivity = SENSITIVITY_DEFAULT;
+      mode = auto_power_down ? ONE_TIME_HIGH_RES_MODE
+                             : CONTINUOUS_HIGH_RES_MODE;
+    }
+    else
+    {
+      /* Very high range, reduce sensitivity
+       * Min + 1, at the minimum of docu the sensor goes crazy:
+       * The values are about 1/10 of the expected.
+       */
+      I2CDEBUG("bh1750 level 3: very bright\n");
+      sensitivity = SENSITIVITY_MIN + 1;
+      mode = auto_power_down ? ONE_TIME_HIGH_RES_MODE
+                             : CONTINUOUS_HIGH_RES_MODE;
+    }
+
+    result = i2c_bh1750_set_sensitivity(sensitivity);
+    if (result < BH1750_RESULT_OK)
+      return result;
+
+    result = i2c_bh1750_set_mode(mode);
+    if (result < BH1750_RESULT_OK)
+      return result;
+
+    /* Give the sensor some time to wake up from the power down. */
+    switch (mode)
+    {
+      case ONE_TIME_HIGH_RES_MODE:
+      case ONE_TIME_HIGH_RES_MODE2:
+        _delay_ms(120);
+        break;
+      case ONE_TIME_LOW_RES_MODE:
+        _delay_ms(16);
+        break;
+      default:
+        break;
+    }
+  }
+
+  int32_t raw = i2c_bh1750_get_raw();
+  if (raw < BH1750_RESULT_OK)
+    return raw;
+
+  /* Base conversion. */
+  int32_t lux = (raw * 5) / 6;
+  I2CDEBUG("bh1750 lux(1)=%li\n", lux);
+
+  /* Take sensitivity into account. */
+  if (i2c_bh1750_data.sensitivity != SENSITIVITY_DEFAULT)
+    lux = (lux * SENSITIVITY_DEFAULT) / i2c_bh1750_data.sensitivity;
+  I2CDEBUG("bh1750 lux(2)=%li\n", lux);
+
+  /* Depending on the mode, a further conversion is necessary. */
+  if ((i2c_bh1750_data.mode == ONE_TIME_HIGH_RES_MODE2)
+      || (i2c_bh1750_data.mode == CONTINUOUS_HIGH_RES_MODE2))
+    lux /= 2;
+  I2CDEBUG("bh1750 lux(3)=%li\n", lux);
+
+  return lux;
+}

--- a/hardware/i2c/master/i2c_bh1750.h
+++ b/hardware/i2c/master/i2c_bh1750.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018 by Erik Kunze <ethersex@erik-kunze.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ * For more information on the GPL, please go to:
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#ifndef __I2C_BH1750_H
+#define __I2C_BH1750_H
+
+#include <stdint.h>
+
+#include "config.h"
+
+#define BH1750_RESULT_OK        0
+#define BH1750_RESULT_ERROR    -1
+#define BH1750_RESULT_NODEV    -2
+#define BH1750_RESULT_INVAL    -3
+
+#define RESOLUTION_LOW         1U
+#define RESOLUTION_NORMAL      2U
+#define RESOLUTION_HIGH        3U
+#define RESOLUTION_AUTO_HIGH  99U
+
+typedef uint8_t i2c_bh1750_resolution;
+
+int8_t i2c_bh1750_set_operating_mode(const i2c_bh1750_resolution resolution,
+                                     const uint8_t auto_power_down);
+int32_t i2c_bh1750_get_lux(void);
+
+#endif /* __I2C_BH1750_H */

--- a/hardware/i2c/master/i2c_bh1750_ecmd.c
+++ b/hardware/i2c/master/i2c_bh1750_ecmd.c
@@ -59,7 +59,7 @@ parse_cmd_i2c_bh1750_setmode(char *cmd, char *output, uint16_t len)
       || (auto_power_down > 1))
     return ECMD_ERR_PARSE_ERROR;
 
-  int16_t result = i2c_bh1750_set_operating_mode(resolution, auto_power_down);
+  int32_t result = i2c_bh1750_set_operating_mode(resolution, auto_power_down);
   return i2c_bh1750_map_result(result, output, len);
 }
 
@@ -67,11 +67,11 @@ parse_cmd_i2c_bh1750_setmode(char *cmd, char *output, uint16_t len)
 int16_t
 parse_cmd_i2c_bh1750_getlux(char *cmd, char *output, uint16_t len)
 {
-  int32_t lux = i2c_bh1750_get_lux();
+  int32_t result = i2c_bh1750_get_lux();
   if (lux < BH1750_RESULT_OK)
-    return i2c_bh1750_map_result(lux, output, len);
+    return i2c_bh1750_map_result(result, output, len);
 
-  return ECMD_FINAL(snprintf_P(output, len, PSTR("%li"), lux));
+  return ECMD_FINAL(snprintf_P(output, len, PSTR("%li"), result));
 }
 
 

--- a/hardware/i2c/master/i2c_bh1750_ecmd.c
+++ b/hardware/i2c/master/i2c_bh1750_ecmd.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2018 by Erik Kunze <ethersex@erik-kunze.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ * For more information on the GPL, please go to:
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#include "config.h"
+#include "core/bit-macros.h"
+#include "core/debug.h"
+#include "protocols/ecmd/ecmd-base.h"
+
+#include "i2c_bh1750.h"
+#include "i2c_bh1750_ecmd.h"
+
+
+static int16_t
+i2c_bh1750_map_result(int32_t result, char *output, uint16_t len)
+{
+  if (result == BH1750_RESULT_OK)
+    return ECMD_FINAL_OK;
+  else if (result == BH1750_RESULT_NODEV)
+    return ECMD_FINAL(snprintf_P(output, len, PSTR("no sensor")));
+  else if (result == BH1750_RESULT_INVAL)
+    return ECMD_ERR_PARSE_ERROR;
+  else
+    return ECMD_ERR_WRITE_ERROR;
+}
+
+
+int16_t
+parse_cmd_i2c_bh1750_setmode(char *cmd, char *output, uint16_t len)
+{
+  while (*cmd == ' ')
+    cmd++;
+
+  i2c_bh1750_resolution resolution, auto_power_down;
+
+  if ((sscanf_P(cmd, PSTR("%hhu %hhu"), &resolution, &auto_power_down) != 2)
+      || (resolution > RESOLUTION_HIGH && resolution != RESOLUTION_AUTO_HIGH)
+      || (auto_power_down > 1))
+    return ECMD_ERR_PARSE_ERROR;
+
+  int16_t result = i2c_bh1750_set_operating_mode(resolution, auto_power_down);
+  return i2c_bh1750_map_result(result, output, len);
+}
+
+
+int16_t
+parse_cmd_i2c_bh1750_getlux(char *cmd, char *output, uint16_t len)
+{
+  int32_t lux = i2c_bh1750_get_lux();
+  if (lux < BH1750_RESULT_OK)
+    return i2c_bh1750_map_result(lux, output, len);
+
+  return ECMD_FINAL(snprintf_P(output, len, PSTR("%li"), lux));
+}
+
+
+/*
+  -- Ethersex META --
+  block([[I2C]] (TWI))
+  ecmd_feature(i2c_bh1750_setmode, "bh1750 mode", RESOLUTION AUTOPOWERDOWN, Set sensor mode)
+  ecmd_feature(i2c_bh1750_getlux, "bh1750 lux", , Get lux value)
+ */

--- a/hardware/i2c/master/i2c_bh1750_ecmd.c
+++ b/hardware/i2c/master/i2c_bh1750_ecmd.c
@@ -51,7 +51,11 @@ parse_cmd_i2c_bh1750_setmode(char *cmd, char *output, uint16_t len)
   i2c_bh1750_resolution resolution, auto_power_down;
 
   if ((sscanf_P(cmd, PSTR("%hhu %hhu"), &resolution, &auto_power_down) != 2)
+#ifdef I2C_BH1750_AUTO_RESOLUTION
       || (resolution > RESOLUTION_HIGH && resolution != RESOLUTION_AUTO_HIGH)
+#else
+      || (resolution > RESOLUTION_HIGH)
+#endif
       || (auto_power_down > 1))
     return ECMD_ERR_PARSE_ERROR;
 

--- a/hardware/i2c/master/i2c_bh1750_ecmd.h
+++ b/hardware/i2c/master/i2c_bh1750_ecmd.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018 by Erik Kunze <ethersex@erik-kunze.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ * For more information on the GPL, please go to:
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#ifndef __I2C_BH1750_ECMD_H
+#define __I2C_BH1750_ECMD_H
+
+#include <stdint.h>
+
+int16_t parse_cmd_i2c_bh1750_getlux(char *cmd, char *output, uint16_t len);
+int16_t parse_cmd_i2c_bh1750_setmode(char *cmd, char *output, uint16_t len);
+
+#endif /* __I2C_BH1750_ECMD_H */

--- a/hardware/i2c/master/i2c_bmp280.c
+++ b/hardware/i2c/master/i2c_bmp280.c
@@ -1,0 +1,467 @@
+/*
+* Copyright (c) 2018 by Erik Kunze <ethersex@erik-kunze.de>
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 3
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+*
+* For more information on the GPL, please go to:
+* http://www.gnu.org/copyleft/gpl.html
+*/
+
+/*
+* BMP280 absolute barometric pressure sensor
+*
+* https://www.bosch-sensortec.com/bst/products/all_products/bmp280
+* https://startingelectronics.org/tutorials/arduino/modules/pressure-sensor/
+*/
+
+#include <avr/io.h>
+#include <util/twi.h>
+#include <util/delay.h>
+
+#include "config.h"
+#include "core/debug.h"
+#include "i2c_master.h"
+#include "i2c_bmp280.h"
+
+
+/* Chip IDs */
+#define BMP280_CHIP_ID1	           0x56
+#define BMP280_CHIP_ID2	           0x57
+#define BMP280_CHIP_ID3	           0x58
+
+/* I2C addresses */
+#define BMP280_ADDR1               0x76 /* Default address */
+#define BMP280_ADDR2               0x77 /* Alternative address */
+
+/* Registers */
+#define BMP280_DIG_T1_ADDR	   0x88
+#define BMP280_CHIP_ID_ADDR	   0xD0
+#define BMP280_SOFT_RESET_ADDR	   0xE0
+#define BMP280_STATUS_ADDR	   0xF3
+#define BMP280_CTRL_MEAS_ADDR	   0xF4
+#define BMP280_CONFIG_ADDR	   0xF5
+#define BMP280_PRESS_ADDR	   0xF7
+#define BMP280_TEMP_ADDR	   0xFA
+
+/* Soft reset command */
+#define BMP280_SOFT_RESET_CMD	   0xB6
+
+
+typedef struct
+{
+  uint16_t dig_t1;
+  int16_t dig_t2;
+  int16_t dig_t3;
+  uint16_t dig_p1;
+  int16_t dig_p2;
+  int16_t dig_p3;
+  int16_t dig_p4;
+  int16_t dig_p5;
+  int16_t dig_p6;
+  int16_t dig_p7;
+  int16_t dig_p8;
+  int16_t dig_p9;
+  int32_t t_fine;
+} i2c_bmp280_calib;
+
+typedef struct
+{
+  uint32_t temp;
+  uint32_t press;
+} i2c_bmp280_raw;
+
+
+static struct
+{
+  uint8_t addr;
+  uint8_t chip_id;
+  i2c_bmp280_calib calib;
+  i2c_bmp280_conf conf;
+} i2c_bmp280_data =
+{
+  .conf =
+  {
+    .os_temp = BMP280_OS_4X,
+    .os_pres = BMP280_OS_16X,
+    .odr = BMP280_ODR_1000_MS,
+    .filter = BMP280_FILTER_COEFF_2
+  }
+};
+
+
+static uint8_t
+i2c_bmp280_select(uint8_t twi_mode)
+{
+  if (i2c_bmp280_data.addr != 0)
+    return i2c_master_select(i2c_bmp280_data.addr, twi_mode);
+
+  if (i2c_master_select(BMP280_ADDR1, twi_mode) != 0)
+  {
+    I2CDEBUG("bmp280 addr=%02x\n", BMP280_ADDR1);
+    i2c_bmp280_data.addr = BMP280_ADDR1;
+    return 1;
+  }
+
+  if (i2c_master_select(BMP280_ADDR2, twi_mode) != 0)
+  {
+    I2CDEBUG("bmp280 addr=0x%02x\n", BMP280_ADDR2);
+    i2c_bmp280_data.addr = BMP280_ADDR2;
+    return 1;
+  }
+
+  return 0;
+}
+
+
+/* Read the data from the given register address of the sensor. */
+static int8_t
+i2c_bmp280_read(uint8_t addr, uint8_t len, uint8_t * data)
+{
+  int8_t result = BMP280_RESULT_NODEV;
+
+  if (!i2c_bmp280_select(TW_WRITE))
+    goto end;
+
+  result = BMP280_RESULT_ERROR;
+
+  TWDR = addr;
+  if (i2c_master_transmit_with_ack() != TW_MT_DATA_ACK)
+    goto end;
+
+  /* Do a repeated start condition */
+  if (i2c_master_start() != TW_REP_START)
+    goto end;
+
+  TWDR = (i2c_bmp280_data.addr << 1) | TW_READ;
+  if (i2c_master_transmit() != TW_MR_SLA_ACK)
+    goto end;
+
+  while (--len > 0)
+  {
+    if (i2c_master_transmit_with_ack() != TW_MR_DATA_ACK)
+      goto end;
+
+    *data++ = TWDR;
+  }
+
+  if (i2c_master_transmit() != TW_MR_DATA_NACK)
+    goto end;
+
+  *data = TWDR;
+
+  result = BMP280_RESULT_OK;
+
+end:
+  i2c_master_stop();
+  return result;
+}
+
+
+/* Write the given data to the register addresses of the sensor. */
+static int8_t
+i2c_bmp280_write(uint8_t * addr, uint8_t len, uint8_t * data)
+{
+  int8_t result = BMP280_RESULT_NODEV;
+
+  if (!i2c_bmp280_select(TW_WRITE))
+    goto end;
+
+  result = BMP280_RESULT_ERROR;
+
+  for (uint8_t i = 0; i < len; i++)
+  {
+    TWDR = addr[i];
+    if (i2c_master_transmit_with_ack() != TW_MT_DATA_ACK)
+      break;
+
+    TWDR = data[i];
+    if (i2c_master_transmit_with_ack() != TW_MT_DATA_ACK)
+      break;
+  }
+
+  result = BMP280_RESULT_OK;
+
+end:
+  i2c_master_stop();
+  return result;
+}
+
+
+/* Trigger the soft reset of the sensor. */
+static int8_t
+i2c_bmp280_soft_reset(void)
+{
+  I2CDEBUG("bmp280 soft reset\n");
+
+  uint8_t addr = BMP280_SOFT_RESET_ADDR;
+  uint8_t cmd = BMP280_SOFT_RESET_CMD;
+
+  int8_t result = i2c_bmp280_write(&addr, 1, &cmd);
+  if (result == BMP280_RESULT_OK)
+    _delay_ms(2);
+
+  return result;
+}
+
+
+/* Read the calibration parameters. */
+static int8_t
+i2c_bmp280_read_calib(void)
+{
+  I2CDEBUG("bmp280 read calibration data\n");
+
+  uint8_t temp[24];
+
+  int8_t result = i2c_bmp280_read(BMP280_DIG_T1_ADDR, sizeof(temp), temp);
+  if (result == BMP280_RESULT_OK)
+  {
+    i2c_bmp280_data.calib.dig_t1 = (uint16_t) (temp[1] << 8 | temp[0]);
+    i2c_bmp280_data.calib.dig_t2 = (int16_t) (temp[3] << 8 | temp[2]);
+    i2c_bmp280_data.calib.dig_t3 = (int16_t) (temp[5] << 8 | temp[4]);
+
+    i2c_bmp280_data.calib.dig_p1 = (uint16_t) (temp[7] << 8 | temp[6]);
+    i2c_bmp280_data.calib.dig_p2 = (int16_t) (temp[9] << 8 | temp[8]);
+    i2c_bmp280_data.calib.dig_p3 = (int16_t) (temp[11] << 8 | temp[10]);
+    i2c_bmp280_data.calib.dig_p4 = (int16_t) (temp[13] << 8 | temp[12]);
+    i2c_bmp280_data.calib.dig_p5 = (int16_t) (temp[15] << 8 | temp[14]);
+    i2c_bmp280_data.calib.dig_p6 = (int16_t) (temp[17] << 8 | temp[16]);
+    i2c_bmp280_data.calib.dig_p7 = (int16_t) (temp[19] << 8 | temp[18]);
+    i2c_bmp280_data.calib.dig_p8 = (int16_t) (temp[21] << 8 | temp[20]);
+    i2c_bmp280_data.calib.dig_p9 = (int16_t) (temp[23] << 8 | temp[22]);
+
+    I2CDEBUG("t1=%u, t2=%i, t3=%i\n", i2c_bmp280_data.calib.dig_t1,
+             i2c_bmp280_data.calib.dig_t2, i2c_bmp280_data.calib.dig_t3);
+    I2CDEBUG("p1=%u, p2=%i, p3=%i\n", i2c_bmp280_data.calib.dig_p1,
+             i2c_bmp280_data.calib.dig_p2, i2c_bmp280_data.calib.dig_p3);
+    I2CDEBUG("p4=%u, p5=%i, p6=%i\n", i2c_bmp280_data.calib.dig_p4,
+             i2c_bmp280_data.calib.dig_p5, i2c_bmp280_data.calib.dig_p6);
+    I2CDEBUG("p7=%u, p8=%i, p9=%i\n", i2c_bmp280_data.calib.dig_p7,
+             i2c_bmp280_data.calib.dig_p8, i2c_bmp280_data.calib.dig_p9);
+  }
+
+  return result;
+}
+
+
+int8_t
+i2c_bmp280_read_conf(i2c_bmp280_conf * conf)
+{
+  uint8_t temp[2];
+
+  int8_t result = i2c_bmp280_read(BMP280_CTRL_MEAS_ADDR, sizeof(temp), temp);
+  if (result == BMP280_RESULT_OK)
+  {
+    conf->os_temp = (temp[0] & 0xE0) >> 5;
+    conf->os_pres = (temp[0] & 0x1C) >> 2;
+    conf->odr = (temp[1] & 0xE0) >> 5;
+    conf->filter = (temp[1] & 0x1C) >> 2;
+
+    i2c_bmp280_data.conf = *conf;
+  }
+
+  return result;
+}
+
+
+/* Reset the sensor, restore/set conf, restore/set mode. */
+int8_t
+i2c_bmp280_write_conf(uint8_t mode, const i2c_bmp280_conf * conf)
+{
+  uint8_t temp[2];
+  uint8_t addr[2] = { BMP280_CTRL_MEAS_ADDR, BMP280_CONFIG_ADDR };
+
+  I2CDEBUG("bmp280 write conf\n");
+
+  int8_t result = i2c_bmp280_read(BMP280_CTRL_MEAS_ADDR, sizeof(temp), temp);
+  if (result < BMP280_RESULT_OK)
+    goto end;
+
+  result = i2c_bmp280_soft_reset();
+  if (result < BMP280_RESULT_OK)
+    goto end;
+
+  temp[0] = (temp[0] & ~0xE0) | (conf->os_temp << 5);
+  temp[0] = (temp[0] & ~0x1C) | (conf->os_pres << 2);
+  temp[1] = (temp[1] & ~0xE0) | (conf->odr << 5);
+  temp[1] = (temp[1] & ~0x1C) | (conf->filter << 2);
+
+  result = i2c_bmp280_write(addr, 2, temp);
+  if (result < BMP280_RESULT_OK)
+    goto end;
+
+  i2c_bmp280_data.conf = *conf;
+
+  if (mode != BMP280_SLEEP_MODE)
+  {
+    /* Write only the power mode register in a separate write */
+    temp[0] = (temp[0] & ~0x03) | mode;
+    result = i2c_bmp280_write(addr, 1, temp);
+  }
+
+end:
+  return result;
+}
+
+
+int8_t
+i2c_bmp280_set_power_mode(uint8_t mode)
+{
+  return i2c_bmp280_write_conf(mode, &i2c_bmp280_data.conf);
+}
+
+
+static int8_t
+i2c_bmp280_get_raw(i2c_bmp280_raw * raw)
+{
+  uint8_t temp[6];
+
+  I2CDEBUG("bmp280 get raw\n");
+
+  int8_t result = i2c_bmp280_read(BMP280_PRESS_ADDR, sizeof(temp), temp);
+  if (result == BMP280_RESULT_OK)
+  {
+    uint32_t v = temp[0];
+    v <<= 8;
+    v |= temp[1];
+    v <<= 8;
+    v |= temp[2];
+    v >>= 4;
+    raw->press = v;
+
+    v = temp[3];
+    v <<= 8;
+    v |= temp[4];
+    v <<= 8;
+    v |= temp[5];
+    v >>= 4;
+    raw->temp = v;
+
+    I2CDEBUG("bmp280 press=%lu temp=%lu\n", raw->press, raw->temp);
+  }
+
+  return result;
+}
+
+
+/* Read the chip-id and calibration data from the sensor. */
+void
+i2c_bmp280_init(void)
+{
+  I2CDEBUG("bmp280 init start\n");
+
+  if (i2c_bmp280_read(BMP280_CHIP_ID_ADDR, sizeof(i2c_bmp280_data.chip_id),
+                      &i2c_bmp280_data.chip_id) == BMP280_RESULT_OK)
+  {
+    I2CDEBUG("bmp280 chip_id=%02x\n", i2c_bmp280_data.chip_id);
+
+    if (i2c_bmp280_data.chip_id == BMP280_CHIP_ID1 ||
+        i2c_bmp280_data.chip_id == BMP280_CHIP_ID2 ||
+        i2c_bmp280_data.chip_id == BMP280_CHIP_ID3)
+    {
+      if (i2c_bmp280_soft_reset() == BMP280_RESULT_OK &&
+          i2c_bmp280_read_calib() == BMP280_RESULT_OK &&
+          i2c_bmp280_set_power_mode(BMP280_NORMAL_MODE) == BMP280_RESULT_OK)
+      {
+        I2CDEBUG("bmp280 init succeded\n");
+        return;
+      }
+    }
+  }
+
+  I2CDEBUG("bmp280 init failed\n");
+}
+
+
+int8_t
+i2c_bmp280_get_temp(int16_t * temp)
+{
+  i2c_bmp280_raw raw;
+  int32_t var1, var2;
+
+  int8_t result = i2c_bmp280_get_raw(&raw);
+  if (result < BMP280_RESULT_OK)
+    goto end;
+
+  var1 = ((((raw.temp >> 3) -
+            ((int32_t) i2c_bmp280_data.calib.dig_t1 << 1))) *
+          ((int32_t) i2c_bmp280_data.calib.dig_t2)) >> 11;
+  var2 = (((((raw.temp >> 4) -
+             ((int32_t) i2c_bmp280_data.calib.dig_t1)) *
+            ((raw.temp >> 4) -
+             ((int32_t) i2c_bmp280_data.calib.dig_t1))) >> 12) *
+          ((int32_t) i2c_bmp280_data.calib.dig_t3)) >> 14;
+
+  i2c_bmp280_data.calib.t_fine = var1 + var2;
+
+  *temp = (i2c_bmp280_data.calib.t_fine * 5 + 128) >> 8;
+
+end:
+  return result;
+}
+
+
+int8_t
+i2c_bmp280_get_press(uint16_t * press)
+{
+  i2c_bmp280_raw raw;
+  int32_t var1, var2;
+  uint32_t p;
+
+  int8_t result = i2c_bmp280_get_raw(&raw);
+  if (result < BMP280_RESULT_OK)
+    goto end;
+
+  var1 = ((((int32_t) i2c_bmp280_data.calib.t_fine) >> 1) - (int32_t) 64000);
+  var2 = ((((var1 >> 2) * (var1 >> 2)) >> 11) *
+          ((int32_t) i2c_bmp280_data.calib.dig_p6));
+  var2 = var2 + ((var1 * ((int32_t) i2c_bmp280_data.calib.dig_p5)) << 1);
+  var2 = (var2 >> 2) + (((int32_t) i2c_bmp280_data.calib.dig_p4) << 16);
+  var1 = (((i2c_bmp280_data.calib.dig_p3 *
+            (((var1 >> 2) * (var1 >> 2)) >> 13)) >> 3) +
+          ((((int32_t) i2c_bmp280_data.calib.dig_p2) * var1) >> 1)) >> 18;
+  var1 = ((((32768 + var1)) *
+           ((int32_t) i2c_bmp280_data.calib.dig_p1)) >> 15);
+  p = (((uint32_t) (((int32_t) 1048576) - raw.press) - (var2 >> 12))) * 3125;
+
+  if (var1 == 0)
+  {
+    *press = 0;
+    goto end;
+  }
+
+  /* Check for overflows */
+  if (p < 0x80000000)
+    p = (p << 1) / ((uint32_t) var1);
+  else
+    p = (p / (uint32_t) var1) * 2;
+
+  var1 = (((int32_t) i2c_bmp280_data.calib.dig_p9) *
+          ((int32_t) (((p >> 3) * (p >> 3)) >> 13))) >> 12;
+  var2 = (((int32_t) (p >> 2)) *
+          ((int32_t) i2c_bmp280_data.calib.dig_p8)) >> 13;
+  p = (uint32_t) ((int32_t) p +
+                  ((var1 + var2 + i2c_bmp280_data.calib.dig_p7) >> 4));
+  *press = p / 10;
+
+end:
+  return result;
+}
+
+
+/*
+  -- Ethersex META --
+  header(hardware/i2c/master/i2c_bmp280.h)
+  init(i2c_bmp280_init)
+ */

--- a/hardware/i2c/master/i2c_bmp280.h
+++ b/hardware/i2c/master/i2c_bmp280.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2018 by Erik Kunze <ethersex@erik-kunze.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ * For more information on the GPL, please go to:
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#ifndef __I2C_BMP280_H
+#define __I2C_BMP280_H
+
+#include <stdint.h>
+
+#include "config.h"
+
+/* ODR options */
+#define BMP280_ODR_0_5_MS      0x00
+#define BMP280_ODR_62_5_MS     0x01
+#define BMP280_ODR_125_MS      0x02
+#define BMP280_ODR_250_MS      0x03
+#define BMP280_ODR_500_MS      0x04
+#define BMP280_ODR_1000_MS     0x05
+#define BMP280_ODR_2000_MS     0x06
+#define BMP280_ODR_4000_MS     0x07
+
+/* Over-sampling */
+#define BMP280_OS_NONE         0x00
+#define BMP280_OS_1X           0x01
+#define BMP280_OS_2X           0x02
+#define BMP280_OS_4X           0x03
+#define BMP280_OS_8X           0x04
+#define BMP280_OS_16X          0x05
+
+/* Filter coefficient */
+#define BMP280_FILTER_OFF      0x00
+#define BMP280_FILTER_COEFF_2  0x01
+#define BMP280_FILTER_COEFF_4  0x02
+#define BMP280_FILTER_COEFF_8  0x03
+#define BMP280_FILTER_COEFF_16 0x04
+
+/* Power modes */
+#define BMP280_SLEEP_MODE      0x00
+#define BMP280_FORCED_MODE     0x01
+#define BMP280_NORMAL_MODE     0x03
+
+#define BMP280_RESULT_OK        0
+#define BMP280_RESULT_ERROR    -1
+#define BMP280_RESULT_NODEV    -2
+#define BMP280_RESULT_INVAL    -3
+
+
+typedef struct
+{
+  uint8_t os_temp;
+  uint8_t os_pres;
+  uint8_t odr;
+  uint8_t filter;
+} i2c_bmp280_conf;
+
+
+void i2c_bmp280_init(void);
+int8_t i2c_bmp280_read_conf(i2c_bmp280_conf * conf);
+int8_t i2c_bmp280_write_conf(uint8_t mode, const i2c_bmp280_conf * conf);
+int8_t i2c_bmp280_set_power_mode(uint8_t mode);
+int8_t i2c_bmp280_get_temp(int16_t * temp);
+int8_t i2c_bmp280_get_press(uint16_t * press);
+
+#endif /* __I2C_BMP280_H */

--- a/hardware/i2c/master/i2c_bmp280_ecmd.c
+++ b/hardware/i2c/master/i2c_bmp280_ecmd.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2018 by Erik Kunze <ethersex@erik-kunze.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ * For more information on the GPL, please go to:
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#include "config.h"
+#include "core/bit-macros.h"
+#include "core/debug.h"
+#include "core/util/fixedpoint.h"
+#include "protocols/ecmd/ecmd-base.h"
+
+#include "i2c_bmp280.h"
+#include "i2c_bmp280_ecmd.h"
+
+
+static int16_t
+i2c_bmp280_map_result(int32_t result, char *output, uint16_t len)
+{
+  if (result == BMP280_RESULT_OK)
+    return ECMD_FINAL_OK;
+  else if (result == BMP280_RESULT_NODEV)
+    return ECMD_FINAL(snprintf_P(output, len, PSTR("no sensor")));
+  else if (result == BMP280_RESULT_INVAL)
+    return ECMD_ERR_PARSE_ERROR;
+  else
+    return ECMD_ERR_WRITE_ERROR;
+}
+
+
+int16_t
+parse_cmd_i2c_bmp280_gettemp(char *cmd, char *output, uint16_t len)
+{
+  int16_t temp;
+
+  int8_t result = i2c_bmp280_get_temp(&temp);
+  if (result < BMP280_RESULT_OK)
+    return i2c_bmp280_map_result(result, output, len);
+
+  return ECMD_FINAL(itoa_fixedpoint(temp, 2, output, len));
+}
+
+
+int16_t
+parse_cmd_i2c_bmp280_getpress(char *cmd, char *output, uint16_t len)
+{
+  uint16_t press;
+
+  int8_t result = i2c_bmp280_get_press(&press);
+  if (result < BMP280_RESULT_OK)
+    return i2c_bmp280_map_result(result, output, len);
+
+  return ECMD_FINAL(itoa_fixedpoint(press, 1, output, len));
+}
+
+
+/*
+  -- Ethersex META --
+  block([[I2C]] (TWI))
+  ecmd_feature(i2c_bmp280_gettemp,  "bmp280 temp", , Get temperature in 0.1°C)
+  ecmd_feature(i2c_bmp280_getpress, "bmp280 apress", , Get absolute pressure in Pa)
+ */

--- a/hardware/i2c/master/i2c_bmp280_ecmd.h
+++ b/hardware/i2c/master/i2c_bmp280_ecmd.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018 by Erik Kunze <ethersex@erik-kunze.de>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ *
+ * For more information on the GPL, please go to:
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#ifndef __I2C_BMP280_ECMD_H
+#define __I2C_BMP280_ECMD_H
+
+#include <stdint.h>
+
+int16_t parse_cmd_i2c_bmp280_gettemp(char *cmd, char *output, uint16_t len);
+int16_t parse_cmd_i2c_bmp280_getpress(char *cmd, char *output, uint16_t len);
+
+#endif /* __I2C_BMP280_ECMD_H */

--- a/hardware/io_expander/hc595.c
+++ b/hardware/io_expander/hc595.c
@@ -45,22 +45,34 @@ hc595_init(void)
   /* FIXME: maybe must set the output enable pin */
 
   hc595_update();
-} 
+}
 
-uint8_t 
+uint8_t
 hc595_write_port(uint8_t port, uint8_t data) {
   hc595_cache[port - IO_HARD_PORTS] = data;
   hc595_update();
   return 0;
 }
-uint8_t 
-hc595_read_port(uint8_t port) 
+uint8_t
+hc595_read_port(uint8_t port)
 {
   return hc595_cache[port - IO_HARD_PORTS];
 }
 
+uint8_t
+hc595_read_ddr(uint8_t port)
+{
+  return 0xFF ;
+}
+
+uint8_t
+hc595_write_ddr(uint8_t port, uint8_t data)
+{
+  return 0;
+}
+
 void
-hc595_update(void) 
+hc595_update(void)
 {
   uint8_t i, x;
   PIN_CLEAR(HC595_CLOCK);
@@ -72,7 +84,7 @@ hc595_update(void)
       PIN_CLEAR(HC595_DATA);
       if (hc595_cache[i] & _BV(--x))
         PIN_SET(HC595_DATA);
-      
+
       /* Pulse the hc595 shift clock */
       PIN_SET(HC595_CLOCK);
       PIN_CLEAR(HC595_CLOCK);
@@ -88,4 +100,3 @@ hc595_update(void)
   header(hardware/io_expander/hc595.h)
   init(hc595_init)
 */
-

--- a/hardware/io_expander/hc595.h
+++ b/hardware/io_expander/hc595.h
@@ -29,5 +29,7 @@
 void hc595_init(void);
 uint8_t hc595_write_port(uint8_t port, uint8_t data);
 uint8_t hc595_read_port(uint8_t port);
+uint8_t hc595_read_ddr(uint8_t port);
+uint8_t hc595_write_ddr(uint8_t port, uint8_t data);
 
 #endif /* _HC595_H */

--- a/protocols/bsbport/bsbport_mqtt.c
+++ b/protocols/bsbport/bsbport_mqtt.c
@@ -120,7 +120,8 @@ bsbport_poll_cb(void)
 
 void
 bsbport_publish_cb(char const *topic, uint16_t topic_length,
-                   const void *payload, uint16_t payload_length)
+                   const void *payload, uint16_t payload_length,
+                   bool retained)
 {
   BSBDEBUG("MQTT Publish: %s", topic);
   if (topic_length < 20)

--- a/protocols/mqtt/mqtt.h
+++ b/protocols/mqtt/mqtt.h
@@ -83,7 +83,8 @@ typedef void (*poll_callback) (void);
 typedef void (*close_callback) (void);
 typedef void (*publish_callback) (char const *topic, uint16_t topic_length,
                                   void const *payload,
-                                  uint16_t payload_length);
+                                  uint16_t payload_length,
+                                  bool retained);
 typedef struct
 {
   // see mqtt.c for explanation


### PR DESCRIPTION
Using named pins on a port extender HC595 breaks the initialization process because some functions were called but not defined for this extension. 

The newly added functions make portio work for the not really existing registers DDRx and PINx in such an extension. They take arguments and return values like any HARD_IO port. Naturally, write of "0" to the DDR-register will not set this pin as an input pin.  

( the diff contains some white-space related changes, I did not made intentionally. Seems my editor doesn't like them. sorry for that.  ) 

