### PR TITLE
Syslog code optimizations

### DIFF
--- a/core/param.h
+++ b/core/param.h
@@ -1,13 +1,9 @@
 /*
- *
- * Copyright (c) 2007 by Christian Dietrich <stettberger@dokucode.de>
- * Copyright (c) 2008 by Stefan Siegl <stesie@brokenpipe.de>
- * Copyright (c) 2015 by Daniel Lindner <daniel.lindner@gmx.de>
  * Copyright (c) 2019 by Erik Kunze <ethersex@erik-kunze.de>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
+ * as published by the Free Software Foundation; either version 3
  * of the License, or (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
@@ -23,14 +19,10 @@
  * http://www.gnu.org/copyleft/gpl.html
  */
 
-#ifndef _SYSLOG_H
-#define _SYSLOG_H
+#ifndef __PARAM_H
+#define __PARAM_H
 
-#include <stdint.h>
+#define MIN(a,b) (((a)<(b))?(a):(b))
+#define MAX(a,b) (((a)>(b))?(a):(b))
 
-uint8_t syslog_send(const char *message);
-uint8_t syslog_sendf_P(const char *message, ...);
-
-void syslog_flush(void);
-
-#endif /* _SYSLOG_H */
+#endif /* __PARAM_H */

--- a/protocols/syslog/syslog_debug.c
+++ b/protocols/syslog/syslog_debug.c
@@ -23,6 +23,7 @@
  */
 
 #include <stdio.h>
+#include <string.h>
 
 #include "protocols/syslog/syslog.h"
 #include "protocols/syslog/syslog_debug.h"


### PR DESCRIPTION
Fix memory leak and generell memory footprint of the syslog module.

## Description

Free message buffer if data could not be enqueued. Fixes a memory leak.

A message longer than the UIP send buffer makes no sense, so it can be truncated before enqueueing.

## Motivation and Context

Memory leaks prevent continuous operation. Reducing memory footprint is always good.

## How Has This Been Tested?

The syslog module is used on two NETIO production systems at my side.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style of this project](http://www.ethersex.de/index.php/Contributing#Coding_Style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
