### PR TITLE
Compatibility with git-worktree

### DIFF
--- a/scripts/get-git-version
+++ b/scripts/get-git-version
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-if test -d .git ; then
+if test -d .git -o -s .git ; then
     git log --pretty=format:%h -n 1
 fi


### PR DESCRIPTION
## Description

In order to be able to detect the Git hash, which is used as version for Ethersex, in git-worktree environments, a small adjustment is necessary.

## Motivation and Context

Support git-worktree environments.

## How Has This Been Tested?

Execute scripts/get-git-version in a worktree environment.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the [code style of this project](http://www.ethersex.de/index.php/Contributing#Coding_Style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
