### PR TITLE
Bugfix : ENC28J60_REV4_WORKAROUND made some events unhandled

### DIFF
--- a/hardware/ethernet/enc28j60_process.c
+++ b/hardware/ethernet/enc28j60_process.c
@@ -57,7 +57,7 @@ void network_process(void)
      * buffer, return */
     if ( !interrupt_occured()
 #   ifdef ENC28J60_REV4_WORKAROUND
-                || pktcnt == 0
+                && pktcnt == 0
 #   endif
            )
         return;


### PR DESCRIPTION
## Description
Fixed the conditional statement to check for interrupt or pending packets. 

## Motivation and Context
It was an OR, making routine ignore all events if there are no packets. 
In this way, i.e. Link Down is lost and neither STATUSLED_NETLINK would fade nor debug message "net: no link!" would be printed. The comment above changed line says "if no interrupt occured and no packets are in the receive buffer, return", so maybe it was in author intention to use AND instead of OR.

## How Has This Been Tested?
Quickly checked that now the behavior is the one wanted , and no other failures have been observed.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] My code follows the [code style of this project](http://www.ethersex.de/index.php/Contributing#Coding_Style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

