### PR TITLE
Fix syslog string truncation

### DIFF
--- a/protocols/syslog/syslog.c
+++ b/protocols/syslog/syslog.c
@@ -83,7 +83,7 @@ syslog_sendf_P(const char *message, ...)
   if (len == 0)
     return 1;                   /* zero sized message -> pretend it was sent */
 
-  len = MIN(len, UIP_MAX_LENGTH + 1);
+  len = MIN(len, UIP_MAX_LENGTH) + 1;
   char *data = malloc(len);
   if (data == NULL)
     return 0;


### PR DESCRIPTION
## Description
 
With c271d9c0d773471bd59b471dee311e043cf268ad the length of the syslog output buffer was one character too short, so that the last character was always truncated.

## Motivation and Context

Guess what ;)

## How Has This Been Tested?

Check the string at syslog server for integrity.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style of this project](http://www.ethersex.de/index.php/Contributing#Coding_Style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

