### PR TITLE
Fix ncurses detection

### DIFF
--- a/scripts/lxdialog/Makefile
+++ b/scripts/lxdialog/Makefile
@@ -28,7 +28,7 @@ lxdialog: $(OBJS)
 	$(HOSTCC) -o lxdialog $(OBJS) $(LIBS)
 
 ncurses:
-	@echo "main() {}" > lxtemp.c
+	@echo "int main() {}" > lxtemp.c
 	@if $(HOSTCC) -lncurses lxtemp.c ; then \
 		rm -f lxtemp.c a.out; \
 	else \


### PR DESCRIPTION
## Description

The test program for detecting the ncurses library
does not compile with newer compilers, causing the actual test on ncurses to fail.
The fix changes the signature of main to match its prototype.

## Motivation and Context
Without this change `make menuconfig` will fail.

## How Has This Been Tested?
Run `make menuconfig` to detect dialog/ncurses.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the [code style of this project](http://www.ethersex.de/index.php/Contributing#Coding_Style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

