### PR TITLE
Replace deprecated fgrep

### DIFF
--- a/core/vfs/do-embed
+++ b/core/vfs/do-embed
@@ -33,12 +33,12 @@ EOF
 $MAKE dummy.E || exit 1
 PAGESZ=$(tail -n 1 dummy.E)
 
-fgrep -q "#define DEBUG_INLINE_DUMMY" autoconf.h || rm -f dummy.[cE]
+grep -Fq "#define DEBUG_INLINE_DUMMY" autoconf.h || rm -f dummy.[cE]
 
 echo "The pagesize of current architecture is $PAGESZ."
 
 do_strip=false
-fgrep -q "#define VFS_INLINE_HTML_CLEAN_SUPPORT" autoconf.h &&  do_strip=true
+grep -Fq "#define VFS_INLINE_HTML_CLEAN_SUPPORT" autoconf.h &&  do_strip=true
 
 while true; do
   fn="$1"; shift
@@ -53,8 +53,8 @@ while true; do
   fi
   unzipped=$(echo "$fn" | sed 's/\.gz$//')
   do_gzip=true
-  fgrep -q "#define DEBUG_INLINE_DISABLE_GZ" autoconf.h &&  do_gzip=false
-  fgrep -q "#define UPNP_INLINE_SUPPORT" autoconf.h && [ "${fn/#*./}" = "xml" ]  && do_gzip=false
+  grep -Fq "#define DEBUG_INLINE_DISABLE_GZ" autoconf.h &&  do_gzip=false
+  grep -Fq "#define UPNP_INLINE_SUPPORT" autoconf.h && [ "${fn/#*./}" = "xml" ]  && do_gzip=false
 
   if  [ "$do_gzip" = "true" ]; then
     # before zipping, squeeze unnecessary bits out
@@ -119,6 +119,6 @@ while true; do
   core/vfs/vfs-concat ethersex.bin $PAGESZ "$fn" > ethersex.embed.bin || exit 1
   mv -f ethersex.embed.bin ethersex.bin
 
-  fgrep -q "#define DEBUG_INLINE_GZ" autoconf.h || rm -f "$fn".gz 
+  grep -Fq "#define DEBUG_INLINE_GZ" autoconf.h || rm -f "$fn".gz
 done
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
fgrep is deprecated. Use grep -F.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Prepare project for the future that is coming :)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Just run a full make with configuration ` vfs` activated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style of this project](http://www.ethersex.de/index.php/Contributing#Coding_Style).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

